### PR TITLE
docs(test-runner): cover ignoring uncovered lines

### DIFF
--- a/docs/docs/test-runner/writing-tests/code-coverage.md
+++ b/docs/docs/test-runner/writing-tests/code-coverage.md
@@ -33,6 +33,40 @@ module.exports = {
 };
 ```
 
+## Ignoring uncovered lines
+
+Web Test Runner uses [`v8-to-istanbul`](https://github.com/istanbuljs/v8-to-istanbul) to covert V8 based code coverage to a form that can be reported by Istanbul. `v8-to-istanbul` allows for ignoring uncovered lines when calculating code coverage through the use of the following custom comment:
+
+```js
+/* c8 ignore next [line count] */
+```
+
+This is somewhat different than other tools where you might have specifically targetted `if` / `else` branches of logic with an ignore statement. Particularly, V8 does not create phantom `else` statements when calculating coverage, so it is likely that you will be able to use less of these statements than in the past.
+
+In this way, you can skip the rest of a line:
+
+```js
+const text = (falsyOrStringVariableWithTrimmableWhiteSpace || /* c8 ignore next */ '').trim();
+```
+
+You can skip the entire next line:
+
+```js
+/* c8 ignore next */
+if (!requiredVariable) return;
+```
+
+Or, you could skip multiple ensuing lines:
+
+```js
+if (normalCase) {
+  // do normal things
+  /* c8 ignore next 3 */
+} else if (specialCase) {
+  // do special things
+}
+```
+
 ## Coverage browser support
 
 The default coverage of the test runner uses the ability of Chromium to do native code coverage instrumentation. This gives us the best speed. When testing multiple browsers this should still be fine, you don't need to get code coverage from all browsers. One browser is usually enough.

--- a/docs/guides/test-runner/code-coverage/index.md
+++ b/docs/guides/test-runner/code-coverage/index.md
@@ -212,6 +212,10 @@ We now have a failing test but still 100% code coverage.
 
 You should, therefore, see code coverage as a tool that only gives you guidance and help on spotting missing tests, rather than a hard guarantee of code quality.
 
+## Ignoring uncovered lines
+
+In more complex applications, it is likely that you will find yourself creating difficult, if not impossible, to test branches of functionality. While this can absolutely be a pointer to logic that is worth breaking down into more approachable parts, there will be cases where this is not feasible. If so, you may chose to ignore a line of code by using the `/* c8 ignore next */` custom comment. Using this, or more advanced forms of [ignoring uncovered lines](../../../docs/test-runner/writing-tests/code-coverage.md#ignoring-uncovered-lines) while computing code coverage can go a long way in preparing your project for long term maintanence.
+
 ## Coverage browser support
 
 The default coverage of the test runner uses the ability of Chromium to do native code coverage instrumentation. This gives us the best speed. When testing multiple browsers this should still be fine, you don't need to get code coverage from all browsers. One browser is usually enough.

--- a/package.json
+++ b/package.json
@@ -107,6 +107,10 @@
       "eslint --fix",
       "prettier --write --ignore-path .eslintignore",
       "git add"
+    ],
+    "*.md": [
+      "prettier --write --ignore-path .eslintignore",
+      "git add"
     ]
   },
   "prettier": {


### PR DESCRIPTION
Add documentation of `/* c8 ignore next */` to "Guides" and "Docs".