### PR TITLE
chore: make use of changeset action and cache deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - master
-    paths:
-      - '.changeset/*.md'
 
 jobs:
   release:
+    # Prevents changesets action from creating a PR on forks
+    if: github.repository == 'modernweb-dev/web'
     name: Release
     runs-on: ubuntu-latest
     steps:
@@ -24,28 +24,29 @@ jobs:
           node-version: 12.x
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: Install Dependencies
-        run: yarn
+        run: yarn --frozen-lockfile
         env:
           ROLLUP_PRODUCTION_BUILD: 'true'
 
-      - name: Changeset version
-        run: yarn changeset version
-
-      - name: Format
-        run: yarn format
-
-      - name: Commit version updates
-        run: |
-          git config --local user.email "no-reply@modern-web.dev"
-          git config --local user.name "Modern Web Bot"
-      - run: git add .
-      - run: "git commit -m 'chore: release new versions'"
-
-      - name: Release to NPM
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@master
+        with:
+          # This expects you to have a script called release which does a build for your packages and calls changeset publish
+          publish: yarn release
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: yarn changeset publish
-
-      - name: Push commits and tags to GitHub
-        run: git push https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY} --follow-tags
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,6 +17,18 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: Install dependencies
         run: yarn --frozen-lockfile
 
@@ -35,6 +47,18 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 14.x
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: Install dependencies
         run: yarn --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint:prettier": "prettier \"**/*.{ts,js,md}\" \"**/package.json\" --check --ignore-path .eslintignore",
     "postinstall": "yarn build",
     "reinstall-workspace": "rimraf demo/projects/*/node_modules && rimraf packages/*/node_modules && rimraf node_modules && yarn install && yarn build",
+    "release": "yarn format && changeset publish",
     "test": "node scripts/workspaces-scripts.mjs test:ci",
     "tsc": "rimraf packages/*/tsconfig.tsbuildinfo && tsc --build packages/tsconfig.project.json",
     "tsc:watch": "yarn tsc --watch",


### PR DESCRIPTION
The action works as follows.

- When you create a changeset and push it to master, it does not immediately publish. 
- First, the action creates a PR which contains all the information about what will be released, which dependent packages get a bump, etc. etc.
- When another PR is merged to master also containing a changeset, the auto-created PR is updated automatically by the action.
- When you merge this auto-generated PR, it will publish all the things for you 🎉 so it's a final check basically, and an easy and overview-able way to stack up intents to release.

I also added some caching to the dependencies, which in lion already sped things up significantly (>50% faster).

Lastly, I checked about linked packages. Long story short is that you don't need linked packages for technical reasons usually, the patch bumps of dependents is usually enough. It is more for your users to keep linked packages' versions more "coupled" so that your majors are always aligned. Because one can make the assumption that e.g. "test-runner-core" 2.0.0 cannot possibly work with "test-runner-launcher" 1.5.7 for example so then linked packages can make sense. 

See [here](https://github.com/atlassian/changesets/issues/415) for the issue discussion and [here](https://github.com/ing-bank/lion/pull/839#discussion_r460960837) for additional comment by Andarist who uses/works on changesets a lot