### PR TITLE
feat: add an easy way to change served mime types

### DIFF
--- a/.changeset/few-fireants-hug.md
+++ b/.changeset/few-fireants-hug.md
@@ -1,0 +1,8 @@
+---
+'@web/dev-server-core': patch
+'@web/dev-server-rollup': patch
+'@web/test-runner': patch
+'@web/test-runner-server': patch
+---
+
+add an easy way to change served mime types

--- a/docs/docs/dev-server/code-transformations.md
+++ b/docs/docs/dev-server/code-transformations.md
@@ -191,17 +191,11 @@ const { fromRollup } = require('@web/dev-server-rollup');
 const json = fromRollup(rollupJson);
 
 module.exports = {
-  plugins: [
-    {
-      name: 'json-mime-type',
-      resolveMimeType(context) {
-        if (context.path.endsWith('.json')) {
-          return 'js';
-        }
-      },
-    },
-    json({}),
-  ],
+  // tell the server to serve json files as js
+  mimeTypes: {
+    '**/*.json': 'js',
+  },
+  plugins: [json({})],
 };
 ```
 
@@ -228,19 +222,12 @@ module.exports = {
   // in a monorepo you need to adjust the rootdir of the web server
   // postcss injects a module which needs to be reachable from the browser
   // rootDir: '../..',
-  plugins: [
-    {
-      name: 'serve-css',
-      // you need to tell the web server you intend to serve .module.css files as
-      // javascript modules
-      resolveMimeType(context) {
-        if (context.path.endsWith('.module.css')) {
-          return 'js';
-        }
-      },
-    },
-    postcss({ include: ['src/**/*.css'], modules: true }),
-  ],
+
+  // tell the server to serve css files as js
+  mimeTypes: {
+    '**/*.css': 'js',
+  },
+  plugins: [postcss({ include: ['src/**/*.css'], modules: true })],
 };
 ```
 
@@ -259,19 +246,11 @@ const { fromRollup } = require('@web/dev-server-rollup');
 const litcss = fromRollup(rollupLitcss);
 
 module.exports = {
-  plugins: [
-    {
-      name: 'serve-css',
-      // you need to tell the web server you intend to serve .css files as
-      // javascript modules
-      resolveMimeType(context) {
-        if (context.path.endsWith('.css')) {
-          return 'js';
-        }
-      },
-    },
-    litcss({ include: ['src/**/*.css'] }),
-  ],
+  // tell the server to serve css files as js
+  mimeTypes: {
+    '**/*.css': 'js',
+  },
+  plugins: [litcss({ include: ['src/**/*.css'] })],
 };
 ```
 
@@ -295,19 +274,11 @@ const { fromRollup } = require('@web/dev-server-rollup');
 const url = fromRollup(rollupUrl);
 
 module.exports = {
-  plugins: [
-    {
-      name: 'serve-assets',
-      // you need to tell the web server which files you want to serve as JS module
-      // in this example we're taking everything in the /assts directory
-      resolveMimeType(context) {
-        if (context.path.startsWith('/assets/')) {
-          return 'js';
-        }
-      },
-    },
-    url({ include: ['assets/**/*.png'] }),
-  ],
+  // tell the server to serve your assets files as js
+  mimeTypes: {
+    './assets/**/*': 'js',
+  },
+  plugins: [url({ include: ['assets/**/*.png'] })],
 };
 ```
 

--- a/docs/docs/dev-server/rollup.md
+++ b/docs/docs/dev-server/rollup.md
@@ -44,19 +44,13 @@ const json = require('@rollup/plugin-json');
 const { rollupAdapter } = require('@web/dev-server-rollup');
 
 module.exports = {
-  plugins: [
-    {
-      name: 'json-mime-type-plugin',
-
-      resolveMimeType(context) {
-        if (context.path.endsWith('.json')) {
-          return 'js';
-        }
-      },
-    },
-
-    rollupAdapter(json()),
-  ],
+  mimeTypes: {
+    // serve all json files as js
+    '**/*.json': 'js',
+    // serve .module.css files as js
+    '**/*.module.css': 'js',
+  },
+  plugins: [rollupAdapter(json())],
 };
 ```
 

--- a/packages/dev-server-core/README.md
+++ b/packages/dev-server-core/README.md
@@ -4,7 +4,7 @@ Core library powering the web server of [@web/test-runner](https://github.com/mo
 
 Documentation:
 
-- [Using es modules](https://github.com/modernweb-dev/web/tree/master/packages/dev-server-core/docs/es-modules.md)
-- [Common code transformations](https://github.com/modernweb-dev/web/tree/master/packages/dev-server-core/docs/code-transformations.md)
-- [Server Middleware](https://github.com/modernweb-dev/web/tree/master/packages/dev-server-core/docs/server-middleware.md)
-- [Server plugins](https://github.com/modernweb-dev/web/tree/master/packages/dev-server-core/docs/server-plugins.md)
+- [Using es modules](https://github.com/modernweb-dev/web/blob/master/docs/learn/standards-based/es-modules.md)
+- [Common code transformations](https://github.com/modernweb-dev/web/blob/master/docs/docs/dev-server/code-transformations.md)
+- [Server Middleware](https://github.com/modernweb-dev/web/blob/master/docs/docs/dev-server/middleware.md)
+- [Server plugins](https://github.com/modernweb-dev/web/blob/master/docs/docs/dev-server/server-plugins.md)

--- a/packages/dev-server-core/package.json
+++ b/packages/dev-server-core/package.json
@@ -52,7 +52,8 @@
     "koa-static": "^5.0.0",
     "lru-cache": "^5.1.1",
     "mime-types": "^2.1.27",
-    "parse5": "^6.0.0"
+    "parse5": "^6.0.0",
+    "picomatch": "^2.2.2"
   },
   "devDependencies": {
     "@types/clone": "^0.1.30",

--- a/packages/dev-server-core/src/DevServerCoreConfig.ts
+++ b/packages/dev-server-core/src/DevServerCoreConfig.ts
@@ -1,6 +1,8 @@
 import { Middleware } from 'koa';
 import { Plugin } from './Plugin';
 
+export type MimeTypeMappings = Record<string, string>;
+
 export interface DevServerCoreConfig {
   port: number;
   rootDir: string;
@@ -8,8 +10,9 @@ export interface DevServerCoreConfig {
   basePath?: string;
   appIndex?: string;
 
-  middleware: Middleware[];
-  plugins: Plugin[];
+  mimeTypes?: MimeTypeMappings;
+  middleware?: Middleware[];
+  plugins?: Plugin[];
 
   http2?: boolean;
   sslKey?: string;

--- a/packages/dev-server-core/src/index.ts
+++ b/packages/dev-server-core/src/index.ts
@@ -1,6 +1,6 @@
 export { DevServer } from './server/DevServer';
 export { Plugin } from './Plugin';
-export { DevServerCoreConfig } from './DevServerCoreConfig';
+export { DevServerCoreConfig, MimeTypeMappings } from './DevServerCoreConfig';
 export {
   getRequestBrowserPath,
   getRequestFilePath,

--- a/packages/dev-server-core/src/middleware/pluginTransformMiddleware.ts
+++ b/packages/dev-server-core/src/middleware/pluginTransformMiddleware.ts
@@ -17,7 +17,7 @@ export function pluginTransformMiddleware(
   fileWatcher: FSWatcher,
 ): Middleware {
   const cache = new PluginTransformCache(fileWatcher, config.rootDir);
-  const transformPlugins = config.plugins.filter(p => 'transform' in p);
+  const transformPlugins = (config.plugins ?? []).filter(p => 'transform' in p);
   if (transformPlugins.length === 0) {
     // nothing to transform
     return (ctx, next) => next();

--- a/packages/dev-server-core/src/plugins/mimeTypesPlugin.ts
+++ b/packages/dev-server-core/src/plugins/mimeTypesPlugin.ts
@@ -1,0 +1,43 @@
+import picoMatch from 'picomatch';
+import { isAbsolute, posix } from 'path';
+
+import { MimeTypeMappings } from '../DevServerCoreConfig';
+import { Plugin } from '../Plugin';
+import { getRequestFilePath } from '../utils';
+
+function createMatcher(rootDir: string, pattern: string) {
+  const resolvedPattern =
+    !isAbsolute(pattern) && !pattern.startsWith('*') ? posix.join(rootDir, pattern) : pattern;
+  return picoMatch(resolvedPattern);
+}
+
+interface Matcher {
+  fn: (test: string) => boolean;
+  mimeType: string;
+}
+
+export function mimeTypesPlugin(mappings: MimeTypeMappings): Plugin {
+  const matchers: Matcher[] = [];
+  let rootDir: string;
+
+  return {
+    name: 'mime-types',
+
+    serverStart({ config }) {
+      ({ rootDir } = config);
+
+      for (const [pattern, mimeType] of Object.entries(mappings)) {
+        matchers.push({ fn: createMatcher(rootDir, pattern), mimeType });
+      }
+    },
+
+    resolveMimeType(context) {
+      const filePath = getRequestFilePath(context, rootDir);
+      for (const matcher of matchers) {
+        if (matcher.fn(filePath)) {
+          return matcher.mimeType;
+        }
+      }
+    },
+  };
+}

--- a/packages/dev-server-core/src/server/DevServer.ts
+++ b/packages/dev-server-core/src/server/DevServer.ts
@@ -41,7 +41,7 @@ export class DevServer {
         : this.config.hostname,
     });
 
-    for (const plugin of this.config.plugins) {
+    for (const plugin of this.config.plugins ?? []) {
       await plugin.serverStart?.({
         config: this.config,
         app: this.koaApp,
@@ -57,7 +57,7 @@ export class DevServer {
     return Promise.all([
       this.fileWatcher.close(),
       promisify(this.server.close).bind(this.server)(),
-      ...this.config.plugins.map(p => p.serverStop?.()),
+      ...(this.config.plugins ?? []).map(p => p.serverStop?.()),
     ]);
   }
 }

--- a/packages/dev-server-core/src/server/createMiddleware.ts
+++ b/packages/dev-server-core/src/server/createMiddleware.ts
@@ -61,8 +61,8 @@ export function createMiddleware(
   }
 
   middlewares.push(pluginTransformMiddleware(config, logger, fileWatcher));
-  middlewares.push(pluginMimeTypeMiddleware(config.plugins));
-  middlewares.push(pluginServeMiddleware(config.plugins));
+  middlewares.push(pluginMimeTypeMiddleware(config.plugins ?? []));
+  middlewares.push(pluginServeMiddleware(config.plugins ?? []));
 
   // serve static files
   middlewares.push(

--- a/packages/dev-server-core/src/server/createPlugins.ts
+++ b/packages/dev-server-core/src/server/createPlugins.ts
@@ -2,15 +2,20 @@ import { DevServerCoreConfig } from '../DevServerCoreConfig';
 import { Plugin } from '../Plugin';
 import { resolveModuleImportsPlugin } from '../plugins/resolveModuleImportsPlugin';
 import { eventStreamPlugin } from '../event-stream/eventStreamPlugin';
+import { mimeTypesPlugin } from '../plugins/mimeTypesPlugin';
 
 export function createPlugins(config: DevServerCoreConfig) {
   const plugins: Plugin[] = [];
 
-  if (config.plugins.some(pl => 'resolveImport' in pl)) {
+  if (config.mimeTypes && Object.keys(config.mimeTypes).length > 0) {
+    plugins.push(mimeTypesPlugin(config.mimeTypes));
+  }
+
+  if (config.plugins?.some(pl => 'resolveImport' in pl)) {
     plugins.push(resolveModuleImportsPlugin(config.plugins, config.rootDir));
   }
 
-  if (config.eventStream && config.plugins.some(pl => pl.injectEventStream)) {
+  if (config.eventStream && config.plugins?.some(pl => pl.injectEventStream)) {
     plugins.push(eventStreamPlugin());
   }
 

--- a/packages/dev-server-core/src/server/createServer.ts
+++ b/packages/dev-server-core/src/server/createServer.ts
@@ -35,6 +35,9 @@ export function createServer(
   const app = new Koa();
 
   const plugins = createPlugins(cfg);
+  if (!cfg.plugins) {
+    cfg.plugins = [];
+  }
   cfg.plugins.push(...plugins);
 
   // special case the legacy plugin, if it is given make sure the resolve module imports plugin

--- a/packages/dev-server-core/test/tests/plugins/mimeTypesPlugin.test.ts
+++ b/packages/dev-server-core/test/tests/plugins/mimeTypesPlugin.test.ts
@@ -1,0 +1,69 @@
+import { expect } from 'chai';
+import fetch from 'node-fetch';
+
+import { createTestServer } from '../helpers';
+
+describe.only('mimeTypesPLugin', () => {
+  it('can configure mime types for files', async () => {
+    const { server, host } = await createTestServer({
+      mimeTypes: {
+        '**/*.css': 'js',
+      },
+      plugins: [
+        {
+          name: 'test',
+          serve(context) {
+            if (context.path === '/foo.css') {
+              return '';
+            }
+          },
+        },
+      ],
+    });
+
+    try {
+      const response = await fetch(`${host}/foo.css`);
+      expect(response.status).to.equal(200);
+      expect(response.headers.get('content-type')).to.equal(
+        'application/javascript; charset=utf-8',
+      );
+    } finally {
+      server.stop();
+    }
+  });
+
+  it('can resolve literal paths', async () => {
+    const { server, host } = await createTestServer({
+      rootDir: __dirname,
+      mimeTypes: {
+        'foo.css': 'js',
+      },
+      plugins: [
+        {
+          name: 'test',
+          serve(context) {
+            if (context.path.endsWith('.css')) {
+              return '';
+            }
+          },
+        },
+      ],
+    });
+
+    try {
+      const responseA = await fetch(`${host}/foo.css`);
+      expect(responseA.status).to.equal(200);
+      expect(responseA.headers.get('content-type')).to.equal(
+        'application/javascript; charset=utf-8',
+      );
+
+      const responseB = await fetch(`${host}/x/foo.css`);
+      expect(responseB.status).to.equal(200);
+      expect(responseB.headers.get('content-type')).not.to.equal(
+        'application/javascript; charset=utf-8',
+      );
+    } finally {
+      server.stop();
+    }
+  });
+});

--- a/packages/dev-server-rollup/README.md
+++ b/packages/dev-server-rollup/README.md
@@ -36,25 +36,17 @@ Some rollup plugins do expensive operations. During development, this matters a 
 The rollup build process assumes that any imported files are are meant to be compiled to JS, web dev server serves many different kinds of files to the browser. If you are transforming a non-standard filetype to JS, for example .json files, you need to instruct the server to handle it as a JS file:
 
 ```js
-const rollupJson = require('@rollup/plugin-json');
-const { fromRollup } = require('@web/dev-server-rollup');
-
-const json = fromRollup(rollupJson);
+const json = require('@rollup/plugin-json');
+const { rollupAdapter } = require('@web/dev-server-rollup');
 
 module.exports = {
-  plugins: [
-    {
-      name: 'json-mime-type-plugin',
-
-      resolveMimeType(context) {
-        if (context.path.endsWith('.json')) {
-          return 'js';
-        }
-      },
-    },
-
-    json({ include: ['src/**/*.js'] }),
-  ],
+  mimeTypes: {
+    // serve all json files as js
+    '**/*.json': 'js',
+    // serve .module.css files as js
+    '**/*.module.css': 'js',
+  },
+  plugins: [rollupAdapter(json())],
 };
 ```
 

--- a/packages/dev-server-rollup/src/createRollupPluginContextAdapter.ts
+++ b/packages/dev-server-rollup/src/createRollupPluginContextAdapter.ts
@@ -55,7 +55,7 @@ export function createRollupPluginContextAdapter<
     async resolve(source: string, importer: string, options: { skipSelf: boolean }) {
       if (!context) throw new Error('Context is required.');
 
-      for (const pl of config.plugins) {
+      for (const pl of config.plugins ?? []) {
         if (
           pl.resolveImport &&
           (!options.skipSelf || pl.resolveImport !== wdsPlugin.resolveImport)

--- a/packages/dev-server-rollup/test/node/plugins/postcss.test.ts
+++ b/packages/dev-server-rollup/test/node/plugins/postcss.test.ts
@@ -11,6 +11,9 @@ describe('@rollup/plugin-postcss', () => {
   it('can run postcss on imported css files', async () => {
     const { server, host } = await createTestServer({
       rootDir: resolve(__dirname, '..', '..', '..', '..', '..'),
+      mimeTypes: {
+        '**/*.css': 'js',
+      },
       plugins: [
         {
           name: 'serve-css',
@@ -28,12 +31,6 @@ html {
 #bar {
   color: red;
 }`;
-            }
-          },
-
-          resolveMimeType(context) {
-            if (context.path.endsWith('.css')) {
-              return 'js';
             }
           },
         },

--- a/packages/dev-server-rollup/web-test-runner.config.js
+++ b/packages/dev-server-rollup/web-test-runner.config.js
@@ -8,16 +8,8 @@ const postcss = fromRollup(rollupPostcss);
 
 module.exports = {
   rootDir: '../..',
-  plugins: [
-    commonjs(),
-    {
-      name: 'serve-css',
-      resolveMimeType(context) {
-        if (context.path.endsWith('.css')) {
-          return 'js';
-        }
-      },
-    },
-    postcss({ modules: true }),
-  ],
+  mimeTypes: {
+    '**/*.css': 'js',
+  },
+  plugins: [commonjs(), postcss({ modules: true })],
 };

--- a/packages/test-runner-browserstack/package.json
+++ b/packages/test-runner-browserstack/package.json
@@ -22,7 +22,9 @@
     "test": "mocha test/**/*.test.ts --require ts-node/register --reporter progress",
     "test:watch": "mocha test/**/*.test.ts --require ts-node/register --watch --watch-files src,test --reporter progress"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "keywords": [
     "web",
     "test",

--- a/packages/test-runner-chrome/package.json
+++ b/packages/test-runner-chrome/package.json
@@ -23,7 +23,9 @@
     "test:ci": "yarn test",
     "test:watch": "mocha test/**/*.test.ts --require ts-node/register --watch --watch-files src,test --reporter progress"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "keywords": [
     "web",
     "test",

--- a/packages/test-runner-playwright/package.json
+++ b/packages/test-runner-playwright/package.json
@@ -23,7 +23,9 @@
     "test:ci": "yarn test",
     "test:watch": "mocha test/**/*.test.ts --require ts-node/register --watch --watch-files src,test --reporter progress"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "keywords": [
     "web",
     "test",

--- a/packages/test-runner-puppeteer/package.json
+++ b/packages/test-runner-puppeteer/package.json
@@ -23,7 +23,9 @@
     "test:ci": "yarn test",
     "test:watch": "mocha test/**/*.test.ts --require ts-node/register --watch --watch-files src,test --reporter progress"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "keywords": [
     "web",
     "test",

--- a/packages/test-runner-selenium/package.json
+++ b/packages/test-runner-selenium/package.json
@@ -23,7 +23,9 @@
     "test:ci": "yarn test",
     "test:watch": "mocha test/**/*.test.ts --require ts-node/register --watch --watch-files src,test --reporter progress"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "keywords": [
     "web",
     "test",

--- a/packages/test-runner-server/src/server/TestRunnerServerConfig.ts
+++ b/packages/test-runner-server/src/server/TestRunnerServerConfig.ts
@@ -1,8 +1,9 @@
-import { Middleware } from '@web/dev-server-core';
+import { Middleware, MimeTypeMappings } from '@web/dev-server-core';
 import { TestRunnerPlugin } from './TestRunnerPlugin';
 
 export interface TestRunnerServerConfig {
   debug?: boolean;
+  mimeTypes?: MimeTypeMappings;
   plugins?: TestRunnerPlugin[];
   middleware?: Middleware[];
 }

--- a/packages/test-runner-server/src/server/testRunnerServer.ts
+++ b/packages/test-runner-server/src/server/testRunnerServer.ts
@@ -35,6 +35,7 @@ export function testRunnerServer(testRunnerServerConfig: TestRunnerServerConfig 
           hostname: config.hostname,
           rootDir,
 
+          mimeTypes: testRunnerServerConfig.mimeTypes,
           middleware: [
             testRunnerApiMiddleware(sessions, rootDir, config, plugins),
             watchFilesMiddleware({ runner, sessions, rootDir, fileWatcher }),

--- a/packages/test-runner/package.json
+++ b/packages/test-runner/package.json
@@ -37,7 +37,9 @@
     "test:source-maps": "node dist/test-runner.js demo/test/source-maps/**/*/*.test.js",
     "test:watch": "node dist/test-runner.js demo/**/pass-*.test.{js,html} --watch"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "keywords": [
     "web",
     "test",

--- a/packages/test-runner/src/test-runner.ts
+++ b/packages/test-runner/src/test-runner.ts
@@ -106,6 +106,7 @@ const cliOptions: commandLineArgs.OptionDefinition[] = [
 
     if (!config.server) {
       const serverConfig: TestRunnerServerConfig = {
+        mimeTypes: config.mimeTypes,
         plugins: config.plugins ?? [],
         middleware: config.middleware ?? [],
       };


### PR DESCRIPTION
Fixes https://github.com/modernweb-dev/web/issues/191

This adds a utility to easily set the mime type for a certain pattern of files from the server and test runner config.

For example:

```js
export default {
  mimeTypes: {
    // serve all json files as js
    '**/*.json': 'js',
    // serve .module.css files as js
    '**/*.module.css': 'js',
  },
}
```

This is useful when doing things like importing CSS files, and will become important as module types other than JS start to become standard. It is also useful when using exotic picture and video formats. 