### PR TITLE
Docs: Fix invalid SauceLabs configuration

### DIFF
--- a/docs/docs/test-runner/browsers/saucelabs.md
+++ b/docs/docs/test-runner/browsers/saucelabs.md
@@ -51,30 +51,24 @@ export default {
     // create a browser launcher per browser you want to test
     // you can get the browser capabilities from the Sauce Labs website
     saucelabsLauncher({
-      capabilities: {
-        ...sharedCapabilities,
-        browserName: 'chrome',
-        browserVersion: 'latest',
-        platformName: 'Windows 10',
-      },
+      ...sharedCapabilities,
+      browserName: 'chrome',
+      browserVersion: 'latest',
+      platformName: 'Windows 10',
     }),
 
     saucelabsLauncher({
-      capabilities: {
-        ...sharedCapabilities,
-        browserName: 'safari',
-        browserVersion: '11.1',
-        platformName: 'macOS 10.13',
-      },
+      ...sharedCapabilities,
+      browserName: 'safari',
+      browserVersion: '11.1',
+      platformName: 'macOS 10.13',
     }),
 
     saucelabsLauncher({
-      capabilities: {
-        ...sharedCapabilities,
-        browserName: 'internet explorer',
-        browserVersion: '11.0',
-        platformName: 'Windows 7',
-      },
+      ...sharedCapabilities,
+      browserName: 'internet explorer',
+      browserVersion: '11.0',
+      platformName: 'Windows 7',
     }),
   ],
 };
@@ -113,17 +107,15 @@ All the Sauce Labs specific options go into a `sauce:options` property. This mus
 export default {
   browsers: [
     saucelabsLauncher({
-      capabilities: {
-        'sauce:options': {
-          name: 'my test name',
-          build: `my project ${process.env.GITHUB_REF ?? 'local'} build ${
-            process.env.GITHUB_RUN_NUMBER ?? ''
-          }`,
-        },
-        browserName: 'chrome',
-        browserVersion: 'latest',
-        platformName: 'Windows 10',
+      'sauce:options': {
+        name: 'my test name',
+        build: `my project ${process.env.GITHUB_REF ?? 'local'} build ${
+          process.env.GITHUB_RUN_NUMBER ?? ''
+        }`,
       },
+      browserName: 'chrome',
+      browserVersion: 'latest',
+      platformName: 'Windows 10',
     }),
   ],
 };


### PR DESCRIPTION
According to the source code we don't need a wrapping `capabilities` object:

https://github.com/modernweb-dev/web/blob/c4b00bba39a35e0e1776c541f6ebea30f065c6e4/packages/test-runner-saucelabs/test-remote/saucelabsLauncher.test.js#L53-L58