### PR TITLE
chore: replace most frontmatter with a markdown headline

### DIFF
--- a/docs/discover/slack.md
+++ b/docs/discover/slack.md
@@ -1,8 +1,4 @@
----
-title: Slack
-eleventyNavigation:
-  key: Slack
----
+# Slack
 
 You can also find us on the Polymer slack in the [#open-wc](https://slack.com/share/IUQNUPWUF/awabyN8iYH4dXX6aGpu16ES9/enQtOTc2Nzc2ODEyOTY3LWM5ZGExNGFiMmM4NDY2YWI2MzYwOGY5ZTNlZjk4OGU4NTFhMGJjNmVhNGI4MzVlNTMwNGRiNGIxNjc4MGJhNDg) channel.
 

--- a/docs/docs/building/index.md
+++ b/docs/docs/building/index.md
@@ -1,7 +1,5 @@
 ---
-title: Building
 layout: with-index.njk
-eleventyNavigation:
-  key: Building
-  order: 3
 ---
+
+# Building ||3

--- a/docs/docs/building/overview.md
+++ b/docs/docs/building/overview.md
@@ -1,10 +1,3 @@
----
-title: Building for Production
-eleventyNavigation:
-  key: Building > Overview
-  title: Overview
-  parent: Building
-  order: 1
----
+# Building >> Overview ||10
 
-Building for production is important to ensure that the smallest possible payload gets shipt to your users.
+Building for production is important to ensure that the smallest possible payload gets shiped to your users.

--- a/docs/docs/building/rollup-plugin-copy.md
+++ b/docs/docs/building/rollup-plugin-copy.md
@@ -1,10 +1,4 @@
----
-title: Rollup Plugin Copy
-eleventyNavigation:
-  key: Rollup Plugin Copy
-  parent: Building
-  order: 1
----
+# Building >> Rollup Plugin Copy ||20
 
 A Rollup plugin which copies asset files while retaining the relative folder structure.
 

--- a/docs/docs/building/rollup-plugin-import-meta-assets.md
+++ b/docs/docs/building/rollup-plugin-import-meta-assets.md
@@ -1,10 +1,4 @@
----
-title: Rollup Plugin import-meta-assets
-eleventyNavigation:
-  key: Rollup Plugin import-meta-assets
-  parent: Building
-  order: 2
----
+# Building >> Rollup Plugin Import Meta Assets ||30
 
 Rollup plugin that detects assets references relative to modules using patterns such as `new URL('./assets/my-img.png', import.meta.url)`.
 
@@ -92,7 +86,9 @@ In this example, we use it to optimize SVG images with [svgo](https://github.com
 import { importMetaAssets } from '@web/rollup-plugin-import-meta-assets';
 const svgo = new SVGO({
   // See https://github.com/svg/svgo#what-it-can-do
-  plugins: [ /* plugins here */],
+  plugins: [
+    /* plugins here */
+  ],
 });
 
 export default {

--- a/docs/docs/dev-server/cli-and-configuration.md
+++ b/docs/docs/dev-server/cli-and-configuration.md
@@ -1,11 +1,4 @@
----
-title: CLI and Configuration
-eleventyNavigation:
-  key: Dev Server > CLI and Configuration
-  title: CLI and Configuration
-  parent: Dev Server
-  order: 2
----
+# Dev Server >> CLI and Configuration ||2
 
 The dev server can be configured using CLI flags, or with a configuration file.
 

--- a/docs/docs/dev-server/index.md
+++ b/docs/docs/dev-server/index.md
@@ -1,7 +1,5 @@
 ---
-title: Development Web Server
 layout: with-index.njk
-eleventyNavigation:
-  key: Dev Server
-  order: 2
 ---
+
+# Dev Server ||2

--- a/docs/docs/dev-server/middleware.md
+++ b/docs/docs/dev-server/middleware.md
@@ -1,10 +1,4 @@
----
-title: Dev Server Middleware
-eleventyNavigation:
-  key: Middleware
-  parent: Dev Server
-  order: 5
----
+# Dev Server >> Middleware ||5
 
 You can add your own middleware to the dev server using the `middleware` property. The middleware should be a standard koa middleware. [Read more about koa here.](https://koajs.com/)
 

--- a/docs/docs/dev-server/node-api.md
+++ b/docs/docs/dev-server/node-api.md
@@ -1,10 +1,4 @@
----
-title: Node API
-eleventyNavigation:
-  key: Node API
-  parent: Dev Server
-  order: 6
----
+# Dev Server >> Node API ||6
 
 The Dev Server has a node API to start the server programmatically.
 

--- a/docs/docs/dev-server/overview.md
+++ b/docs/docs/dev-server/overview.md
@@ -1,7 +1,7 @@
 ---
 title: Web Dev Server
 eleventyNavigation:
-  key: Dev Server > Overview
+  key: Dev Server >> Overview
   title: Overview
   parent: Dev Server
   order: 1

--- a/docs/docs/dev-server/plugins/esbuild.md
+++ b/docs/docs/dev-server/plugins/esbuild.md
@@ -1,10 +1,4 @@
----
-title: Esbuild
-eleventyNavigation:
-  key: Esbuild
-  parent: Plugins
-  order: 2
----
+# Dev Server >> Plugins >> Esbuild ||3
 
 Plugin for using [esbuild](https://github.com/evanw/esbuild) in web dev server and web test runner. [esbuild](https://github.com/evanw/esbuild) is a blazing fast build tool.
 

--- a/docs/docs/dev-server/plugins/import-maps.md
+++ b/docs/docs/dev-server/plugins/import-maps.md
@@ -1,10 +1,4 @@
----
-title: Import Maps
-eleventyNavigation:
-  key: Import Maps
-  parent: Plugins
-  order: 4
----
+# Dev Server >> Plugins >> Import Maps ||5
 
 Plugin for resolving imports using [Import maps](https://github.com/WICG/import-maps).
 

--- a/docs/docs/dev-server/plugins/index.md
+++ b/docs/docs/dev-server/plugins/index.md
@@ -1,36 +1,5 @@
 ---
-title: Dev Server Plugins
 layout: with-index.njk
-eleventyNavigation:
-  key: Plugins
-  parent: Dev Server
-  order: 3
 ---
 
-Plugins are objects with lifecycle hooks called by the dev server or test runner as it serves files to the browser. They can be used to serve virtual files, transform files, or resolve module imports.
-
-Plugins share a similar API to [rollup](https://github.com/rollup/rollup) plugins. In fact, you can reuse rollup plugins in the dev server. See the [Rollup section](./rollup.md) for that, and the [examples section](./examples.md) for practical use cases.
-
-A plugin is an object that you add to the `plugins` array in your configuration file. You can add an object directly, or create one from a function somewhere:
-
-In your `web-dev-server.config.js` or `web-test-runner.config.js`:
-
-```js
-import awesomePlugin from 'awesome-plugin';
-
-export default {
-  plugins: [
-    // use a plugin
-    awesomePlugin({ someOption: 'someProperty' }),
-    // create an inline plugin
-    {
-      name: 'my-plugin',
-      transform(context) {
-        if (context.response.is('html')) {
-          return { body: context.body.replace(/<base href=".*">/, '<base href="/foo/">') };
-        }
-      },
-    },
-  ],
-};
-```
+# Dev Server >> Plugins ||3

--- a/docs/docs/dev-server/plugins/legacy.md
+++ b/docs/docs/dev-server/plugins/legacy.md
@@ -1,10 +1,4 @@
----
-title: Legacy
-eleventyNavigation:
-  key: Legacy
-  parent: Plugins
-  order: 5
----
+# Dev Server >> Plugins >> Legacy ||6
 
 Plugin for using the dev server or test runner on legacy browsers, for example on Internet Explorer 11 which does not support modules.
 

--- a/docs/docs/dev-server/plugins/overview.md
+++ b/docs/docs/dev-server/plugins/overview.md
@@ -1,35 +1,12 @@
----
-title: Dev Server Plugins
-eleventyNavigation:
-  key: Overview
-  parent: Plugins
-  order: 1
----
+# Dev Server >> Plugins >> Overview ||1
 
-Plugins are objects with lifecycle hooks called by the dev server or test runner as it serves files to the browser. They can be used to serve virtual files, transform files, or resolve module imports.
+The Web Dev Server comes with a few plugins out of the box.
 
-Plugins share a similar API to [rollup](https://github.com/rollup/rollup) plugins. In fact, you can reuse rollup plugins in the dev server. See the [Rollup section](./rollup.md) for that, and the [examples section](./examples.md) for practical use cases.
+See
 
-A plugin is an object that you add to the `plugins` array in your configuration file. You can add an object directly, or create one from a function somewhere:
+- [esbuild](./esbuild.md)
+- [rollup](./rollup.md)
+- [import-maps](./import-maps.md)
+- [legacy](./legacy.md)
 
-In your `web-dev-server.config.mjs` or `web-test-runner.config.mjs`:
-
-```js
-import awesomePlugin from 'awesome-plugin';
-
-export default {
-  plugins: [
-    // use a plugin
-    awesomePlugin({ someOption: 'someProperty' }),
-    // create an inline plugin
-    {
-      name: 'my-plugin',
-      transform(context) {
-        if (context.response.is('html')) {
-          return { body: context.body.replace(/<base href=".*">/, '<base href="/foo/">') };
-        }
-      },
-    },
-  ],
-};
-```
+If you have more specific needs it's best to [write your own plugin](../writing-plugins/overview.md).

--- a/docs/docs/dev-server/plugins/rollup.md
+++ b/docs/docs/dev-server/plugins/rollup.md
@@ -1,10 +1,4 @@
----
-title: Rollup
-eleventyNavigation:
-  key: Rollup
-  parent: Plugins
-  order: 3
----
+# Dev Server >> Plugins >> Rollup ||4
 
 Adapter for using rollup plugins in web dev server and web test runner.
 

--- a/docs/docs/dev-server/writing-plugins/examples.md
+++ b/docs/docs/dev-server/writing-plugins/examples.md
@@ -1,16 +1,10 @@
----
-title: Examples
-eleventyNavigation:
-  key: Examples
-  parent: Plugins
-  order: 2
----
+# Dev Server >> Writing Plugins >> Examples ||2
 
 Common examples using plugins.
 
 Generally speaking, the two most important plugins are [esbuild](./esbuild.md) and [rollup](./rollup.md). Esbuild can be used for fast transformations, while rollup has a rich plugin ecosystem we can use.
 
-Some of the examples require you to write your own plugin. The examples are straight forward, but you can check the [writing plugins section](./writing-plugins.md) for a more detailed explanation.
+Some of the examples require you to Write Your Own plugin. The examples are straight forward, but you can check the [writing plugins section](./writing-plugins.md) for a more detailed explanation.
 
 ## Typescript
 

--- a/docs/docs/dev-server/writing-plugins/hooks.md
+++ b/docs/docs/dev-server/writing-plugins/hooks.md
@@ -1,10 +1,4 @@
----
-title: Hooks
-eleventyNavigation:
-  key: Hooks
-  parent: Writing Plugins
-  order: 2
----
+# Dev Server >> Writing Plugins >> Hooks ||3
 
 ## Hook: serve
 

--- a/docs/docs/dev-server/writing-plugins/index.md
+++ b/docs/docs/dev-server/writing-plugins/index.md
@@ -1,8 +1,5 @@
 ---
-title: Development Web Server
 layout: with-index.njk
-eleventyNavigation:
-  key: Writing Plugins
-  parent: Dev Server
-  order: 4
 ---
+
+# Dev Server >> Writing Plugins ||4

--- a/docs/docs/dev-server/writing-plugins/overview.md
+++ b/docs/docs/dev-server/writing-plugins/overview.md
@@ -1,15 +1,12 @@
----
-title: Overview
-eleventyNavigation:
-  key: Writing Plugins Overview
-  title: Overview
-  parent: Writing Plugins
-  order: 1
----
+# Dev Server >> Writing Plugins >> Overview ||1
+
+Plugins are objects with lifecycle hooks called by the dev server or test runner as it serves files to the browser. They can be used to serve virtual files, transform files, or resolve module imports.
+
+Plugins share a similar API to [rollup](https://github.com/rollup/rollup) plugins. In fact, you can reuse rollup plugins in the dev server. See the [Rollup section](../plugins/rollup.md) for that, and the [examples section](./examples.md) for practical use cases.
 
 A plugin is an object that you add to the `plugins` array in your configuration file. You can add an object directly, or create one from a function somewhere:
 
-In your `web-dev-server.config.js` or `web-test-runner.config.js`:
+In your `web-dev-server.config.mjs` or `web-test-runner.config.mjs`:
 
 ```js
 import awesomePlugin from 'awesome-plugin';

--- a/docs/docs/dev-server/writing-plugins/web-sockets.md
+++ b/docs/docs/dev-server/writing-plugins/web-sockets.md
@@ -1,10 +1,4 @@
----
-title: Web Sockets
-eleventyNavigation:
-  key: Web Sockets
-  parent: Writing Plugins
-  order: 3
----
+# Dev Server >> Writing Plugins >> Web Sockets ||4
 
 The dev server has a web socket API for communicating with the browser. To use web sockets, your plugin must set the `injectWebSocket` option to `true`. If one plugin has this option set, a web socket script will be injected into the pages server by the dev server.
 

--- a/docs/docs/test-runner/advanced.md
+++ b/docs/docs/test-runner/advanced.md
@@ -1,10 +1,4 @@
----
-title: Advanced
-eleventyNavigation:
-  key: Advanced
-  parent: Test Runner
-  order: 10
----
+# Test Runner >> Advanced ||10
 
 The test runner has a modular architecture, with the `@web/test-runner` package implemented an opinionated set of defaults.
 

--- a/docs/docs/test-runner/browser-launchers/browserstack.md
+++ b/docs/docs/test-runner/browser-launchers/browserstack.md
@@ -1,10 +1,4 @@
----
-title: Browserstack
-eleventyNavigation:
-  key: Browserstack
-  parent: Browsers
-  order: 60
----
+# Test Runner >> Browser Launchers >> Browserstack ||60
 
 Browser launchers for web test runner to run tests remotely on [Browserstack](https://www.browserstack.com/).
 

--- a/docs/docs/test-runner/browser-launchers/chrome.md
+++ b/docs/docs/test-runner/browser-launchers/chrome.md
@@ -1,10 +1,4 @@
----
-title: Chrome
-eleventyNavigation:
-  key: Chrome
-  parent: Browsers
-  order: 20
----
+# Test Runner >> Browser Launchers >> Chrome ||20
 
 Runs tests with a locally installed instance of Chrome and controls it using [puppeteer-core](https://www.npmjs.com/package/puppeteer-core). This avoids the post-install step of `puppeteer` or `playwright`, speeding up the installation of projects.
 

--- a/docs/docs/test-runner/browser-launchers/index.md
+++ b/docs/docs/test-runner/browser-launchers/index.md
@@ -1,10 +1,7 @@
 ---
-title: Browsers
 layout: with-index.njk
-eleventyNavigation:
-  key: Browsers
-  parent: Test Runner
-  order: 5
 ---
+
+# Test Runner >> Browser Launchers ||5
 
 Browser launchers boot up and control a browser instance to run your tests. By default, tests are run with the locally installed instance of Chrome, controlled via `puppeteer-core`.

--- a/docs/docs/test-runner/browser-launchers/overview.md
+++ b/docs/docs/test-runner/browser-launchers/overview.md
@@ -1,11 +1,4 @@
----
-title: Browser Launchers
-eleventyNavigation:
-  key: Browsers > Overview
-  title: Overview
-  parent: Browsers
-  order: 10
----
+# Test Runner >> Browser Launchers >> Overview ||10
 
 For convenience you can configure a few other browser launchers using CLI flags
 

--- a/docs/docs/test-runner/browser-launchers/playwright.md
+++ b/docs/docs/test-runner/browser-launchers/playwright.md
@@ -1,10 +1,4 @@
----
-title: Playwright
-eleventyNavigation:
-  key: Playwright
-  parent: Browsers
-  order: 40
----
+# Test Runner >> Browser Launchers >> Playwright ||40
 
 Run tests using [Playwright](https://www.npmjs.com/package/playwright), using a bundled versions of Chromium, Firefox, and/or Webkit.
 

--- a/docs/docs/test-runner/browser-launchers/puppeteer.md
+++ b/docs/docs/test-runner/browser-launchers/puppeteer.md
@@ -1,10 +1,4 @@
----
-title: Puppeteer
-eleventyNavigation:
-  key: Puppeteer
-  parent: Browsers
-  order: 30
----
+# Test Runner >> Browser Launchers >> Puppeteer ||30
 
 Run tests using [Puppeteer](https://www.npmjs.com/package/puppeteer), using a bundled version of Chromium or Firefox (experimental). Use the [Chrome launcher](./chrome.md) to run tests with a globally installed version of Chrome.
 

--- a/docs/docs/test-runner/browser-launchers/saucelabs.md
+++ b/docs/docs/test-runner/browser-launchers/saucelabs.md
@@ -1,10 +1,4 @@
----
-title: Sauce Labs
-eleventyNavigation:
-  key: Sauce Labs
-  parent: Browsers
-  order: 70
----
+# Test Runner >> Browser Launchers >> Sauce Labs ||70
 
 Browser launchers for web test runner to run tests remotely on [Sauce Labs](https://saucelabs.com/).
 

--- a/docs/docs/test-runner/browser-launchers/selenium.md
+++ b/docs/docs/test-runner/browser-launchers/selenium.md
@@ -1,10 +1,4 @@
----
-title: Selenium
-eleventyNavigation:
-  key: Selenium
-  parent: Browsers
-  order: 50
----
+# Test Runner >> Browser Launchers >> Selenium ||50
 
 Run tests using [selenium-webdriver](https://www.npmjs.com/package/selenium-webdriver).
 

--- a/docs/docs/test-runner/browser-launchers/write-your-own.md
+++ b/docs/docs/test-runner/browser-launchers/write-your-own.md
@@ -1,10 +1,4 @@
----
-title: Writing Browser Launchers
-eleventyNavigation:
-  key: Writing Browser Launchers
-  parent: Browsers
-  order: 90
----
+# Test Runner >> Browser Launchers >> Write Your Own ||90
 
 A browser launcher handles booting up or connecting to a browser, visiting a URL and closing the browser when tests finish.
 

--- a/docs/docs/test-runner/cli-and-configuration.md
+++ b/docs/docs/test-runner/cli-and-configuration.md
@@ -1,10 +1,4 @@
----
-title: CLI and Configuration
-eleventyNavigation:
-  key: CLI and Configuration
-  parent: Test Runner
-  order: 2
----
+# Test Runner >> CLI and Configuration ||2
 
 The test runner can be configured using CLI flags, or with a configuration file.
 

--- a/docs/docs/test-runner/commands.md
+++ b/docs/docs/test-runner/commands.md
@@ -1,10 +1,4 @@
----
-title: Commands
-eleventyNavigation:
-  key: Commands
-  parent: Test Runner
-  order: 6
----
+# Test Runner >> Commands ||6
 
 Commands for executing code server-side during your tests in the browser. To control the browser page, access the file system, or execute NodeJS libraries.
 

--- a/docs/docs/test-runner/index.md
+++ b/docs/docs/test-runner/index.md
@@ -1,7 +1,5 @@
 ---
-title: Web Test Runner
 layout: with-index.njk
-eleventyNavigation:
-  key: Test Runner
-  order: 1
 ---
+
+# Test Runner ||1

--- a/docs/docs/test-runner/overview.md
+++ b/docs/docs/test-runner/overview.md
@@ -1,7 +1,7 @@
 ---
 title: Web Test Runner
 eleventyNavigation:
-  key: Test Runner > Overview
+  key: Test Runner >> Overview
   title: Overview
   parent: Test Runner
   order: 1

--- a/docs/docs/test-runner/plugins.md
+++ b/docs/docs/test-runner/plugins.md
@@ -1,16 +1,10 @@
----
-title: Plugins
-eleventyNavigation:
-  key: Server Plugins
-  parent: Test Runner
-  order: 7
----
+# Test Runner >> Plugins ||7
 
 The test runner uses `@web/dev-server` to your test files to the browser. The dev server has many configuration options, a plugin system to do code transformations, and middleware to change the server's behavior.
 
 We recommend reading these pages:
 
-- [Plugins](../dev-server/plugins/index.md) for a general overview
+- [Plugins](../dev-server/plugins/overview.md) for a general overview
 - [esbuild](../dev-server/plugins/esbuild.md) for TS, JSX and TSX
 - [rollup](../dev-server/plugins/esbuild.md) for using rollup plugins
-- [Writing plugins](../dev-server/plugins/writing-plugins.md)
+- [Writing plugins](../dev-server/writing-plugins/overview.md)

--- a/docs/docs/test-runner/reporters/index.md
+++ b/docs/docs/test-runner/reporters/index.md
@@ -1,8 +1,5 @@
 ---
-title: Reporters
 layout: with-index.njk
-eleventyNavigation:
-  key: Reporters
-  parent: Test Runner
-  order: 8
 ---
+
+# Test Runner >> Reporters ||8

--- a/docs/docs/test-runner/reporters/junit.md
+++ b/docs/docs/test-runner/reporters/junit.md
@@ -1,10 +1,4 @@
----
-title: JUnit
-eleventyNavigation:
-  key: JUnit
-  parent: Reporters
-  order: 20
----
+# Test Runner >> Reporters >> JUnit ||20
 
 JUnit XML reporter for web test runner
 

--- a/docs/docs/test-runner/reporters/overview.md
+++ b/docs/docs/test-runner/reporters/overview.md
@@ -1,11 +1,4 @@
----
-title: Reporters
-eleventyNavigation:
-  key: Reporters > Overview
-  title: Overview
-  parent: Reporters
-  order: 10
----
+# Test Runner >> Reporters >> Overview ||10
 
 You can customize the test reporters using the `reporters` option.
 

--- a/docs/docs/test-runner/reporters/write-your-own.md
+++ b/docs/docs/test-runner/reporters/write-your-own.md
@@ -1,10 +1,4 @@
----
-title: Writing Reporters
-eleventyNavigation:
-  key: Writing Reporters
-  parent: Reporters
-  order: 30
----
+# Test Runner >> Reporters >> Write Your Own ||30
 
 A reporter reports test results and/or test progress. It is an object with several hooks which are called during the lifecycle of of the test runner. The actual logging to the terminal is managed by the test run to ensure interaction with the dynamic progress bar and watch menu are managed properly.
 

--- a/docs/docs/test-runner/test-frameworks/index.md
+++ b/docs/docs/test-runner/test-frameworks/index.md
@@ -1,11 +1,8 @@
 ---
-title: Test frameworks
 layout: with-index.njk
-eleventyNavigation:
-  key: Test Frameworks
-  parent: Test Runner
-  order: 4
 ---
+
+# Test Runner >> Test Frameworks ||4
 
 Test frameworks load and run your tests in the browser, and provide the framework needed to define your tests.
 

--- a/docs/docs/test-runner/test-frameworks/mocha.md
+++ b/docs/docs/test-runner/test-frameworks/mocha.md
@@ -1,9 +1,4 @@
----
-title: Test Runner Mocha
-eleventyNavigation:
-  key: Mocha
-  parent: Test Frameworks
----
+# Test Runner >> Test Frameworks >> Mocha ||10
 
 Test framework implementation of [Mocha](https://mochajs.org/).
 

--- a/docs/docs/test-runner/test-frameworks/write-your-own.md
+++ b/docs/docs/test-runner/test-frameworks/write-your-own.md
@@ -1,11 +1,6 @@
----
-title: Writing Test Frameworks
-eleventyNavigation:
-  key: Writing Test Frameworks
-  parent: Test Frameworks
----
+# Test Runner >> Test Frameworks >> Write Your Own ||20
 
-You can write your own test framework for web test runner by wrap an existing testing framework or create a specific once for your project.
+You can Write Your Own test framework for web test runner by wrap an existing testing framework or create a specific once for your project.
 
 This is a minimal example:
 

--- a/docs/docs/test-runner/testing-in-a-ci.md
+++ b/docs/docs/test-runner/testing-in-a-ci.md
@@ -1,10 +1,4 @@
----
-title: Testing in a CI
-eleventyNavigation:
-  key: Testing in a CI
-  parent: Test Runner
-  order: 9
----
+# Test Runner >> Testing in a CI ||9
 
 It's possible to use the test runner in a CI, but because it runs tests on a real browser you need to ensure the CI environments can support it.
 

--- a/docs/docs/test-runner/writing-tests/code-coverage.md
+++ b/docs/docs/test-runner/writing-tests/code-coverage.md
@@ -1,10 +1,4 @@
----
-title: Code Coverage
-eleventyNavigation:
-  key: Code Coverage
-  parent: Writing tests
-  order: 40
----
+# Test Runner >> Writing Tests >> Code Coverage ||40
 
 You can run tests with code coverage using the `--coverage` flag:
 

--- a/docs/docs/test-runner/writing-tests/helper-libraries.md
+++ b/docs/docs/test-runner/writing-tests/helper-libraries.md
@@ -1,10 +1,4 @@
----
-title: Helper Libraries
-eleventyNavigation:
-  key: Helper Libraries
-  parent: Writing tests
-  order: 30
----
+# Test Runner >> Writing Tests >> Helper Libraries ||30
 
 Not all helper libraries ship es modules which are usable in the browser. On this page we collect libraries which are available as es modules. If need to use a library with another module format, you can follow the instructions at the bottom of the [es modules page](../../../guides/web-development/es-modules.md)
 

--- a/docs/docs/test-runner/writing-tests/html-tests.md
+++ b/docs/docs/test-runner/writing-tests/html-tests.md
@@ -1,11 +1,4 @@
----
-title: HTML Tests
-eleventyNavigation:
-  key: Writing tests > HTML Tests
-  title: HTML Tests
-  parent: Writing tests
-  order: 20
----
+# Test Runner >> Writing Tests >> HTML Tests ||20
 
 HTML files are loaded in the browser as is, and are not processed by a test framework. This way you have full control over the test environment. Depending on which test framework you're using, the way you run your tests can be a little different.
 

--- a/docs/docs/test-runner/writing-tests/index.md
+++ b/docs/docs/test-runner/writing-tests/index.md
@@ -1,10 +1,7 @@
 ---
-title: Writing tests
 layout: with-index.njk
-eleventyNavigation:
-  key: Writing tests
-  parent: Test Runner
-  order: 3
 ---
+
+# Test Runner >> Writing Tests ||3
 
 Web test runners reads the configured test files, and runs them inside each of the configured browsers. Each test file runs in it's own browser environment, there is no shared state between tests. This enables concurrency and keeps tests isolated.

--- a/docs/docs/test-runner/writing-tests/js-tests.md
+++ b/docs/docs/test-runner/writing-tests/js-tests.md
@@ -1,11 +1,4 @@
----
-title: JS Tests
-eleventyNavigation:
-  key: Writing tests > JS Tests
-  title: JS Tests
-  parent: Writing tests
-  order: 10
----
+# Test Runner >> Writing Tests >> JS Tests ||10
 
 Javascript files are loaded by the test framework that is configured. The default test framework is mocha, which loads your test as a standard browser es module. You can use module imports to import your code and any modules you want to use for testing.
 

--- a/docs/docs/test-runner/writing-tests/mocking.md
+++ b/docs/docs/test-runner/writing-tests/mocking.md
@@ -1,11 +1,4 @@
----
-title: Mocking
-eleventyNavigation:
-  key: Writing tests > Mocking
-  title: Mocking
-  parent: Writing tests
-  order: 50
----
+# Test Runner >> Writing Tests >> Mocking ||50
 
 ## Mocking functions
 

--- a/docs/guides/going-buildless/css.md
+++ b/docs/guides/going-buildless/css.md
@@ -1,10 +1,4 @@
----
-title: CSS
-eleventyNavigation:
-  key: CSS
-  parent: Going Buildless
-  order: 30
----
+# Going Buildless >> CSS ||30
 
 ```js script
 // TODO: find out why this is needed?

--- a/docs/guides/going-buildless/es-modules.md
+++ b/docs/guides/going-buildless/es-modules.md
@@ -1,10 +1,4 @@
----
-title: ECMAScript Modules
-eleventyNavigation:
-  key: ES Modules
-  parent: Going Buildless
-  order: 60
----
+# Going Buildless >> ES Modules ||60
 
 All modern browsers support standard es modules. These are javascript files using `import` and `export` statements:
 

--- a/docs/guides/going-buildless/getting-started.md
+++ b/docs/guides/going-buildless/getting-started.md
@@ -1,11 +1,4 @@
----
-title: Getting Started
-eleventyNavigation:
-  key: Going Buildless > Getting Started
-  title: Getting Started
-  parent: Going Buildless
-  order: 5
----
+# Going Buildless >> Getting Started ||5
 
 At Modern Web, it is our goal to help developers discover buildless workflows, by working closely with the browser rather than lots of complex tooling and abstractions. In this section, we've gathered several tips, tricks, and alternatives to help you discover the browsers native capabilities, and to go buildless.
 

--- a/docs/guides/going-buildless/index.md
+++ b/docs/guides/going-buildless/index.md
@@ -1,7 +1,5 @@
 ---
-title: Going Buildless
 layout: with-index.njk
-eleventyNavigation:
-  key: Going Buildless
-  order: 10
 ---
+
+# Going Buildless ||10

--- a/docs/guides/going-buildless/serving.md
+++ b/docs/guides/going-buildless/serving.md
@@ -1,10 +1,4 @@
----
-title: Serving
-eleventyNavigation:
-  key: Serving
-  parent: Going Buildless
-  order: 10
----
+# Going Buildless >> Serving ||10
 
 The fundamental relationship at the heart of the web is the relationship between the server and the client or browser (we'll use "browser" and "client" interchangeably for the rest of this article).
 

--- a/docs/guides/test-runner/browsers.md
+++ b/docs/guides/test-runner/browsers.md
@@ -1,10 +1,4 @@
----
-title: Browsers
-eleventyNavigation:
-  key: Browsers
-  parent: Test Runner
-  order: 30
----
+# Test Runner >> Browsers ||30
 
 Browser launchers are responsible for opening and controlling the actual browser.
 

--- a/docs/guides/test-runner/code-coverage/index.md
+++ b/docs/guides/test-runner/code-coverage/index.md
@@ -1,10 +1,4 @@
----
-title: Taking code coverage into account
-eleventyNavigation:
-  key: Code Coverage
-  parent: Test Runner
-  order: 50
----
+# Test Runner >> Code Coverage ||50
 
 Once you have a decent set of tests you may want to look into what could still be improved.
 Code coverage can help to find which code segments have not yet been tested.

--- a/docs/guides/test-runner/getting-started.md
+++ b/docs/guides/test-runner/getting-started.md
@@ -1,10 +1,4 @@
----
-title: Getting started with the test runner
-eleventyNavigation:
-  key: Getting Started
-  parent: Test Runner
-  order: 10
----
+# Test Runner >> Getting Started ||10
 
 Testing your code is very important to have the confidence to release often.
 Green tests should mean that the change is good to go 👍

--- a/docs/guides/test-runner/index.md
+++ b/docs/guides/test-runner/index.md
@@ -1,7 +1,5 @@
 ---
-title: Web Test Runner
 layout: with-index.njk
-eleventyNavigation:
-  key: Test Runner
-  order: 20
 ---
+
+# Test Runner ||20

--- a/docs/guides/test-runner/responsive.md
+++ b/docs/guides/test-runner/responsive.md
@@ -1,10 +1,4 @@
----
-title: Testing responsive sites
-eleventyNavigation:
-  key: Responsive
-  parent: Test Runner
-  order: 40
----
+# Test Runner >> Responsive Sites ||40
 
 With the world going mobile first, it is more important than ever to test your code against different viewport.
 

--- a/docs/guides/test-runner/using-typescript.md
+++ b/docs/guides/test-runner/using-typescript.md
@@ -1,10 +1,4 @@
----
-title: Using Typescript
-eleventyNavigation:
-  key: Using Typescript
-  parent: Test Runner
-  order: 60
----
+# Test Runner >> Using Typescript ||60
 
 [Typescript](https://www.typescriptlang.org/) is a superset of Javascript, adding type safety to your code.
 

--- a/docs/guides/test-runner/watch-and-debug/index.md
+++ b/docs/guides/test-runner/watch-and-debug/index.md
@@ -1,10 +1,4 @@
----
-title: Using watch mode and debugging
-eleventyNavigation:
-  key: Watch and Debug
-  parent: Test Runner
-  order: 20
----
+# Test Runner >> Watch and Debug ||20
 
 During development, it can be annoying to re-run all your tests manually every time there is a change.
 Watch mode helps by watching the file system, re-running the tests that have changes, and reporting the updated results.

--- a/docs/guides/test-runner/writing-plugins.md
+++ b/docs/guides/test-runner/writing-plugins.md
@@ -1,10 +1,4 @@
----
-title: Enable your needs with custom plugins
-eleventyNavigation:
-  key: Writing Plugins
-  parent: Test Runner
-  order: 70
----
+# Test Runner >> Writing Plugins ||70
 
 Not every use case will be covered by existing plugins 😱 &nbsp;
 Therefore if you encounter a situation that requires some custom adjustments you can create a plugin yourself.

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "update-dependency": "node scripts/update-dependency.js"
   },
   "dependencies": {
-    "@d4kmor/cli": "^0.3.2",
-    "@d4kmor/launch": "^0.3.0",
+    "@d4kmor/cli": "^0.4.3",
+    "@d4kmor/launch": "^0.4.0",
     "patch-package": "^6.2.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1070,14 +1070,15 @@
     human-id "^1.0.2"
     prettier "^1.18.2"
 
-"@d4kmor/cli@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@d4kmor/cli/-/cli-0.3.2.tgz#5736b6824655bad06a0b5eda214af4d12b1cd400"
-  integrity sha512-SQlm9yPW6mV/6jLEyE6dQyd58K2NeBZMa7nAUS9gNC0Ge/6kuAEB2avNj1eBvEP/U3hbm3RUsF35nTsa68W4Hw==
+"@d4kmor/cli@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@d4kmor/cli/-/cli-0.4.3.tgz#cdb161e7ece7c0d724a37184528c058bc244b392"
+  integrity sha512-i1UbrLALQvMlOBMVBwlB8y6rPxwkdYJztXB1fQgAO5e9JAD3rrbvah9qTisakqG7QYJa3Du6QGuBdbUjPB3pAw==
   dependencies:
     "@11ty/eleventy" "^0.11.0"
-    "@d4kmor/eleventy-plugin-mdjs-unified" "^0.2.0"
-    "@d4kmor/eleventy-rocket-nav" "^0.2.0"
+    "@d4kmor/core" "^0.1.1"
+    "@d4kmor/eleventy-plugin-mdjs-unified" "^0.3.0"
+    "@d4kmor/eleventy-rocket-nav" "^0.2.1"
     "@open-wc/building-rollup" "^1.8.0"
     "@web/config-loader" "^0.1.2"
     "@web/dev-server" "^0.0.10"
@@ -1091,6 +1092,11 @@
     rollup-plugin-visualizer "^4.0.4"
     rollup-plugin-workbox "^5.0.1"
 
+"@d4kmor/core@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@d4kmor/core/-/core-0.1.1.tgz#b98fb1a55e0c88c5c8a817f5a017ce8770fd7c22"
+  integrity sha512-iL5mb8atadYDmdcftNk+HiHbpD11uA99wJ2DkbMag+BjBundFocXukRuRQY3xKfuQlCjTiBDK4cZulmzNVJepA==
+
 "@d4kmor/drawer@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@d4kmor/drawer/-/drawer-0.2.0.tgz#e8bcb28a6c188e6f76ea6f9f37b2a760602c8f02"
@@ -1099,26 +1105,26 @@
     "@lion/overlays" "0.16.6"
     lit-element "^2.3.1"
 
-"@d4kmor/eleventy-plugin-mdjs-unified@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@d4kmor/eleventy-plugin-mdjs-unified/-/eleventy-plugin-mdjs-unified-0.2.0.tgz#6e7817ac9f70b224189c049c2a21fe0f9901aa4a"
-  integrity sha512-tyMGxtQbNF6CVXI2UT3KgUHqVppfSkh75nHjZjOfTwPqPys9gALf4SifNnyksOQ5jheBOV0R93Bsn3AfyKrnkg==
+"@d4kmor/eleventy-plugin-mdjs-unified@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@d4kmor/eleventy-plugin-mdjs-unified/-/eleventy-plugin-mdjs-unified-0.3.0.tgz#4c8fe98cacdacae7466899e4f9a7fcdf372f75a6"
+  integrity sha512-hkHGYPS3k/2MC4lOLa8LLHKNEzUvPn521sPntG1r11p3wtbNm4JS7LBMYS8JCi/XGhvmYufqFW2ttX2ZQv/fEQ==
   dependencies:
     "@mdjs/core" "^0.4.0"
     unist-util-visit "^2.0.3"
 
-"@d4kmor/eleventy-rocket-nav@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@d4kmor/eleventy-rocket-nav/-/eleventy-rocket-nav-0.2.0.tgz#5b61475809f6c5a938019b43adfae3682604b4e8"
-  integrity sha512-kjRlCYi7KXhTarVL+57jhn0MnMeVbQGYX2ud/Jyg6w+jEqldrElYzRXETaQ3CDQSa5jyYBUXQPxf0SqTE2B0eg==
+"@d4kmor/eleventy-rocket-nav@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@d4kmor/eleventy-rocket-nav/-/eleventy-rocket-nav-0.2.1.tgz#d8f0d0ac94660744293cd542269be120b9c46009"
+  integrity sha512-keYTmrpUlmuT2CFegyYAzURHQ55vc4ky2GSMB7bvSQNZ5w5qDbH9AVXerHbOadxkRwsrY/OXrcBsRuKfdUG0DA==
   dependencies:
     dependency-graph "^0.8.1"
     sax-wasm "^1.4.5"
 
-"@d4kmor/launch@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@d4kmor/launch/-/launch-0.3.0.tgz#fb566e96a0661d3c7c98a1ac8c0f8daa49255d77"
-  integrity sha512-Bdw1qZ0U4F0BMSlnMgwkBYRvm/5kC5xKlM3W9/OUYDLnL18KidacF925bA5erQPQo4hrD/evQcIGgxCtyJtIww==
+"@d4kmor/launch@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@d4kmor/launch/-/launch-0.4.0.tgz#c5b226e874cdd46c5fe47470726fcb0467e64db0"
+  integrity sha512-QFNyFOQ60ihRok7YeYv0xLZqd+pXLfQEaZK7RvPxMTG9+VS5ogSh8BoOufDNXEePW27DgA79aOE5pDTAt0xA2g==
   dependencies:
     "@d4kmor/drawer" "^0.2.0"
     "@d4kmor/navigation" "^0.2.0"
@@ -5086,6 +5092,11 @@ estree-walker@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
   integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
+
+estree-walker@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.1.tgz#f8e030fb21cefa183b44b7ad516b747434e7a3e0"
+  integrity sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==
 
 esutils@^2.0.2:
   version "2.0.3"


### PR DESCRIPTION
## What I did:

1. update to latest rocket
2. replace most frontmatter with markdown headlines
3. small cleanup in docs to align wordings and remove duplicate content