### PR TITLE
fix(test-runner-mocha): avoid using document.baseURI in IE11

### DIFF
--- a/.changeset/clever-bears-nail.md
+++ b/.changeset/clever-bears-nail.md
@@ -1,0 +1,6 @@
+---
+'@web/test-runner-mocha': patch
+'@web/test-runner': patch
+---
+
+avoid using document.baseURI in IE11

--- a/packages/test-runner-mocha/src/autorun.ts
+++ b/packages/test-runner-mocha/src/autorun.ts
@@ -10,6 +10,10 @@ import { collectTestResults } from './collectTestResults.js';
 
 sessionStarted();
 
+// avoid using document.baseURI for IE11 support
+const base = document.querySelector('base');
+const baseURI = (base || window.location).href;
+
 (async () => {
   const errors: TestResultError[] = [];
 
@@ -27,7 +31,7 @@ sessionStarted();
   const userOptions = typeof testFrameworkConfig === 'object' ? testFrameworkConfig : {};
   mocha.setup({ ui: 'bdd', allowUncaught: false, ...userOptions });
 
-  await import(new URL(testFile, document.baseURI).href).catch(error => {
+  await import(new URL(testFile, baseURI).href).catch(error => {
     console.error(error);
     errors.push({
       message:


### PR DESCRIPTION
## What I did

Updated test-runner-mocha to avoid using `document.baseURI` since this is not supported in IE11.
