### PR TITLE
feat(test-runner-cli): improve terminal performance

### DIFF
--- a/packages/test-runner-cli/src/cli/TestRunnerCli.ts
+++ b/packages/test-runner-cli/src/cli/TestRunnerCli.ts
@@ -14,7 +14,7 @@ import openBrowser from 'open';
 import { writeCoverageReport } from './writeCoverageReport';
 import { getSelectFilesMenu } from './getSelectFilesMenu';
 import { getWatchCommands } from './getWatchCommands';
-import { Terminal } from '../Terminal';
+import { DynamicTerminal } from '../terminal/DynamicTerminal';
 import { TestRunnerLogger } from '../logger/TestRunnerLogger';
 import { BufferedLogger } from '../reporter/BufferedLogger';
 
@@ -34,7 +34,7 @@ const KEYCODES = {
 };
 
 export class TestRunnerCli {
-  private terminal = new Terminal();
+  private terminal = new DynamicTerminal();
   private reportedFilesByTestRun = new Map<number, Set<string>>();
   private sessions: TestSessionManager;
   private activeMenu: MenuType = MENUS.OVERVIEW;

--- a/packages/test-runner-cli/src/terminal/BufferedConsole.ts
+++ b/packages/test-runner-cli/src/terminal/BufferedConsole.ts
@@ -1,0 +1,24 @@
+import { Writable } from 'stream';
+import { Console } from 'console';
+
+/**
+ * Buffers console messages so that they can be flushed all at once.
+ */
+export class BufferedConsole {
+  private buffer: any[] = [];
+  private outStream = new Writable({
+    write: (chunk, encoding, callback) => {
+      callback();
+      this.buffer.push(chunk);
+    },
+  });
+  public console = new Console({ colorMode: true, stdout: this.outStream });
+
+  flush() {
+    // flush all pending console output
+    for (const chunk of this.buffer) {
+      process.stdout.write(chunk);
+    }
+    this.buffer = [];
+  }
+}


### PR DESCRIPTION
In the past we used to format all console messages as a tring, and log it all at once. Because we now rely on NodeJS to format the console output, there is a noticeable delay between removing the progress bar, adding the static logs, and adding the progress bar back. 

This change adds a BufferedConsole where the formatting is done and cached, and the raw colored strings are piped to stdout directly. There is still a flicking sometimes, but it's back to the level it was before.