### PR TITLE
feat(dev-server): clear terminal on file changes

### DIFF
--- a/.changeset/stupid-balloons-notice.md
+++ b/.changeset/stupid-balloons-notice.md
@@ -1,0 +1,6 @@
+---
+'@web/dev-server': patch
+'@web/dev-server-cli': patch
+---
+
+clear terminal on file changes

--- a/packages/dev-server-cli/src/logger/logStartMessage.ts
+++ b/packages/dev-server-cli/src/logger/logStartMessage.ts
@@ -1,12 +1,12 @@
-import { DevServerCliConfig } from './config/DevServerCliConfig';
-import { DevServerLogger } from './logger/DevServerLogger';
+import { DevServerCliConfig } from '../config/DevServerCliConfig';
+import { Logger } from '@web/dev-server-core';
 import ip from 'ip';
 import chalk from 'chalk';
 
 const createAddress = (config: DevServerCliConfig, host: string, path: string) =>
   `http${config.http2 ? 's' : ''}://${host}:${config.port}${path}`;
 
-function logNetworkAddress(config: DevServerCliConfig, logger: DevServerLogger, openPath: string) {
+function logNetworkAddress(config: DevServerCliConfig, logger: Logger, openPath: string) {
   try {
     const address = ip.address();
     if (typeof address === 'string') {
@@ -19,7 +19,7 @@ function logNetworkAddress(config: DevServerCliConfig, logger: DevServerLogger, 
   }
 }
 
-export function logStartMessage(config: DevServerCliConfig, logger: DevServerLogger) {
+export function logStartMessage(config: DevServerCliConfig, logger: Logger) {
   const prettyHost = config.hostname ?? 'localhost';
   let openPath = typeof config.open === 'string' ? config.open : '/';
   if (!openPath.startsWith('/')) {

--- a/packages/dev-server-cli/src/logger/loggerPlugin.ts
+++ b/packages/dev-server-cli/src/logger/loggerPlugin.ts
@@ -1,0 +1,32 @@
+import { Plugin } from '@web/dev-server-core';
+import { logStartMessage } from './logStartMessage';
+
+const CLEAR_COMMAND = process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H';
+
+export interface LoggerPluginArgs {
+  clearTerminalOnChange: boolean;
+  logStartMessage: boolean;
+}
+
+export function loggerPlugin(args: LoggerPluginArgs): Plugin {
+  return {
+    name: 'logger',
+
+    serverStart({ config, logger, fileWatcher }) {
+      if (args.logStartMessage) {
+        process.stdout.write(CLEAR_COMMAND);
+        logStartMessage(config, logger);
+      }
+
+      function onChange() {
+        if (args.clearTerminalOnChange) {
+          process.stdout.write(CLEAR_COMMAND);
+          logStartMessage(config, logger);
+        }
+      }
+
+      fileWatcher.addListener('change', onChange);
+      fileWatcher.addListener('unlink', onChange);
+    },
+  };
+}

--- a/packages/dev-server-cli/src/startDevServer.ts
+++ b/packages/dev-server-cli/src/startDevServer.ts
@@ -3,10 +3,11 @@ import { DevServer } from '@web/dev-server-core';
 import { DevServerLogger } from './logger/DevServerLogger';
 import { DevServerCliConfig } from './config/DevServerCliConfig';
 import { openBrowser } from './openBrowser';
-import { logStartMessage as logStartMessageFunction } from './logStartMessage';
+import { loggerPlugin } from './logger/loggerPlugin';
 
 export interface StartDevServerOptions {
   autoExitProcess?: boolean;
+  clearTerminalOnChange?: boolean;
   logStartMessage?: boolean;
 }
 
@@ -14,7 +15,15 @@ export async function startDevServer(
   config: DevServerCliConfig,
   options: StartDevServerOptions = {},
 ) {
-  const { autoExitProcess = true, logStartMessage = true } = options;
+  const { autoExitProcess = true, clearTerminalOnChange = false, logStartMessage = true } = options;
+  config.plugins = config.plugins ?? [];
+  config.plugins.push(
+    loggerPlugin({
+      clearTerminalOnChange,
+      logStartMessage,
+    }),
+  );
+
   const logger = new DevServerLogger();
   const server = new DevServer(config, logger);
 
@@ -34,10 +43,6 @@ export async function startDevServer(
       console.error(error);
       stop();
     });
-  }
-
-  if (logStartMessage) {
-    logStartMessageFunction(config, logger);
   }
 
   await server.start();

--- a/packages/dev-server/src/startDevServer.ts
+++ b/packages/dev-server/src/startDevServer.ts
@@ -87,7 +87,11 @@ export async function startDevServer(options: StartDevServerOptions = {}) {
     }
 
     const validatedConfig = validateCoreConfig<DevServerConfig>(config);
-    return originalStartDevServer(validatedConfig, { autoExitProcess, logStartMessage });
+    return originalStartDevServer(validatedConfig, {
+      autoExitProcess,
+      logStartMessage,
+      clearTerminalOnChange: config.watch,
+    });
   } catch (error) {
     console.error(chalk.red(`\nFailed to start dev server: ${error.message}\n`));
     process.exit(1);


### PR DESCRIPTION
When running in watch mode, we clear the terminal when you change files so that errors are not repeated.