### PR TITLE
chore: align docs

### DIFF
--- a/docs/docs/test-runner/browsers/overview.md
+++ b/docs/docs/test-runner/browsers/overview.md
@@ -1,5 +1,5 @@
 ---
-title: Chrome
+title: Browser Launchers
 eleventyNavigation:
   key: Browsers > Overview
   title: Overview

--- a/docs/docs/test-runner/browsers/writing-browser-lauchers.md
+++ b/docs/docs/test-runner/browsers/writing-browser-lauchers.md
@@ -1,0 +1,13 @@
+---
+title: Writing Browser Launchers
+eleventyNavigation:
+  key: Writing Browser Launchers
+  parent: Browsers
+  order: 90
+---
+
+A browser launcher handles booting up or connecting to a browser, visiting a URL and closing the browser when tests finish.
+
+If you want to implement your own browser launcher, it's best to look at the [interface in the source code](../../../../packages/test-runner-core/src/browser-launcher/BrowserLauncher.ts).
+
+For a reference implementation, you can take a look at [@web/test-runner-chrome](https://github.com/modernweb-dev/web/tree/master/packages/test-runner-chrome).

--- a/docs/docs/test-runner/reporters/index.md
+++ b/docs/docs/test-runner/reporters/index.md
@@ -1,24 +1,8 @@
 ---
 title: Reporters
+layout: with-index.njk
 eleventyNavigation:
   key: Reporters
   parent: Test Runner
   order: 8
 ---
-
-You can customize the test reporters using the `reporters` option.
-
-```js
-// import the browser launcher you want to use
-import { defaultReporter } from '@web/test-runner';
-import { myReporter } from 'my-reporter';
-
-export default {
-  reporters: [
-    // use the default reporter only for reporting test progress
-    defaultReporter({ reportTestResults: false, reportTestProgress: true }),
-    // use another reporter to report test results
-    myReporter(),
-  ],
-};
-```

--- a/docs/docs/test-runner/reporters/junit.md
+++ b/docs/docs/test-runner/reporters/junit.md
@@ -3,7 +3,7 @@ title: JUnit
 eleventyNavigation:
   key: JUnit
   parent: Reporters
-  order: 1
+  order: 20
 ---
 
 JUnit XML reporter for web test runner

--- a/docs/docs/test-runner/reporters/overview.md
+++ b/docs/docs/test-runner/reporters/overview.md
@@ -1,0 +1,25 @@
+---
+title: Reporters
+eleventyNavigation:
+  key: Reporters > Overview
+  title: Overview
+  parent: Reporters
+  order: 10
+---
+
+You can customize the test reporters using the `reporters` option.
+
+```js
+// import the browser launcher you want to use
+import { defaultReporter } from '@web/test-runner';
+import { myReporter } from 'my-reporter';
+
+export default {
+  reporters: [
+    // use the default reporter only for reporting test progress
+    defaultReporter({ reportTestResults: false, reportTestProgress: true }),
+    // use another reporter to report test results
+    myReporter(),
+  ],
+};
+```

--- a/docs/docs/test-runner/reporters/writing-reporters.md
+++ b/docs/docs/test-runner/reporters/writing-reporters.md
@@ -1,4 +1,10 @@
-# Reporter
+---
+title: Writing Reporters
+eleventyNavigation:
+  key: Writing Reporters
+  parent: Reporters
+  order: 30
+---
 
 A reporter reports test results and/or test progress. It is an object with several hooks which are called during the lifecycle of of the test runner. The actual logging to the terminal is managed by the test run to ensure interaction with the dynamic progress bar and watch menu are managed properly.
 

--- a/docs/docs/test-runner/test-frameworks/writing-test-frameworks.md
+++ b/docs/docs/test-runner/test-frameworks/writing-test-frameworks.md
@@ -1,7 +1,7 @@
 ---
-title: Writing a test framework
+title: Writing Test Frameworks
 eleventyNavigation:
-  key: Writing Test Framework
+  key: Writing Test Frameworks
   parent: Test Frameworks
 ---
 

--- a/packages/test-runner-core/docs/browser-launcher.md
+++ b/packages/test-runner-core/docs/browser-launcher.md
@@ -1,7 +1,0 @@
-# Browser Launcher
-
-A browser launcher handles booting up or connecting to a browser, visiting a URL and closing the browser when tests finish.
-
-If you want to implement your own browser launcher, it's best to look at the [interface in the source code](../src/browser-launcher/BrowserLauncher.ts).
-
-For a reference implementation, you can take a look at [@web/test-runner-chrome](https://github.com/modernweb-dev/web/tree/master/packages/test-runner-chrome)

--- a/packages/test-runner-core/docs/server.md
+++ b/packages/test-runner-core/docs/server.md
@@ -1,7 +1,0 @@
-# Server
-
-While it is technically possible to implement your own server, for most cases it would be easier to use the [default server](https://github.com/modernweb-dev/web/tree/master/packages/test-runner-server) and set up a proxy or plugin to delegate work to other servers or compilers.
-
-If you want to implement your own server, it's best to look at the [interface in the source code](../src/server/Server.ts).
-
-For a reference implementation, you can take a look at [@web/test-runner-server](https://github.com/modernweb-dev/web/tree/master/packages/test-runner-server)

--- a/packages/test-runner-core/test/src/runner/TestRunner.test.ts
+++ b/packages/test-runner-core/test/src/runner/TestRunner.test.ts
@@ -67,7 +67,7 @@ it('can run a single test file', async () => {
   await runner.stop();
 });
 
-it('closes test runner for a succesful test', async () => {
+it('closes test runner for a successful test', async () => {
   const { browser, runner } = await createTestRunner();
   let resolveStopped: (passed: boolean) => void;
   const stopped = new Promise<boolean>(resolve => {

--- a/packages/test-runner/README.md
+++ b/packages/test-runner/README.md
@@ -2,16 +2,16 @@
 
 Test runner for web applications.
 
-👉&nbsp;&nbsp; Headless browsers with [Puppeteer](browsers/puppeteer.md), [Playwright](browsers/playwright.md), or [Selenium](browsers/selenium.md). <br>
+👉&nbsp;&nbsp; Headless browsers with [Puppeteer](https://modern-web.dev/docs/test-runner/browsers/puppeteer/), [Playwright](https://modern-web.dev/docs/test-runner/browsers/playwright/), or [Selenium](https://modern-web.dev/docs/test-runner/browsers/selenium/). <br>
 🚧&nbsp;&nbsp; Reports logs, 404s, and errors from the browser. <br>
 🔍&nbsp;&nbsp; Debug opens a real browser window with devtools.<br>
-📦&nbsp;&nbsp; Mock es modules using [Import Maps](./writing-tests/mocking.md).<br>
+📦&nbsp;&nbsp; Mock es modules using [Import Maps](.https://modern-web.dev/docs/test-runner/writing-tests/mocking/).<br>
 🔧&nbsp;&nbsp; Exposes browser properties like viewport size and dark mode.<br>
 ⏱&nbsp;&nbsp;Runs tests in parallel and isolation.<br>
 👀&nbsp;&nbsp; Interactive watch mode.<br>
 🏃&nbsp;&nbsp; Fast development by rerunning only changed tests.<br>
-🚀&nbsp;&nbsp; Powered by [esbuild](/docs/dev-server/plugins/esbuild.md) and [rollup plugins](/docs/dev-server/plugins/rollup.md)
+🚀&nbsp;&nbsp; Powered by [esbuild](https://modern-web.dev/docs/dev-server/plugins/esbuild/) and [rollup plugins](https://modern-web.dev/docs/dev-server/plugins/rollup/)
 
-Check out this [step by step guide](../../guides/test-runner/getting-started.md) to get started.
+Check out this [step by step guide](https://modern-web.dev/guides/test-runner/getting-started/) to get started.
 
 See [our website](https://modern-web.dev/docs/test-runner/overview/) for full documentation.


### PR DESCRIPTION
What I did:

- Move last `docs` folder in `web-test-runner-core` into the main docs
- Make all links full URLs in the web test runner readme (so they also work on npmjs)
- Aligned to always have a "writing foo" page e.g.  `Plugins -> Write Plugins`, `Reporters -> Write Reporters`, `Browser -> Write Browser Launchers` ("Write Browsers" sounded a little too big for a single page 😅)