### PR TITLE
feat(test-runner): throw when combining browser config and flags

### DIFF
--- a/.changeset/cuddly-pugs-type.md
+++ b/.changeset/cuddly-pugs-type.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner': patch
+---
+
+throw when combining browsers config and flags

--- a/packages/test-runner/src/startTestRunner.ts
+++ b/packages/test-runner/src/startTestRunner.ts
@@ -139,8 +139,18 @@ export async function startTestRunner(options: StartTestRunnerOptions = {}) {
     }
 
     if (cliArgs.puppeteer) {
+      if (config.browsers && config.browsers.length > 0) {
+        throw new TestRunnerStartError(
+          'The --puppeteer flag cannot be used when defining browsers manually in your config.',
+        );
+      }
       config.browsers = puppeteerLauncher(cliArgs.browsers);
     } else if (cliArgs.playwright) {
+      if (config.browsers && config.browsers.length > 0) {
+        throw new TestRunnerStartError(
+          'The --playwright flag cannot be used when defining browsers manually in your config.',
+        );
+      }
       config.browsers = playwrightLauncher(cliArgs.browsers);
     } else {
       if (cliArgs.browsers != null) {


### PR DESCRIPTION
It looks like the `--puppeteer` and `--playwright` flags overwrite the user defined browsers option without notifying the user.

This change throws an error to the user, as there is confusion about the user's intent. The flags should only be used as a shorthand to set up the defaults.