### PR TITLE
feat(test-runner-mocha): add a custom reporter for HTML tests

### DIFF
--- a/.changeset/two-mails-rhyme.md
+++ b/.changeset/two-mails-rhyme.md
@@ -1,0 +1,6 @@
+---
+'@web/test-runner': patch
+'@web/test-runner-mocha': patch
+---
+
+adds a custom reporter for HTML tests, avoiding errors when debugging

--- a/packages/test-runner-mocha/src/standalone.ts
+++ b/packages/test-runner-mocha/src/standalone.ts
@@ -8,6 +8,8 @@ import '../../../node_modules/mocha/mocha.js';
 import { collectTestResults } from './collectTestResults.js';
 
 const mocha = (window as any).mocha as BrowserMocha;
+const BaseReporter = (mocha as any).Mocha.reporters.Base;
+class QuietReporter extends BaseReporter {}
 
 sessionStarted();
 
@@ -16,7 +18,12 @@ export async function runTests(testFn: () => unknown | Promise<unknown>) {
 
   // setup mocha
   const userOptions = typeof testFrameworkConfig === 'object' ? testFrameworkConfig : {};
-  mocha.setup({ ui: 'bdd', allowUncaught: false, ...userOptions });
+  mocha.setup({
+    ui: 'bdd',
+    allowUncaught: false,
+    reporter: QuietReporter as any,
+    ...userOptions,
+  });
 
   // setup the tests
   try {

--- a/packages/test-runner/demo/test/pass-html-1.test.html
+++ b/packages/test-runner/demo/test/pass-html-1.test.html
@@ -5,10 +5,8 @@
       import { runTests } from '../../../test-runner-mocha/dist/standalone.js';
 
       runTests(() => {
-        describe('HTML tests', () => {
-          it('works', () => {
-            expect('foo').to.equal('foo');
-          });
+        it('works', () => {
+          expect('foo').to.equal('foo');
         });
       });
     </script>


### PR DESCRIPTION
adds a custom reporter for HTML tests, avoiding errors when debugging
