### PR TITLE
feat(test-runner): improve browser close logic

### DIFF
--- a/.changeset/smart-plums-cheat.md
+++ b/.changeset/smart-plums-cheat.md
@@ -1,0 +1,8 @@
+---
+'@web/test-runner': patch
+'@web/test-runner-browserstack': patch
+'@web/test-runner-core': patch
+'@web/test-runner-saucelabs': patch
+---
+
+improve browser and proxy close logic

--- a/packages/test-runner-browserstack/src/browserstackLauncher.ts
+++ b/packages/test-runner-browserstack/src/browserstackLauncher.ts
@@ -47,9 +47,10 @@ export class BrowserstackLauncher extends SeleniumLauncher {
     throw new Error('Starting a debug session is not supported in browserstack');
   }
 
-  async stop() {
-    await unregisterBrowserstackLocal(this);
-    return super.stop();
+  stop() {
+    const stopPromise = super.stop();
+    unregisterBrowserstackLocal(this);
+    return stopPromise;
   }
 }
 

--- a/packages/test-runner-browserstack/src/browserstackManager.ts
+++ b/packages/test-runner-browserstack/src/browserstackManager.ts
@@ -13,32 +13,46 @@ let connection: browserstack.Local | undefined = undefined;
 
 export const localId = `web-test-runner-${uuid()}`;
 
+async function setupLocalConnection(password: string, options: Partial<browserstack.Options> = {}) {
+  process.on('SIGINT', closeLocalConnection);
+  process.on('SIGTERM', closeLocalConnection);
+  process.on('beforeExit', closeLocalConnection);
+  process.on('exit', closeLocalConnection);
+
+  connection = new browserstack.Local();
+
+  console.log('[Browserstack] Setting up Browserstack Local proxy...');
+  await promisify(connection.start).bind(connection)({
+    key: password,
+    force: true,
+    localIdentifier: localId,
+    ...options,
+  });
+}
+
+function closeLocalConnection() {
+  if (connection && (connection as any).pid != null) {
+    process.kill((connection as any).pid);
+    connection = undefined;
+  }
+}
+
 export async function registerBrowserstackLocal(
   launcher: BrowserLauncher,
   password: string,
   options: Partial<browserstack.Options> = {},
 ) {
-  if (!connection) {
-    connection = new browserstack.Local();
-
-    console.log('[Browserstack] Setting up Browserstack Local proxy...\n');
-    await promisify(connection.start).bind(connection)({
-      key: password,
-      force: true,
-      localIdentifier: localId,
-      ...options,
-    });
-  }
-
   launchers.add(launcher);
+
+  if (!connection) {
+    await setupLocalConnection(password, options);
+  }
 }
 
 export function unregisterBrowserstackLocal(launcher: BrowserLauncher) {
   launchers.delete(launcher);
 
   if (connection && launchers.size === 0) {
-    if ((connection as any).pid != null) {
-      process.kill((connection as any).pid);
-    }
+    closeLocalConnection();
   }
 }

--- a/packages/test-runner-core/src/runner/TestRunner.ts
+++ b/packages/test-runner-core/src/runner/TestRunner.ts
@@ -134,7 +134,7 @@ export class TestRunner extends EventEmitter<EventMap> {
     }
 
     this.stopped = true;
-    this.scheduler.stop();
+    await this.scheduler.stop();
     this.server.stop().catch(error => {
       console.error(error);
     });

--- a/packages/test-runner-saucelabs/src/SauceLabsLauncher.ts
+++ b/packages/test-runner-saucelabs/src/SauceLabsLauncher.ts
@@ -29,8 +29,9 @@ export class SauceLabsLauncher extends SeleniumLauncher {
     return super.initialize(config);
   }
 
-  async stop() {
-    await super.stop();
-    await this.manager.deregisterLauncher(this);
+  stop() {
+    const stopPromise = super.stop();
+    this.manager.deregisterLauncher(this);
+    return stopPromise;
   }
 }

--- a/packages/test-runner-saucelabs/src/SauceLabsLauncherManager.ts
+++ b/packages/test-runner-saucelabs/src/SauceLabsLauncherManager.ts
@@ -21,6 +21,7 @@ export class SauceLabsLauncherManager {
     process.on('SIGINT', this.closeConnection);
     process.on('SIGTERM', this.closeConnection);
     process.on('beforeExit', this.closeConnection);
+    process.on('exit', this.closeConnection);
   }
 
   get webdriverEndpoint() {
@@ -35,7 +36,7 @@ export class SauceLabsLauncherManager {
       return;
     }
 
-    console.log('[Saucelabs] Setting up Sauce Connect proxy...\n');
+    console.log('[Saucelabs] Setting up Sauce Connect proxy...');
     this.connectionPromise = this.api.startSauceConnect(this.connectOptions ?? {});
     this.connection = await this.connectionPromise;
   }

--- a/packages/test-runner-saucelabs/test-remote/saucelabsLauncher.test.js
+++ b/packages/test-runner-saucelabs/test-remote/saucelabsLauncher.test.js
@@ -45,12 +45,6 @@ it('runs tests on saucelabs', async function () {
         browserVersion: 'latest',
         platformName: 'Windows 10',
       }),
-      sauceLabsLauncher({
-        ...sharedCapabilities,
-        browserName: 'firefox',
-        browserVersion: 'latest',
-        platformName: 'Windows 10',
-      }),
       // sauceLabsLauncher({
       //   ...sharedCapabilities,
       //   browserName: 'safari',

--- a/packages/test-runner/demo/saucelabs.config.mjs
+++ b/packages/test-runner/demo/saucelabs.config.mjs
@@ -56,12 +56,12 @@ export default {
     //   browserVersion: 'latest',
     //   platformName: 'Windows 10',
     // }),
-    sauceLabsLauncher({
-      ...sharedCapabilities,
-      browserName: 'internet explorer',
-      browserVersion: '11.0',
-      platformName: 'Windows 7',
-    }),
+    // sauceLabsLauncher({
+    //   ...sharedCapabilities,
+    //   browserName: 'internet explorer',
+    //   browserVersion: '11.0',
+    //   platformName: 'Windows 7',
+    // }),
   ],
   browserStartTimeout: 1000 * 60 * 1,
   testsStartTimeout: 1000 * 60 * 1,


### PR DESCRIPTION
This improves the logic of closing browsers when testing ends, and makes the logic around closing the browstack/saucelabs proxy more paranoid. This hopefully improves stability and reduces zombie proxies staying opened.