### PR TITLE
chore(test-runner-mocha): new version

### DIFF
--- a/.changeset/seven-avocados-sing.md
+++ b/.changeset/seven-avocados-sing.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-mocha': minor
+---
+
+release new version of test-runner-mocha

--- a/packages/test-runner-mocha/package.json
+++ b/packages/test-runner-mocha/package.json
@@ -23,7 +23,9 @@
     "test": "mocha test/**/*.test.js",
     "test:watch": "mocha test/**/*.test.js --watch --watch-files src,test"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "keywords": [
     "web",
     "test",
@@ -33,7 +35,8 @@
     "framework"
   ],
   "dependencies": {
-    "@types/mocha": "^8.0.1"
+    "@types/mocha": "^8.0.1",
+    "@web/test-runner-mocha": "^0.3.7"
   },
   "devDependencies": {
     "clean-css": "^4.2.3",


### PR DESCRIPTION
## What I did

1. Mocha didn't get included in the breaking version bump.
