### PR TITLE
chore: use @esm-bundle/chai everywhere

### DIFF
--- a/docs/blog/introducing-modern-web/index.md
+++ b/docs/blog/introducing-modern-web/index.md
@@ -64,10 +64,10 @@ Some highlights:
 
 This is the minimal instruction on how to start using the test runner.
 
-1. Install the test runner
+1. Install the necessary packages
 
    ```
-   npm i -D @web/test-runner @open-wc/testing
+   npm i -D @web/test-runner @esm-bundle/chai
    ```
 
 2. Add a script to your `package.json`
@@ -84,7 +84,7 @@ This is the minimal instruction on how to start using the test runner.
 3. Create a test file `test/sum.test.js`.
 
    ```js
-   import { expect } from '@open-wc/testing';
+   import { expect } from '@esm-bundle/chai';
    import { sum } from '../src/sum.js';
 
    it('sums up 2 numbers', () => {
@@ -223,7 +223,7 @@ npm i -D @web/test-runner-commands
 With that, we get a `setViewport` method which we can use.
 
 ```js
-import { expect } from '@open-wc/testing';
+import { expect } from '@esm-bundle/chai';
 import { setViewport } from '@web/test-runner-commands';
 import { isMobile } from '../src/isMobile';
 

--- a/docs/docs/test-runner/writing-tests/helper-libraries.md
+++ b/docs/docs/test-runner/writing-tests/helper-libraries.md
@@ -6,17 +6,31 @@ eleventyNavigation:
   order: 30
 ---
 
-[@open-wc/testing](https://open-wc.org/testing/testing.html) is a general-purpose library, including assertions via chai, HTML test fixtures, a11y tests, and test helpers.
+Not all helper libraries ship es modules which are usable in the browser. On this page we collect libraries which are available as es modules. If need to use a library with another module format, you can follow the instructions at the bottom of the [es modules page](../../../learn/web-development/es-modules.md)
 
-It is an opinionated implementation that brings together multiple libraries. You could also use the individual libraries together:
+## General libraries
 
-- [@bundled-es-modules/chai](https://www.npmjs.com/package/@bundled-es-modules/chai)
-- [@open-wc/testing-helpers](https://www.npmjs.com/package/@open-wc/testing-helpers)
-- [@open-wc/chai-dom-equals](https://www.npmjs.com/package/@open-wc/chai-dom-equals)
-- [chai-a11y-axe](https://www.npmjs.com/package/chai-a11y-axe)
+[@open-wc/testing](https://open-wc.org/testing/testing.html) is a general-purpose library, including assertions via chai, HTML test fixtures, a11y tests, and test helpers. It is an opinionated implementation that brings together multiple libraries.
 
-For stubbing and mocking, we recommend [sinon](https://www.npmjs.com/package/sinon) which ships an es module variant out of the box:
+## Assertions
+
+[chai](https://www.npmjs.com/package/chai) is a popular assertion library. It doesn't ship an es module, but you can use [@esm-bundle/chai](https://www.npmjs.com/package/@esm-bundle/chai) for that.
 
 ```js
-import { stub, useFakeTimers } from 'sinon';
+import { expect } from '@esm-bundle/chai';
+
+expect(undefined).to.not.be.a('function');
 ```
+
+## Chai plugins
+
+- [@open-wc/chai-dom-equals](https://www.npmjs.com/package/@open-wc/chai-dom-equals) for diffing HTML
+- [chai-a11y-axe](https://www.npmjs.com/package/chai-a11y-axe) for testing accessibility
+
+## Testing helpers
+
+[@open-wc/testing-helpers](https://www.npmjs.com/package/@open-wc/testing-helpers) contains useful helper functions for setting up snippets of HTML test fixtures, and testing async behavior
+
+## Mocking
+
+For stubbing and mocking, we recommend [sinon](https://www.npmjs.com/package/sinon). Check the [mocking page](./mocking.md) for more.

--- a/docs/docs/test-runner/writing-tests/js-tests.md
+++ b/docs/docs/test-runner/writing-tests/js-tests.md
@@ -12,7 +12,7 @@ Javascript files are loaded by the test framework that is configured. The defaul
 For example:
 
 ```js
-import { expect } from '@bundled-es-modules/chai';
+import { expect } from '@esm-bundle/chai';
 import { myFunction } from '../src/myFunction.js';
 
 describe('myFunction', () => {

--- a/docs/docs/test-runner/writing-tests/mocking.md
+++ b/docs/docs/test-runner/writing-tests/mocking.md
@@ -112,7 +112,7 @@ Test file:
   <body>
     <script type="module">
       import { runTests } from '@web/test-runner-mocha';
-      import { expect } from '@bundled-es-modules/chai';
+      import { expect } from '@esm-bundle/chai';
       // import inside will resolve to ./mocks/postData.js
       import { sendMessage } from '../src/sendMessage.js';
       // resolves to ./mocks/postData.js

--- a/docs/learn/test-runner/code-coverage/index.md
+++ b/docs/learn/test-runner/code-coverage/index.md
@@ -30,7 +30,7 @@ As good citizens we start with the tests first
 👉 `test/calc.test.js`
 
 ```js
-import { expect } from '@open-wc/testing';
+import { expect } from '@esm-bundle/chai';
 import { calc } from '../src/calc.js';
 
 it('does plus for 2 numbers', () => {

--- a/docs/learn/test-runner/getting-started.md
+++ b/docs/learn/test-runner/getting-started.md
@@ -27,10 +27,10 @@ Now that we know what we want we need to place this file somewhere and run a too
 
 ## Setup tools
 
-1. Install the test runner
+1. Install the necessary packages
 
    ```
-   npm i -D @web/test-runner @open-wc/testing
+   npm i -D @web/test-runner @esm-bundle/chai
    ```
 
 2. Add a script to your `package.json`
@@ -62,7 +62,7 @@ fair enough - we didn't create a test file yet.
 1. Take the spec/test from above and create a test file `test/sum.test.js`.
 
    ```js
-   import { expect } from '@open-wc/testing';
+   import { expect } from '@esm-bundle/chai';
    import { sum } from '../src/sum.js';
 
    it('sums up 2 numbers', () => {

--- a/docs/learn/test-runner/responsive.md
+++ b/docs/learn/test-runner/responsive.md
@@ -48,7 +48,7 @@ npm i -D @web/test-runner-commands
 With that we get a `setViewport` method which we can put to good use.
 
 ```js
-import { expect } from '@open-wc/testing';
+import { expect } from '@esm-bundle/chai';
 import { setViewport } from '@web/test-runner-commands';
 import { isMobile } from '../src/isMobile';
 
@@ -116,7 +116,7 @@ Next, we can write our tests to change the viewport and check if our media queri
 
     <script type="module">
       import { runTests } from '@web/test-runner-mocha';
-      import { expect } from '@open-wc/testing';
+      import { expect } from '@esm-bundle/chai';
       import { setViewport } from '@web/test-runner-commands';
 
       runTests(() => {

--- a/docs/learn/test-runner/using-typescript.md
+++ b/docs/learn/test-runner/using-typescript.md
@@ -17,7 +17,7 @@ To get started with Typescript we recommend getting familiar with it first using
 First, we need to install the required dependencies:
 
 ```
-npm i -D @web/test-runner @open-wc/testing typescript
+npm i -D @web/test-runner @esm-bundle/chai @types/mocha typescript
 ```
 
 Next, we need to run initialize typescript for our project:
@@ -61,7 +61,7 @@ export function sum(...numbers: number[]) {
 Add the `test/sum.test.ts` file:
 
 ```ts
-import { expect } from '@open-wc/testing';
+import { expect } from '@esm-bundle/chai';
 import { sum } from '../src/sum.js';
 
 it('sums up 2 numbers', () => {

--- a/docs/learn/test-runner/watch-and-debug/index.md
+++ b/docs/learn/test-runner/watch-and-debug/index.md
@@ -41,7 +41,7 @@ We want to be able to pass in a string like `1 + 2 + 3` to get its sum.
 👉 `test/calc.test.js`
 
 ```js
-import { expect } from '@open-wc/testing';
+import { expect } from '@esm-bundle/chai';
 import { calc } from '../src/calc.js';
 
 it('calculates sums', () => {

--- a/docs/learn/test-runner/writing-plugins.md
+++ b/docs/learn/test-runner/writing-plugins.md
@@ -27,23 +27,35 @@ Then we create a test file in accordance with popper documentation
 👉 `test/tooltip.test.js`
 
 ```js
-import { expect, fixture, html } from '@open-wc/testing';
 import { createPopper } from '@popperjs/core';
 
 it('can use popper', async () => {
-  const wrapper = await fixture(html`
+  const fixture = document.createElement('div');
+  fixture.innerHTML = `
     <div>
+      <style>
+        #tooltip {
+          background-color: #333;
+          color: white;
+          padding: 5px 10px;
+          border-radius: 4px;
+          font-size: 13px;
+        }
+      </style>
+
       <button id="button" aria-describedby="tooltip">I'm a button</button>
       <div id="tooltip" role="tooltip">I'm a tooltip</div>
     </div>
-  `);
+  `;
+  document.body.appendChild(fixture);
 
-  const button = wrapper.querySelector('#button');
-  const tooltip = wrapper.querySelector('#tooltip');
+  const button = fixture.querySelector('#button');
+  const tooltip = fixture.querySelector('#tooltip');
 
   createPopper(button, tooltip, {
     placement: 'right',
   });
+  fixture.remove();
 });
 ```
 
@@ -140,8 +152,6 @@ hello world
 /node_modules/@popperjs/core/lib/dom-utils/getDocumentElement.js
 hello world
 /node_modules/@popperjs/core/lib/dom-utils/getComputedStyle.js
-hello world
-/node_modules/@open-wc/testing-helpers/src/fixture-no-side-effect.js
 hello world
 /node_modules/@popperjs/core/lib/utils/getOppositePlacement.js
 ```

--- a/packages/browser-logs/package.json
+++ b/packages/browser-logs/package.json
@@ -19,8 +19,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "node ../test-runner/dist/test-runner.js test-custom/**/*.test.ts",
-    "test:watch": "node ../test-runner/dist/test-runner.js test-custom/**/*.test.ts --watch"
+    "test": "node ../test-runner/dist/test-runner.js test-browser/**/*.test.ts",
+    "test:watch": "node ../test-runner/dist/test-runner.js test-browser/**/*.test.ts --watch"
   },
   "files": [
     "*.d.ts",
@@ -39,13 +39,13 @@
     "serialize",
     "deserialize"
   ],
-  "devDependencies": {
-    "@bundled-es-modules/chai": "^4.2.2"
-  },
   "exports": {
     ".": {
       "import": "./index.mjs",
       "require": "./dist/index.js"
     }
+  },
+  "devDependencies": {
+    "@esm-bundle/chai": "^4.1.5"
   }
 }

--- a/packages/browser-logs/test-browser/browser-logs.test.ts
+++ b/packages/browser-logs/test-browser/browser-logs.test.ts
@@ -1,4 +1,4 @@
-import { expect } from '@bundled-es-modules/chai';
+import { expect } from '@esm-bundle/chai';
 import { serialize } from '../src/serialize.js';
 import { deserialize } from '../src/deserialize.js';
 

--- a/packages/dev-server-import-maps/test/browser/test/import-map-a.test.html
+++ b/packages/dev-server-import-maps/test/browser/test/import-map-a.test.html
@@ -12,7 +12,7 @@
   <body>
     <script type="module">
       import { runTests } from '@web/test-runner-mocha';
-      import { expect } from '@bundled-es-modules/chai';
+      import { expect } from '@esm-bundle/chai';
       import { sendMessage } from '../src/sendMessage.js';
       import { postData, __importMeta } from '../src/postData.js';
 

--- a/packages/dev-server-import-maps/test/browser/test/import-map-b.test.html
+++ b/packages/dev-server-import-maps/test/browser/test/import-map-b.test.html
@@ -2,7 +2,7 @@
   <body>
     <script type="module">
       import { runTests } from '@web/test-runner-mocha';
-      import { expect } from '@bundled-es-modules/chai';
+      import { expect } from '@esm-bundle/chai';
       import { postData, __importMeta } from '../src/postData.js';
 
       runTests(() => {

--- a/packages/dev-server-import-maps/test/browser/web-test-runner.config.mjs
+++ b/packages/dev-server-import-maps/test/browser/web-test-runner.config.mjs
@@ -13,7 +13,7 @@ export default {
             'chai/': '/node_modules/chai/',
             sinon: '/node_modules/sinon/pkg/sinon-esm.js',
             '@web/test-runner-mocha': '/packages/test-runner-mocha/dist/standalone.js',
-            '@bundled-es-modules/chai': '/node_modules/@bundled-es-modules/chai/index.js',
+            '@esm-bundle/chai': '/node_modules/@esm-bundle/chai/index.js',
           },
         },
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -888,11 +888,6 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@bundled-es-modules/chai@^4.2.2":
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/@bundled-es-modules/chai/-/chai-4.2.2.tgz#88dffebd7cd1e87397738107c3c54b9b4ea56e5e"
-  integrity sha512-iGmVYw2/zJCoqyKTtWEYCtFmMyi8WmACQKtky0lpNyEKWX0YIOpKWGD7saMXL+tPpllss0otilxV0SLwyi3Ytg==
-
 "@changesets/apply-release-plan@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@changesets/apply-release-plan/-/apply-release-plan-4.0.0.tgz#e78efb56a4e459a8dab814ba43045f2ace0f27c9"
@@ -1131,6 +1126,13 @@
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@d4kmor/navigation/-/navigation-0.1.3.tgz#61c48008818fe30a88078ac4d16cbe2f37d0010e"
   integrity sha512-ek7+oqCwlD+gKdWgHYMNOwBCirNagKrgMFINiVTPzw4AG7VCX0LL7CVNT7uW2tyuSGFolPI4BItr+4qKEXzd2w==
+
+"@esm-bundle/chai@^4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@esm-bundle/chai/-/chai-4.1.5.tgz#4d709d93af5364a8e06f40cec0200d223409931e"
+  integrity sha512-gAsVEoNufupcbM1Yli7ufbj7jja2qJrzLHhO8vqhiiM1r4NKOl/8ewtjtJMmhgCBG0ET2lnFhXWEFm9LjwZRbQ==
+  dependencies:
+    "@types/chai" "^4.2.12"
 
 "@hapi/address@2.x.x":
   version "2.1.4"
@@ -1656,7 +1658,7 @@
   resolved "https://registry.yarnpkg.com/@types/caniuse-api/-/caniuse-api-3.0.0.tgz#af31cc52062be0ab24583be072fd49b634dcc2fe"
   integrity sha512-wT1VfnScjAftZsvLYaefu/UuwYJdYBwD2JDL2OQd01plGmuAoir5V6HnVHgrfh7zEwcasoiyO2wQ+W58sNh2sw==
 
-"@types/chai@*", "@types/chai@^4.2.11":
+"@types/chai@*", "@types/chai@^4.2.11", "@types/chai@^4.2.12":
   version "4.2.12"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.12.tgz#6160ae454cd89dae05adc3bb97997f488b608201"
   integrity sha512-aN5IAC8QNtSUdQzxu7lGBgYAOuU1tmRU4c9dIq5OKGf/SBVjXo+ffM2wEjudAWbgpOhy60nLoAGH1xm8fpCKFQ==


### PR DESCRIPTION
This updates all our code and docs to use `@esm-bundle/chai` instead of `@open-wc/testing` or `@bundles-es-modules/chai`.