### PR TITLE
docs: add testing in a CI page

### DIFF
--- a/docs/docs/test-runner/advanced.md
+++ b/docs/docs/test-runner/advanced.md
@@ -3,7 +3,7 @@ title: Advanced
 eleventyNavigation:
   key: Advanced
   parent: Test Runner
-  order: 9
+  order: 10
 ---
 
 The test runner has a modular architecture, with the `@web/test-runner` package implemented an opinionated set of defaults.

--- a/docs/docs/test-runner/browsers/puppeteer.md
+++ b/docs/docs/test-runner/browsers/puppeteer.md
@@ -20,6 +20,10 @@ npm i -D @web/test-runner-puppeteer
 wtr test/**/*.test.js --node-resolve --puppeteer
 ```
 
+## Troubleshooting
+
+Check the official <a href="https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md" target="_blank">troubleshooting page</a> for help with problems during installation.
+
 ## Customizing launcher options
 
 If you want to customize the puppeteer launcher options, you can add the browser launcher in the config.

--- a/docs/docs/test-runner/testing-in-a-ci.md
+++ b/docs/docs/test-runner/testing-in-a-ci.md
@@ -1,0 +1,21 @@
+---
+title: Testing in a CI
+eleventyNavigation:
+  key: Testing in a CI
+  parent: Test Runner
+  order: 9
+---
+
+It's possible to use the test runner in a CI, but because it runs tests on a real browser you need to ensure the CI environments can support it.
+
+The test runner uses `@web/test-runner-chrome` by default which looks for a locally installed Chrome. For your CI you can look for an image which installs Chrome to run your tests.
+
+## Puppeteer
+
+You can also use `@web/test-runner-puppeteer` which downloads it's own compatible version of Chromium. This is more convenient, and can be more stable as well.
+
+Puppeteer has a [dedicated page](https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md) on troubleshooting in general, and contains section on using puppeteer in a CI environment.
+
+## Playwright
+
+If you want to use `@web/test-runner-playwright` in a CI environment you need to ensure the necessary native libraries are installed. Check the [official documentation](https://playwright.dev/#version=master&path=docs%2Fci.md&q=) for more information.


### PR DESCRIPTION
Fixes https://github.com/modernweb-dev/web/issues/326

This adds basic instructions on testing in a CI. I'd prefer to defer as much as possible to the official docs, since it's not WTR specific. But if we have practical advice, we could put it there. What do you think @Westbrook ?