### PR TITLE
docs(test-runner): fix links to esbuild/rollup plugins in overview

### DIFF
--- a/docs/docs/test-runner/overview.md
+++ b/docs/docs/test-runner/overview.md
@@ -17,7 +17,7 @@ Test runner for web applications.
 ⏱&nbsp;&nbsp;Runs tests in parallel and isolation.<br>
 👀&nbsp;&nbsp; Interactive watch mode.<br>
 🏃&nbsp;&nbsp; Fast development by rerunning only changed tests.<br>
-🚀&nbsp;&nbsp; Powered by [esbuild](/docs/dev-server/plugins/esbuild.md) and [rollup plugins](/docs/dev-server/plugins/rollup.md)
+🚀&nbsp;&nbsp; Powered by [esbuild](/docs/dev-server/plugins/esbuild/) and [rollup plugins](/docs/dev-server/plugins/rollup/)
 
 ## Installation
 

--- a/docs/docs/test-runner/overview.md
+++ b/docs/docs/test-runner/overview.md
@@ -17,7 +17,7 @@ Test runner for web applications.
 ⏱&nbsp;&nbsp;Runs tests in parallel and isolation.<br>
 👀&nbsp;&nbsp; Interactive watch mode.<br>
 🏃&nbsp;&nbsp; Fast development by rerunning only changed tests.<br>
-🚀&nbsp;&nbsp; Powered by [esbuild](/docs/dev-server/plugins/esbuild/) and [rollup plugins](/docs/dev-server/plugins/rollup/)
+🚀&nbsp;&nbsp; Powered by [esbuild](../dev-server/plugins/esbuild.md) and [rollup plugins](../dev-server/plugins/rollup.md)
 
 ## Installation
 


### PR DESCRIPTION
## What I did

Some of the links on https://modern-web.dev/docs/test-runner/overview/ result in 404s. I fixed the links to the plugins, but the links in the 1st bullet point are incorrect, too:

> Headless browsers with [Puppeteer](https://modern-web.dev/docs/test-runner/browsers/puppeteer/), [Playwright](https://modern-web.dev/docs/test-runner/browsers/playwright/), or [Selenium](https://modern-web.dev/docs/test-runner/browsers/selenium/)

But I don't know where they should link to