### PR TITLE
fix(test-runner-saucelabs): close webdriver before proxy

### DIFF
--- a/.changeset/thirty-guests-invent.md
+++ b/.changeset/thirty-guests-invent.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-saucelabs': patch
+---
+
+close webdriver before proxy

--- a/packages/test-runner-saucelabs/src/SauceLabsLauncher.ts
+++ b/packages/test-runner-saucelabs/src/SauceLabsLauncher.ts
@@ -30,7 +30,7 @@ export class SauceLabsLauncher extends SeleniumLauncher {
   }
 
   async stop() {
+    await super.stop();
     await this.manager.deregisterLauncher(this);
-    return super.stop();
   }
 }


### PR DESCRIPTION
This closes the webdriver instance before closing the saucelabs proxy, improving stability.