### PR TITLE
fix(test-runner-playwright): correctly map pages to browsers

### DIFF
--- a/.changeset/three-tables-repair.md
+++ b/.changeset/three-tables-repair.md
@@ -1,0 +1,6 @@
+---
+'@web/test-runner': patch
+'@web/test-runner-playwright': patch
+---
+
+correctly map pages to browsers


### PR DESCRIPTION
Playwright was keeping a pool of inactive pages without mapping them to a browser. This meant that rerunning a test file would rerun on different browsers at random.