### PR TITLE
fix(rollup-plugin-import-meta-assets): add ESM entrypoint with .mjs file

### DIFF
--- a/packages/rollup-plugin-import-meta-assets/package.json
+++ b/packages/rollup-plugin-import-meta-assets/package.json
@@ -14,6 +14,7 @@
   "author": "modern-web",
   "homepage": "https://github.com/modernweb-dev/web/tree/master/packages/rollup-plugin-import-meta-assets",
   "main": "src/index.js",
+  "module": "index.mjs",
   "engines": {
     "node": ">=10.0.0"
   },


### PR DESCRIPTION
I was having this error:

```
[!] Error: Cannot find module '/home/hsablonniere/dev/clever-components/node_modules/@web/rollup-plugin-import-meta-assets/dist/index.js'. Please verify that the package.json has a valid "main" entry
```