### PR TITLE
fix(dev-server-rollup): make sure absolute paths are always returned as-is

### DIFF
--- a/.changeset/slimy-queens-retire.md
+++ b/.changeset/slimy-queens-retire.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server-rollup': patch
+---
+
+make sure absolute paths are always returned as-is

--- a/packages/dev-server-rollup/src/createRollupPluginContextAdapter.ts
+++ b/packages/dev-server-rollup/src/createRollupPluginContextAdapter.ts
@@ -72,9 +72,7 @@ export function createRollupPluginContextAdapter<
             const importerDir = path.dirname(importer);
 
             return {
-              id: resolvedId.startsWith(importerDir)
-                ? resolvedId
-                : path.join(importerDir, resolvedId),
+              id: path.isAbsolute(resolvedId) ? resolvedId : path.join(importerDir, resolvedId),
             };
           }
         }


### PR DESCRIPTION
This is a port of https://github.com/LarsDenBakker/es-dev-server-rollup/pull/6