### PR TITLE
fix: output TypeScript definitions into src for js packages

### DIFF
--- a/.changeset/wet-geckos-fry.md
+++ b/.changeset/wet-geckos-fry.md
@@ -1,0 +1,6 @@
+---
+'@web/config-loader': patch
+'@web/rollup-plugin-copy': patch
+---
+
+TypeScript definition files should reside next to the source files

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -32,15 +32,15 @@ jobs:
       - name: Install dependencies
         run: yarn --frozen-lockfile
 
+      - name: Lint
+        run: yarn lint
+
       - name: Build packages
         run: yarn build
 
       # build for production in CI to make sure tests can run with production build
       - name: Build for production
         run: yarn build:production
-
-      - name: Lint
-        run: yarn lint
 
       - name: Test
         run: yarn test

--- a/packages/config-loader/index.d.ts
+++ b/packages/config-loader/index.d.ts
@@ -1,1 +1,1 @@
-export * from './dist/index';
+export * from './src/index';

--- a/packages/config-loader/tsconfig.json
+++ b/packages/config-loader/tsconfig.json
@@ -4,7 +4,7 @@
   "extends": "../../tsconfig.node-base.json",
   "compilerOptions": {
     "module": "commonjs",
-    "outDir": "./dist",
+    "outDir": "./src",
     "rootDir": "./src",
     "composite": true,
     "allowJs": true,

--- a/packages/rollup-plugin-copy/package.json
+++ b/packages/rollup-plugin-copy/package.json
@@ -16,7 +16,7 @@
   "bugs": {
     "url": "https://github.com/modernweb-dev/web/issues"
   },
-  "main": "index.js",
+  "main": "src/copy.js",
   "module": "index.mjs",
   "engines": {
     "node": ">=10.0.0"

--- a/packages/rollup-plugin-copy/tsconfig.json
+++ b/packages/rollup-plugin-copy/tsconfig.json
@@ -4,7 +4,7 @@
   "extends": "../../tsconfig.node-base.json",
   "compilerOptions": {
     "module": "commonjs",
-    "outDir": "./dist",
+    "outDir": "./src",
     "rootDir": "./src",
     "composite": true,
     "allowJs": true,

--- a/scripts/update-package-configs.mjs
+++ b/scripts/update-package-configs.mjs
@@ -76,7 +76,7 @@ packageDirnameMap.forEach((packageDirname, packageName) => {
       extends: `../../tsconfig.${pkg.environment === 'browser' ? 'browser' : 'node'}-base.json`,
       compilerOptions: {
         module: pkg.environment === 'browser' ? 'ESNext' : 'commonjs',
-        outDir: './dist',
+        outDir: pkg.type === 'ts' ? './dist' : './src',
         rootDir: './src',
         composite: true,
         allowJs: true,


### PR DESCRIPTION
What I did:
- output TypeScript definitions into src for js packages
- main entry for commonjs pointed to non-existing file in plugin-rollup-copy
- type exports should be from src in config-loader
- execute linting step before build (so that it won't fail on generated definition files)