### PR TITLE
feat(test-runner-playwright): add experimental window focus mode

### DIFF
--- a/.changeset/wild-fans-tickle.md
+++ b/.changeset/wild-fans-tickle.md
@@ -1,0 +1,7 @@
+---
+'@web/test-runner': patch
+'@web/test-runner-core': patch
+'@web/test-runner-playwright': patch
+---
+
+added experimental mode to test workflows where tests on firefox require the browser window to be focused

--- a/packages/test-runner-core/src/browser-launcher/BrowserLauncher.ts
+++ b/packages/test-runner-core/src/browser-launcher/BrowserLauncher.ts
@@ -18,6 +18,8 @@ export interface BrowserLauncher {
    */
   type: string;
 
+  __experimentalWindowFocus__?: boolean;
+
   /**
    * One time startup for the browser launcher. Called when the test runner
    * starts. Use this for async initialization work.

--- a/packages/test-runner-playwright/src/PlaywrightLauncher.ts
+++ b/packages/test-runner-playwright/src/PlaywrightLauncher.ts
@@ -25,13 +25,16 @@ export class PlaywrightLauncher implements BrowserLauncher {
   private inactivePages: PlaywrightLauncherPage[] = [];
   private testCoveragePerSession = new Map<string, CoverageMapData>();
   private __launchBrowserPromise?: Promise<Browser>;
+  public __experimentalWindowFocus__: boolean;
 
   constructor(
     private product: ProductType,
     private launchOptions: LaunchOptions,
     private createPageFunction?: CreatePageFunction,
+    __experimentalWindowFocus__?: boolean,
   ) {
     this.name = capitalize(product);
+    this.__experimentalWindowFocus__ = !!__experimentalWindowFocus__;
   }
 
   async initialize(config: TestRunnerCoreConfig, testFiles: string[]) {

--- a/packages/test-runner-playwright/src/index.ts
+++ b/packages/test-runner-playwright/src/index.ts
@@ -10,6 +10,7 @@ export interface PlaywrightLauncherArgs {
   product?: ProductType;
   launchOptions?: LaunchOptions;
   createPage?: (args: { config: TestRunnerCoreConfig; browser: Browser }) => Promise<Page>;
+  __experimentalWindowFocus__?: boolean;
 }
 
 export { PlaywrightLauncher };
@@ -22,5 +23,10 @@ export function playwrightLauncher(args: PlaywrightLauncherArgs = {}) {
     );
   }
 
-  return new PlaywrightLauncher(product, args.launchOptions ?? {}, args.createPage);
+  return new PlaywrightLauncher(
+    product,
+    args.launchOptions ?? {},
+    args.createPage,
+    !!args.__experimentalWindowFocus__,
+  );
 }

--- a/packages/test-runner/demo/groups.config.mjs
+++ b/packages/test-runner/demo/groups.config.mjs
@@ -1,25 +1,23 @@
-//@ts-check
 import { playwrightLauncher } from '@web/test-runner-playwright';
 
 export default /** @type {import('@web/test-runner').TestRunnerConfig} */ ({
   nodeResolve: true,
   rootDir: '../../',
-  files: 'demo/test/pass-*.test.js',
 
   groups: [
     {
       name: 'chromium',
-      files: 'demo/test/pass-1.test.js',
+      files: 'demo/test/pass-*.test.js',
       browsers: [playwrightLauncher({ product: 'chromium' })],
     },
     {
       name: 'firefox',
-      files: 'demo/test/pass-1.test.js',
+      files: 'demo/test/pass-*.test.js',
       browsers: [playwrightLauncher({ product: 'firefox' })],
     },
     {
       name: 'webkit',
-      files: 'demo/test/pass-1.test.js',
+      files: 'demo/test/pass-*.test.js',
       browsers: [playwrightLauncher({ product: 'webkit' })],
     },
   ],


### PR DESCRIPTION
## What I did

When testing on firefox some tests can fail because firefox requires the browser window to be focused to fire focus/blur events. 

This adds an experimental mode for the playwright launcher where you can mark a browser launcher to be launched in a special "focus" mode. We first run all other tests, and then at the end launch the firefox browser and run tests with a concurrency of 1 to ensure the window is focused.

It's experimental so that we can test it out and see if it works. Then we can later unflag it.
