### PR TITLE
feat(test-runner): track and log page reloads

### DIFF
--- a/.changeset/happy-hats-cry.md
+++ b/.changeset/happy-hats-cry.md
@@ -1,0 +1,9 @@
+---
+'@web/test-runner': patch
+'@web/test-runner-chrome': patch
+'@web/test-runner-core': patch
+'@web/test-runner-playwright': patch
+'@web/test-runner-selenium': patch
+---
+
+track and log page reloads

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -33,7 +33,9 @@
     "test": "mocha \"test/**/*.test.mjs\" --reporter dot",
     "test:watch": "mocha \"test/**/*.test.mjs\" --watch --watch-files src,test --reporter dot"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "keywords": [
     "web",
     "dev",

--- a/packages/test-runner-core/src/browser-launcher/BrowserLauncher.ts
+++ b/packages/test-runner-core/src/browser-launcher/BrowserLauncher.ts
@@ -1,9 +1,11 @@
 import { CoverageMapData } from 'istanbul-lib-coverage';
 import { TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig';
+import { TestResultError } from '../test-session/TestSession';
 
 export interface SessionResult {
   testCoverage?: CoverageMapData;
-  browserLogs: any[][];
+  errors?: TestResultError[];
+  browserLogs?: any[][];
 }
 
 export interface BrowserLauncher {

--- a/packages/test-runner-core/src/browser-launcher/getBrowserPageNavigationError.ts
+++ b/packages/test-runner-core/src/browser-launcher/getBrowserPageNavigationError.ts
@@ -1,0 +1,28 @@
+import { TestResultError } from '../test-session/TestSession';
+
+const navigationError = (reason: string) =>
+  `Tests were interrupted because the page was ${reason}. This can happen when clicking a link, submitting a form or interacting with window.location.`;
+
+/**
+ * Returns an error if the browser was navigated by the user
+ * @param testURL
+ * @param navigations
+ */
+export function getBrowserPageNavigationError(
+  testURL: URL,
+  navigations: URL[],
+): TestResultError | undefined {
+  if (testURL && navigations.length > 1) {
+    const nav = navigations[navigations.length - 1];
+    if (nav.origin === testURL.origin && nav.pathname === testURL.pathname) {
+      return { message: navigationError('reloaded') };
+    } else {
+      const reportedPath =
+        testURL!.origin === nav.origin ? `${nav.pathname}${nav.search}` : nav.href;
+      return {
+        message: navigationError(`navigated to ${reportedPath}`),
+      };
+    }
+  }
+  return undefined;
+}

--- a/packages/test-runner-core/src/index.ts
+++ b/packages/test-runner-core/src/index.ts
@@ -1,6 +1,7 @@
 import * as constants from './utils/constants';
 export { constants };
 export { BrowserLauncher, SessionResult } from './browser-launcher/BrowserLauncher';
+export { getBrowserPageNavigationError } from './browser-launcher/getBrowserPageNavigationError';
 export {
   Reporter,
   ReportTestResultsArgs,

--- a/packages/test-runner-core/src/runner/TestScheduler.ts
+++ b/packages/test-runner-core/src/runner/TestScheduler.ts
@@ -125,13 +125,14 @@ export class TestScheduler {
 
     try {
       if (session.browser.isActive(session.id)) {
-        const { testCoverage, browserLogs } = await withTimeout(
+        const { testCoverage, browserLogs, errors } = await withTimeout(
           session.browser.stopSession(session.id),
           'Timed out stopping the browser page',
           this.config.testsFinishTimeout!,
         );
+        updatedSession.errors = [...(updatedSession.errors ?? []), ...(errors ?? [])];
         updatedSession.testCoverage = testCoverage;
-        updatedSession.logs = browserLogs;
+        updatedSession.logs = browserLogs ?? [];
       }
     } catch (error) {
       sessionErrors.push(error);

--- a/packages/test-runner/demo/selenium.config.js
+++ b/packages/test-runner/demo/selenium.config.js
@@ -1,0 +1,60 @@
+const selenium = require('selenium-standalone');
+const { Builder } = require('selenium-webdriver');
+const { Options: ChromeOptions } = require('selenium-webdriver/chrome');
+const { Options: FirefoxOptions } = require('selenium-webdriver/firefox');
+const { seleniumLauncher } = require('@web/test-runner-selenium');
+
+const installPromise = new Promise((resolve, reject) => {
+  selenium.install(err => {
+    if (err) {
+      reject(err);
+    } else {
+      resolve();
+    }
+  });
+});
+
+let seleniumServer;
+
+module.exports = {
+  rootDir: '../../../',
+  preserveSymlinks: true,
+  nodeResolve: true,
+
+  browsers: [
+    seleniumLauncher({
+      driverBuilder: new Builder()
+        .forBrowser('chrome')
+        .setChromeOptions(new ChromeOptions().headless())
+        .usingServer('http://localhost:4444/wd/hub'),
+    }),
+
+    seleniumLauncher({
+      driverBuilder: new Builder()
+        .forBrowser('firefox')
+        .setFirefoxOptions(new FirefoxOptions().headless())
+        .usingServer('http://localhost:4444/wd/hub'),
+    }),
+  ],
+
+  plugins: [
+    {
+      async serverStart() {
+        await installPromise;
+        seleniumServer = await new Promise((resolve, reject) => {
+          selenium.start((err, server) => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve(server);
+            }
+          });
+        });
+      },
+
+      serverStop() {
+        seleniumServer.kill();
+      },
+    },
+  ],
+};

--- a/packages/test-runner/demo/test/fail-location-href.test.js
+++ b/packages/test-runner/demo/test/fail-location-href.test.js
@@ -1,0 +1,6 @@
+// window.location.href = '/foo/';
+window.location.href = 'https://www.example.org/';
+
+it('x', async () => {
+  await new Promise(r => setTimeout(r, 1000));
+});

--- a/packages/test-runner/demo/test/fail-location-reload.test.js
+++ b/packages/test-runner/demo/test/fail-location-reload.test.js
@@ -1,0 +1,5 @@
+window.location.reload();
+
+it('x', async () => {
+  await new Promise(r => setTimeout(r, 1000));
+});

--- a/packages/test-runner/demo/test/fail-location-replace.test.js
+++ b/packages/test-runner/demo/test/fail-location-replace.test.js
@@ -1,0 +1,5 @@
+window.location.replace('/new-page/');
+
+it('x', async () => {
+  await new Promise(r => setTimeout(r, 1000));
+});

--- a/packages/test-runner/package.json
+++ b/packages/test-runner/package.json
@@ -31,7 +31,7 @@
     "test:legacy": "node dist/bin.js \"demo/test/pass-*.test.{js,html}\" --config legacy.config.js",
     "test:logging": "node dist/bin.js \"demo/test/logging.test.js\"",
     "test:many": "node dist/bin.js \"demo/test/many/**/*.test.js\"",
-    "test:mixed": "node dist/bin.js \"demo/**/*.test.js\"",
+    "test:mixed": "node dist/bin.js \"demo/test/*.test.js\"",
     "test:mocha-options": "node dist/bin.js --config \"demo/test/mocha-options/config.js\"",
     "test:playwright": "node dist/bin.js \"demo/test/pass-*.test.{js,html}\" --playwright --browsers chromium firefox webkit",
     "test:puppeteer-firefox": "node dist/bin.js \"demo/test/pass-*.test.{js,html}\" --puppeteer --browsers firefox",


### PR DESCRIPTION
Fixes https://github.com/modernweb-dev/web/issues/29

This adds tracking for page reloads,  reporting it in the terminal with a helpful message:

<img width="903" alt="Screenshot 2020-09-07 at 22 49 17" src="https://user-images.githubusercontent.com/11994993/92416167-762a7280-f15c-11ea-86fd-87192e8869e7.png">
