### PR TITLE
fix(test-runner-cli): fixed error when files is defined as string in the config file

### DIFF
--- a/.changeset/warm-tigers-complain.md
+++ b/.changeset/warm-tigers-complain.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-cli': patch
+---
+
+validate config now accepts a string for as files field

--- a/packages/test-runner-cli/src/startTestRunner.ts
+++ b/packages/test-runner-cli/src/startTestRunner.ts
@@ -31,7 +31,10 @@ const defaultCoverageConfig: CoverageConfig = {
 };
 
 function validateConfig(config: Partial<TestRunnerConfig>): TestRunnerConfig {
-  if (!(typeof config.files === 'string' || Array.isArray(config.files)) || config.files.length === 0) {
+  if (
+    !(typeof config.files === 'string' || Array.isArray(config.files)) ||
+    config.files.length === 0
+  ) {
     throw new Error('No test files configured.');
   }
   if (typeof config.testFrameworkImport !== 'string') {

--- a/packages/test-runner-cli/src/startTestRunner.ts
+++ b/packages/test-runner-cli/src/startTestRunner.ts
@@ -31,7 +31,7 @@ const defaultCoverageConfig: CoverageConfig = {
 };
 
 function validateConfig(config: Partial<TestRunnerConfig>): TestRunnerConfig {
-  if (!Array.isArray(config.files) || config.files.length === 0) {
+  if (!(typeof config.files === 'string' || Array.isArray(config.files)) || config.files.length === 0) {
     throw new Error('No test files configured.');
   }
   if (typeof config.testFrameworkImport !== 'string') {


### PR DESCRIPTION
When a string was used in the 'files' field the validator would throw an error.
I've changed the boolean expression for the error to be thrown to accept both Arrays and Strings that are not empty.

### Truth table (of fixed expression)
Boolean expression: `!(IsString || IsArray) || IsEmpty`
| IsString | IsArray | IsEmpty | Result |
| --- | --- | --- | --- |
| FALSE | FALSE | FALSE | **TRUE** | 
| FALSE | FALSE | TRUE | **TRUE** |
| FALSE | TRUE | FALSE | **FALSE** |
| FALSE | TRUE | TRUE | **TRUE** | 
| TRUE | FALSE | FALSE | **FALSE** |
| TRUE | FALSE | TRUE | **TRUE** |  
| TRUE | TRUE | FALSE | **FALSE** | 
| TRUE | TRUE | TRUE | **TRUE** | 

In this table you can see the only time the error won't be thrown, is when either the IsArray or IsString are true and the String or array is not empty.