### PR TITLE
feat(test-runner): allow setting concurrency per browser

### DIFF
--- a/.changeset/rich-comics-grow.md
+++ b/.changeset/rich-comics-grow.md
@@ -1,0 +1,10 @@
+---
+'@web/test-runner': patch
+'@web/test-cli': patch
+'@web/test-runner-chrome': patch
+'@web/test-runner-core': patch
+'@web/test-runner-playwright': patch
+'@web/test-runner-puppeteer': patch
+---
+
+allow configuring concurrency per browser launcher

--- a/docs/docs/test-runner/browser-launchers/chrome.md
+++ b/docs/docs/test-runner/browser-launchers/chrome.md
@@ -45,3 +45,15 @@ export default {
   ],
 };
 ```
+
+## Concurrency
+
+You can override the concurrency of this specific browser launcher
+
+```js
+import { chromeLauncher } from '@web/test-runner-chrome';
+
+export default {
+  browsers: [chromeLauncher({ concurrency: 1 })],
+};
+```

--- a/docs/docs/test-runner/browser-launchers/playwright.md
+++ b/docs/docs/test-runner/browser-launchers/playwright.md
@@ -53,3 +53,15 @@ export default {
   ],
 };
 ```
+
+## Concurrency
+
+You can override the concurrency of this specific browser launcher
+
+```js
+import { playwrightLauncher } from '@web/test-runner-playwright';
+
+export default {
+  browsers: [playwrightLauncher({ product: 'firefox', concurrency: 1 })],
+};
+```

--- a/docs/docs/test-runner/browser-launchers/puppeteer.md
+++ b/docs/docs/test-runner/browser-launchers/puppeteer.md
@@ -40,6 +40,22 @@ export default {
 };
 ```
 
+## Concurrency
+
+You can override the concurrency of this specific browser launcher
+
+```js
+import { puppeteerLauncher } from '@web/test-runner-puppeteer';
+
+export default {
+  browsers: [
+    puppeteerLauncher({
+      concurrency: 1,
+    }),
+  ],
+};
+```
+
 ## Testing Firefox
 
 Testing Firefox with Puppeteer is still experimental. There is currently no official way to install both chromium and firefox, but you can set this up for your repository by adding a post-install step to your package scripts:

--- a/packages/test-runner-chrome/src/ChromeLauncher.ts
+++ b/packages/test-runner-chrome/src/ChromeLauncher.ts
@@ -21,6 +21,10 @@ export type CreatePageFunction = (args: {
 export class ChromeLauncher implements BrowserLauncher {
   public name: string;
   public type = 'puppeteer';
+  public concurrency?: number;
+  private launchOptions: LaunchOptions;
+  private customPuppeteer?: typeof puppeteerCore;
+  private createPageFunction?: CreatePageFunction;
   private config?: TestRunnerCoreConfig;
   private testFiles?: string[];
   private browser?: Browser;
@@ -32,10 +36,15 @@ export class ChromeLauncher implements BrowserLauncher {
   private __launchBrowserPromise?: Promise<Browser>;
 
   constructor(
-    private launchOptions: LaunchOptions,
-    private customPuppeteer?: typeof puppeteerCore,
-    private createPageFunction?: CreatePageFunction,
+    launchOptions: LaunchOptions,
+    customPuppeteer?: typeof puppeteerCore,
+    createPageFunction?: CreatePageFunction,
+    concurrency?: number,
   ) {
+    this.launchOptions = launchOptions;
+    this.customPuppeteer = customPuppeteer;
+    this.createPageFunction = createPageFunction;
+    this.concurrency = concurrency;
     if (!customPuppeteer) {
       // without a custom puppeteer, we use the locally installed chrome
       this.name = 'Chrome';

--- a/packages/test-runner-chrome/src/index.ts
+++ b/packages/test-runner-chrome/src/index.ts
@@ -7,10 +7,16 @@ export interface ChromeLauncherArgs {
   puppeteer?: typeof puppeteerCore;
   launchOptions?: LaunchOptions;
   createPage?: (args: { config: TestRunnerCoreConfig; browser: Browser }) => Promise<Page>;
+  concurrency?: number;
 }
 
 export { ChromeLauncher };
 
 export function chromeLauncher(args: ChromeLauncherArgs = {}) {
-  return new ChromeLauncher(args.launchOptions ?? {}, args.puppeteer, args.createPage);
+  return new ChromeLauncher(
+    args.launchOptions ?? {},
+    args.puppeteer,
+    args.createPage,
+    args.concurrency,
+  );
 }

--- a/packages/test-runner-core/src/browser-launcher/BrowserLauncher.ts
+++ b/packages/test-runner-core/src/browser-launcher/BrowserLauncher.ts
@@ -18,6 +18,12 @@ export interface BrowserLauncher {
    */
   type: string;
 
+  /**
+   * Optional concurrency for this browser launcher only. Overwrites a globally
+   * configured concurrency option.
+   */
+  concurrency?: number;
+
   __experimentalWindowFocus__?: boolean;
 
   /**

--- a/packages/test-runner-core/src/runner/TestScheduler.ts
+++ b/packages/test-runner-core/src/runner/TestScheduler.ts
@@ -94,7 +94,14 @@ export class TestScheduler {
         runningBrowsers += 1;
 
         const runningCount = this.getRunningSessions(browser).length;
-        const maxBudget = browser.__experimentalWindowFocus__ ? 1 : this.config.concurrency;
+        let maxBudget;
+
+        if (browser.__experimentalWindowFocus__) {
+          maxBudget = 1;
+        } else {
+          maxBudget = browser.concurrency ?? this.config.concurrency;
+        }
+
         const runBudget = Math.max(0, maxBudget - runningCount);
         if (runBudget !== 0) {
           // we have budget to schedule new sessions for this browser

--- a/packages/test-runner-playwright/src/PlaywrightLauncher.ts
+++ b/packages/test-runner-playwright/src/PlaywrightLauncher.ts
@@ -16,6 +16,10 @@ export type CreatePageFunction = (args: {
 export class PlaywrightLauncher implements BrowserLauncher {
   public name: string;
   public type = 'playwright';
+  public concurrency?: number;
+  private product: ProductType;
+  private launchOptions: LaunchOptions;
+  private createPageFunction?: CreatePageFunction;
   private config?: TestRunnerCoreConfig;
   private testFiles?: string[];
   private browser?: Browser;
@@ -28,11 +32,16 @@ export class PlaywrightLauncher implements BrowserLauncher {
   public __experimentalWindowFocus__: boolean;
 
   constructor(
-    private product: ProductType,
-    private launchOptions: LaunchOptions,
-    private createPageFunction?: CreatePageFunction,
+    product: ProductType,
+    launchOptions: LaunchOptions,
+    createPageFunction?: CreatePageFunction,
     __experimentalWindowFocus__?: boolean,
+    concurrency?: number,
   ) {
+    this.product = product;
+    this.launchOptions = launchOptions;
+    this.createPageFunction = createPageFunction;
+    this.concurrency = concurrency;
     this.name = capitalize(product);
     this.__experimentalWindowFocus__ = !!__experimentalWindowFocus__;
   }

--- a/packages/test-runner-playwright/src/index.ts
+++ b/packages/test-runner-playwright/src/index.ts
@@ -11,6 +11,7 @@ export interface PlaywrightLauncherArgs {
   launchOptions?: LaunchOptions;
   createPage?: (args: { config: TestRunnerCoreConfig; browser: Browser }) => Promise<Page>;
   __experimentalWindowFocus__?: boolean;
+  concurrency?: number;
 }
 
 export { PlaywrightLauncher };
@@ -28,5 +29,6 @@ export function playwrightLauncher(args: PlaywrightLauncherArgs = {}) {
     args.launchOptions ?? {},
     args.createPage,
     !!args.__experimentalWindowFocus__,
+    args.concurrency,
   );
 }

--- a/packages/test-runner-puppeteer/src/puppeteerLauncher.ts
+++ b/packages/test-runner-puppeteer/src/puppeteerLauncher.ts
@@ -8,15 +8,18 @@ export interface PuppeteerLauncherConfig {
     config: TestRunnerCoreConfig;
     browser: puppeteer.Browser;
   }) => Promise<puppeteer.Page>;
+  concurrency?: number;
 }
 
 export function puppeteerLauncher({
   launchOptions,
   createPage,
+  concurrency,
 }: PuppeteerLauncherConfig = {}): BrowserLauncher {
   return chromeLauncher({
     launchOptions,
     puppeteer: (puppeteer as any).default as typeof puppeteer,
     createPage,
+    concurrency,
   });
 }

--- a/packages/test-runner/demo/focus.config.mjs
+++ b/packages/test-runner/demo/focus.config.mjs
@@ -1,0 +1,24 @@
+import { playwrightLauncher } from '@web/test-runner-playwright';
+
+export default /** @type {import('@web/test-runner').TestRunnerConfig} */ ({
+  nodeResolve: true,
+  rootDir: '../../',
+
+  groups: [
+    {
+      name: 'firefox',
+      files: 'demo/test/focus/focus-*.test.js',
+      browsers: [playwrightLauncher({ product: 'firefox', concurrency: 1 })],
+    },
+    {
+      name: 'chromium',
+      files: 'demo/test/focus/focus-*.test.js',
+      browsers: [playwrightLauncher({ product: 'chromium' })],
+    },
+    {
+      name: 'webkit',
+      files: 'demo/test/focus/focus-*.test.js',
+      browsers: [playwrightLauncher({ product: 'webkit' })],
+    },
+  ],
+});

--- a/packages/test-runner/demo/test/focus/focus-a.test.js
+++ b/packages/test-runner/demo/test/focus/focus-a.test.js
@@ -1,0 +1,15 @@
+import { expect } from '@esm-bundle/chai';
+
+it('can run a test with focus a', async () => {
+  const input = document.createElement('input');
+  document.body.appendChild(input);
+
+  let firedEvent = false;
+  input.addEventListener('focus', () => {
+    firedEvent = true;
+  });
+  input.focus();
+
+  await Promise.resolve();
+  expect(firedEvent).to.be.true;
+});

--- a/packages/test-runner/demo/test/focus/focus-b.test.js
+++ b/packages/test-runner/demo/test/focus/focus-b.test.js
@@ -1,0 +1,15 @@
+import { expect } from '@esm-bundle/chai';
+
+it('can run a test with focus b', async () => {
+  const input = document.createElement('input');
+  document.body.appendChild(input);
+
+  let firedEvent = false;
+  input.addEventListener('focus', () => {
+    firedEvent = true;
+  });
+  input.focus();
+
+  await Promise.resolve();
+  expect(firedEvent).to.be.true;
+});

--- a/packages/test-runner/demo/test/focus/focus-c.test.js
+++ b/packages/test-runner/demo/test/focus/focus-c.test.js
@@ -1,0 +1,15 @@
+import { expect } from '@esm-bundle/chai';
+
+it('can run a test with focus b', async () => {
+  const input = document.createElement('input');
+  document.body.appendChild(input);
+
+  let firedEvent = false;
+  input.addEventListener('focus', () => {
+    firedEvent = true;
+  });
+  input.focus();
+
+  await Promise.resolve();
+  expect(firedEvent).to.be.true;
+});

--- a/packages/test-runner/demo/test/focus/focus-d.test.js
+++ b/packages/test-runner/demo/test/focus/focus-d.test.js
@@ -1,0 +1,15 @@
+import { expect } from '@esm-bundle/chai';
+
+it('can run a test with focus b', async () => {
+  const input = document.createElement('input');
+  document.body.appendChild(input);
+
+  let firedEvent = false;
+  input.addEventListener('focus', () => {
+    firedEvent = true;
+  });
+  input.focus();
+
+  await Promise.resolve();
+  expect(firedEvent).to.be.true;
+});

--- a/packages/test-runner/demo/test/focus/focus-e.test.js
+++ b/packages/test-runner/demo/test/focus/focus-e.test.js
@@ -1,0 +1,15 @@
+import { expect } from '@esm-bundle/chai';
+
+it('can run a test with focus b', async () => {
+  const input = document.createElement('input');
+  document.body.appendChild(input);
+
+  let firedEvent = false;
+  input.addEventListener('focus', () => {
+    firedEvent = true;
+  });
+  input.focus();
+
+  await Promise.resolve();
+  expect(firedEvent).to.be.true;
+});

--- a/packages/test-runner/demo/test/focus/focus-f.test.js
+++ b/packages/test-runner/demo/test/focus/focus-f.test.js
@@ -1,0 +1,15 @@
+import { expect } from '@esm-bundle/chai';
+
+it('can run a test with focus b', async () => {
+  const input = document.createElement('input');
+  document.body.appendChild(input);
+
+  let firedEvent = false;
+  input.addEventListener('focus', () => {
+    firedEvent = true;
+  });
+  input.focus();
+
+  await Promise.resolve();
+  expect(firedEvent).to.be.true;
+});

--- a/packages/test-runner/demo/test/focus/focus-g.test.js
+++ b/packages/test-runner/demo/test/focus/focus-g.test.js
@@ -1,0 +1,15 @@
+import { expect } from '@esm-bundle/chai';
+
+it('can run a test with focus b', async () => {
+  const input = document.createElement('input');
+  document.body.appendChild(input);
+
+  let firedEvent = false;
+  input.addEventListener('focus', () => {
+    firedEvent = true;
+  });
+  input.focus();
+
+  await Promise.resolve();
+  expect(firedEvent).to.be.true;
+});

--- a/packages/test-runner/demo/test/focus/focus-h.test.js
+++ b/packages/test-runner/demo/test/focus/focus-h.test.js
@@ -1,0 +1,15 @@
+import { expect } from '@esm-bundle/chai';
+
+it('can run a test with focus b', async () => {
+  const input = document.createElement('input');
+  document.body.appendChild(input);
+
+  let firedEvent = false;
+  input.addEventListener('focus', () => {
+    firedEvent = true;
+  });
+  input.focus();
+
+  await Promise.resolve();
+  expect(firedEvent).to.be.true;
+});

--- a/packages/test-runner/demo/test/focus/focus-i.test.js
+++ b/packages/test-runner/demo/test/focus/focus-i.test.js
@@ -1,0 +1,15 @@
+import { expect } from '@esm-bundle/chai';
+
+it('can run a test with focus b', async () => {
+  const input = document.createElement('input');
+  document.body.appendChild(input);
+
+  let firedEvent = false;
+  input.addEventListener('focus', () => {
+    firedEvent = true;
+  });
+  input.focus();
+
+  await Promise.resolve();
+  expect(firedEvent).to.be.true;
+});

--- a/packages/test-runner/demo/test/focus/focus-j.test.js
+++ b/packages/test-runner/demo/test/focus/focus-j.test.js
@@ -1,0 +1,15 @@
+import { expect } from '@esm-bundle/chai';
+
+it('can run a test with focus b', async () => {
+  const input = document.createElement('input');
+  document.body.appendChild(input);
+
+  let firedEvent = false;
+  input.addEventListener('focus', () => {
+    firedEvent = true;
+  });
+  input.focus();
+
+  await Promise.resolve();
+  expect(firedEvent).to.be.true;
+});

--- a/packages/test-runner/demo/test/focus/focus-k.test.js
+++ b/packages/test-runner/demo/test/focus/focus-k.test.js
@@ -1,0 +1,15 @@
+import { expect } from '@esm-bundle/chai';
+
+it('can run a test with focus b', async () => {
+  const input = document.createElement('input');
+  document.body.appendChild(input);
+
+  let firedEvent = false;
+  input.addEventListener('focus', () => {
+    firedEvent = true;
+  });
+  input.focus();
+
+  await Promise.resolve();
+  expect(firedEvent).to.be.true;
+});

--- a/packages/test-runner/demo/test/focus/focus-l.test.js
+++ b/packages/test-runner/demo/test/focus/focus-l.test.js
@@ -1,0 +1,15 @@
+import { expect } from '@esm-bundle/chai';
+
+it('can run a test with focus b', async () => {
+  const input = document.createElement('input');
+  document.body.appendChild(input);
+
+  let firedEvent = false;
+  input.addEventListener('focus', () => {
+    firedEvent = true;
+  });
+  input.focus();
+
+  await Promise.resolve();
+  expect(firedEvent).to.be.true;
+});

--- a/packages/test-runner/demo/test/focus/focus-m.test.js
+++ b/packages/test-runner/demo/test/focus/focus-m.test.js
@@ -1,0 +1,15 @@
+import { expect } from '@esm-bundle/chai';
+
+it('can run a test with focus b', async () => {
+  const input = document.createElement('input');
+  document.body.appendChild(input);
+
+  let firedEvent = false;
+  input.addEventListener('focus', () => {
+    firedEvent = true;
+  });
+  input.focus();
+
+  await Promise.resolve();
+  expect(firedEvent).to.be.true;
+});

--- a/packages/test-runner/demo/test/focus/focus-n.test.js
+++ b/packages/test-runner/demo/test/focus/focus-n.test.js
@@ -1,0 +1,15 @@
+import { expect } from '@esm-bundle/chai';
+
+it('can run a test with focus b', async () => {
+  const input = document.createElement('input');
+  document.body.appendChild(input);
+
+  let firedEvent = false;
+  input.addEventListener('focus', () => {
+    firedEvent = true;
+  });
+  input.focus();
+
+  await Promise.resolve();
+  expect(firedEvent).to.be.true;
+});

--- a/packages/test-runner/demo/test/focus/focus-o.test.js
+++ b/packages/test-runner/demo/test/focus/focus-o.test.js
@@ -1,0 +1,15 @@
+import { expect } from '@esm-bundle/chai';
+
+it('can run a test with focus b', async () => {
+  const input = document.createElement('input');
+  document.body.appendChild(input);
+
+  let firedEvent = false;
+  input.addEventListener('focus', () => {
+    firedEvent = true;
+  });
+  input.focus();
+
+  await Promise.resolve();
+  expect(firedEvent).to.be.true;
+});

--- a/packages/test-runner/demo/test/focus/focus-p.test.js
+++ b/packages/test-runner/demo/test/focus/focus-p.test.js
@@ -1,0 +1,15 @@
+import { expect } from '@esm-bundle/chai';
+
+it('can run a test with focus b', async () => {
+  const input = document.createElement('input');
+  document.body.appendChild(input);
+
+  let firedEvent = false;
+  input.addEventListener('focus', () => {
+    firedEvent = true;
+  });
+  input.focus();
+
+  await Promise.resolve();
+  expect(firedEvent).to.be.true;
+});

--- a/packages/test-runner/package.json
+++ b/packages/test-runner/package.json
@@ -29,6 +29,7 @@
     "test:ci": "yarn test",
     "test:custom-html": "node dist/bin.js \"demo/test/pass-*.test.{js,html}\" --config demo/customhtml.config.js",
     "test:filter-logs": "node dist/bin.js --config demo/filter-logs.config.mjs",
+    "test:focus": "node dist/bin.js --config demo/focus.config.mjs",
     "test:groups-config": "node dist/bin.js --config demo/groups.config.mjs",
     "test:groups-pattern": "node dist/bin.js --groups \"demo/test/groups/**/*.config.mjs\"",
     "test:legacy": "node dist/bin.js \"demo/test/pass-*.test.{js,html}\" --config demo/legacy.config.mjs",


### PR DESCRIPTION
## What I did

Concurrency can now be configured per browser launcher, for the chrome, puppeteer and playwright launchers. 

Among other things, this is needed for firefox because it doesn't allow testing focus on tabs which are backgrounded. Setting a concurrency of 1 fixes that.

Fixes https://github.com/modernweb-dev/web/issues/238
