### PR TITLE
feat(test-runner): always print stack traces in errors

### DIFF
--- a/.changeset/honest-phones-kneel.md
+++ b/.changeset/honest-phones-kneel.md
@@ -1,0 +1,6 @@
+---
+'@web/test-runner-cli': patch
+'@web/test-runner': patch
+---
+
+always print stack traces in errors

--- a/packages/test-runner-cli/src/reporter/reportTestsErrors.ts
+++ b/packages/test-runner-cli/src/reporter/reportTestsErrors.ts
@@ -55,15 +55,18 @@ export async function formatError(
   }
 
   if (typeof err.expected === 'string' && typeof err.actual === 'string') {
-    strings.push(`${chalk.gray('error:')} ${chalk.red(err.message)}`);
-    strings.push(renderDiff(err.actual, err.expected));
-  } else if (err.stack) {
+    strings.push(`${renderDiff(err.actual, err.expected)} \n`);
+  }
+
+  if (err.stack) {
     strings.push(
       `${chalk.red(
         await formatStackTrace(err, userAgent, rootDir, stackLocationRegExp, sourceMapFunction),
       )}`,
     );
-  } else {
+  }
+
+  if (!err.expected && !err.stack) {
     strings.push(chalk.red(err.message ?? 'Unknown error'));
   }
 


### PR DESCRIPTION
## What I did

Fixes https://github.com/modernweb-dev/web/issues/557
