### PR TITLE
fix(dev-server-rollup): moved test runner dependencies to dev dependencies

### DIFF
--- a/.changeset/selfish-badgers-sip.md
+++ b/.changeset/selfish-badgers-sip.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server-rollup': patch
+---
+
+moved test runner dependencies to dev dependencies

--- a/packages/dev-server-rollup/package.json
+++ b/packages/dev-server-rollup/package.json
@@ -42,8 +42,6 @@
   ],
   "dependencies": {
     "@web/dev-server-core": "^0.2.6",
-    "@web/test-runner-chrome": "^0.6.4",
-    "@web/test-runner-core": "^0.7.6",
     "chalk": "^4.1.0",
     "parse5": "^6.0.1",
     "rollup": "^2.20.0",
@@ -61,6 +59,8 @@
     "@rollup/plugin-replace": "^2.3.3",
     "@rollup/plugin-url": "^5.0.1",
     "@types/parse5": "^5.0.3",
+    "@web/test-runner-chrome": "^0.6.4",
+    "@web/test-runner-core": "^0.7.6",
     "chai": "^4.2.0",
     "node-fetch": "v3.0.0-beta.9",
     "rollup-plugin-postcss": "^3.1.2",


### PR DESCRIPTION
Moved test runner dependencies to dev dependencies