### PR TITLE
feat(dev-server-core): expose websockets server on the manager

### DIFF
--- a/.changeset/cool-mails-rescue.md
+++ b/.changeset/cool-mails-rescue.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server-core': patch
+---
+
+Expose webSocketServer on the WebSocketManager in case developers using the Node API want apply their own WebSocket message handling, but reusing the WebSocket Server of the dev server.

--- a/docs/docs/dev-server/node-api.md
+++ b/docs/docs/dev-server/node-api.md
@@ -133,6 +133,25 @@ async function main() {
 main();
 ```
 
+## Websockets Server
+
+The WebSocketsManager is exposed in case you need more fine-grained control. It contains three helpers:
+
+- `sendImport`: imports the given path, executing the module as well as a default export if it exports a function
+- `sendConsoleLog`: logs a message to the browser console of all connected web sockets.
+- `send`: sends messages to all connected web sockets.
+
+If you want to use the WebSockets server directly to handle messages yourself, use the `webSocketServer` property.
+
+```js
+const { server, webSockets } = await startDevServer();
+
+const wss = webSockets.webSocketServer;
+wss.on('connection', ws => {
+  ws.on('message', message => handleWsMessage(message, ws));
+});
+```
+
 ## Advanced
 
 If you need more control than what `startDevServer` gives you, you can also use the individual pieces that make up the dev server directly.

--- a/packages/dev-server-core/src/web-sockets/WebSocketsManager.ts
+++ b/packages/dev-server-core/src/web-sockets/WebSocketsManager.ts
@@ -16,7 +16,7 @@ export interface Events {
  */
 export class WebSocketsManager extends EventEmitter<Events> {
   public webSocketImport = NAME_WEB_SOCKET_IMPORT;
-  private webSocketServer: WebSocket.Server;
+  public webSocketServer: WebSocket.Server;
   private openSockets = new Set<WebSocket>();
 
   constructor(server: Server) {
@@ -51,7 +51,7 @@ export class WebSocketsManager extends EventEmitter<Events> {
   }
 
   /**
-   * Imports the given path, executing the module as well as a default export if it executes a function.
+   * Imports the given path, executing the module as well as a default export if it exports a function.
    *
    * This is a built-in web socket message and will be handled automatically.
    *


### PR DESCRIPTION
## What I did

1. make the webSocketServer property of the WebSocketsManager public, so it can be used by users of Node API for WDS
2. add documentation about this