### PR TITLE
fix(dev-server-core): properly close server on exit

### DIFF
--- a/.changeset/tough-spies-flash.md
+++ b/.changeset/tough-spies-flash.md
@@ -1,0 +1,8 @@
+---
+'@web/dev-server-core': patch
+'@web/dev-server': patch
+'@web/test-runner': patch
+'@web/test-runner-core': patch
+---
+
+properly close server on exit

--- a/packages/dev-server/src/startDevServer.ts
+++ b/packages/dev-server/src/startDevServer.ts
@@ -76,7 +76,6 @@ export async function startDevServer(options: StartDevServerParams = {}) {
       process.on('uncaughtException', error => {
         /* eslint-disable-next-line no-console */
         console.error(error);
-        stop();
       });
 
       process.on('SIGINT', async () => {


### PR DESCRIPTION
This fixes an issue where killing the server left some background processes running because connections to the server were being kept open.