### PR TITLE
fix(test-runner-saucelabs): improve handling of closing proxy

### DIFF
--- a/.changeset/tricky-drinks-juggle.md
+++ b/.changeset/tricky-drinks-juggle.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-saucelabs': patch
+---
+
+improved closing of saucelabs tunnel connection

--- a/packages/test-runner-saucelabs/src/SauceLabsLauncher.ts
+++ b/packages/test-runner-saucelabs/src/SauceLabsLauncher.ts
@@ -30,6 +30,7 @@ export class SauceLabsLauncher extends SeleniumLauncher {
   }
 
   async stop() {
+    console.log('browser launcher stop()');
     await this.manager.deregisterLauncher(this);
     return super.stop();
   }

--- a/packages/test-runner-saucelabs/src/SauceLabsLauncherManager.ts
+++ b/packages/test-runner-saucelabs/src/SauceLabsLauncherManager.ts
@@ -7,26 +7,56 @@ import SaucelabsAPI, {
 
 export class SauceLabsLauncherManager {
   private launchers = new Set<BrowserLauncher>();
-  private connectionPromise: Promise<SauceConnectInstance> | undefined = undefined;
+  private connectionPromise?: Promise<SauceConnectInstance>;
+  private connection?: SauceConnectInstance;
+  private options: SauceLabsOptions;
+  private connectOptions?: SauceConnectOptions;
 
-  constructor(private options: SauceLabsOptions, private connectOptions?: SauceConnectOptions) {}
+  constructor(options: SauceLabsOptions, connectOptions?: SauceConnectOptions) {
+    this.options = options;
+    this.connectOptions = connectOptions;
+
+    process.on('SIGINT', this.closeConnection);
+    process.on('SIGTERM', this.closeConnection);
+    process.on('beforeExit', this.closeConnection);
+  }
 
   async registerLauncher(launcher: BrowserLauncher) {
     this.launchers.add(launcher);
 
-    if (this.connectionPromise == null) {
-      const api = new SaucelabsAPI(this.options);
-      this.connectionPromise = api.startSauceConnect(this.connectOptions ?? {});
+    if (this.connectionPromise != null) {
       await this.connectionPromise;
+      return;
     }
+
+    const api = new SaucelabsAPI(this.options);
+    this.connectionPromise = api.startSauceConnect(this.connectOptions ?? {});
+    this.connection = await this.connectionPromise;
   }
 
   async deregisterLauncher(launcher: BrowserLauncher) {
     this.launchers.delete(launcher);
 
-    if (this.connectionPromise != null && this.launchers.size === 0) {
-      const connection = await this.connectionPromise;
-      await connection.close();
+    if (this.launchers.size === 0) {
+      this.closeConnection();
     }
   }
+
+  private closeConnection = async () => {
+    if (this.connection == null && this.connectionPromise == null) {
+      // already closed
+      return;
+    }
+
+    if (this.connection == null) {
+      // wait for connection to finish opening
+      await this.connectionPromise;
+    }
+
+    if (this.connection != null) {
+      this.connection.close();
+    }
+    this.connection = undefined;
+    this.connectionPromise = undefined;
+  };
 }


### PR DESCRIPTION
This improves the logic which closes the saucelabs proxy. The connection is now available synchronously so that we can close the proxy ASAP. Also added listeners to for SIGINT and SIGTERM to ensure the proxy is always closed.