### PR TITLE
feat(test-runner-mocha): default to use spec reporter

### DIFF
--- a/.changeset/gentle-glasses-reflect.md
+++ b/.changeset/gentle-glasses-reflect.md
@@ -1,0 +1,18 @@
+---
+'@web/test-runner-mocha': minor
+'@web/test-runner': minor
+---
+
+Disabled the in-browser reporter during regular test runs, improving performance.
+
+Defaulted to the spec reporter instead of the HTML reporter in the browser when debugging. This avoids manipulating the testing environment by default.
+
+You can opt back into the old behavior by setting the mocha config:
+
+```js
+export default {
+  testFramework: {
+    config: { reporter: 'html' },
+  },
+};
+```

--- a/packages/test-runner-mocha/src/autorun.ts
+++ b/packages/test-runner-mocha/src/autorun.ts
@@ -5,8 +5,8 @@ import {
   TestResultError,
 } from '../../test-runner-core/browser/session.js';
 import '../../../node_modules/mocha/mocha.js';
-import { styles } from './styles.js';
 import { collectTestResults } from './collectTestResults.js';
+import { setupMocha } from './mochaSetup.js';
 
 sessionStarted();
 
@@ -18,18 +18,7 @@ const baseURI = (base || window.location).href;
   const errors: TestResultError[] = [];
 
   const { testFile, debug, testFrameworkConfig } = await getConfig();
-  const div = document.createElement('div');
-  div.id = 'mocha';
-  document.body.appendChild(div);
-
-  if (debug) {
-    const styleElement = document.createElement('style');
-    styleElement.textContent = styles;
-    document.head.appendChild(styleElement);
-  }
-
-  const userOptions = typeof testFrameworkConfig === 'object' ? testFrameworkConfig : {};
-  mocha.setup({ ui: 'bdd', allowUncaught: false, ...userOptions });
+  setupMocha(debug, testFrameworkConfig);
 
   await import(new URL(testFile, baseURI).href).catch(error => {
     console.error(error);

--- a/packages/test-runner-mocha/src/mochaSetup.ts
+++ b/packages/test-runner-mocha/src/mochaSetup.ts
@@ -1,0 +1,32 @@
+import { styles } from './styles.js';
+
+const mocha = (window as any).mocha as BrowserMocha;
+const BaseReporter = (mocha as any).Mocha.reporters.Base;
+class SilentReporter extends BaseReporter {}
+
+export function setupMocha(debug: boolean, testFrameworkConfig?: unknown) {
+  const userOptions = typeof testFrameworkConfig === 'object' ? testFrameworkConfig : {};
+  const mochaOptions = {
+    ui: 'bdd' as const,
+    allowUncaught: false,
+    reporter: 'spec',
+    ...userOptions,
+  };
+
+  if (!debug) {
+    // in non-debug mode the user is not viewing the browser and so we avoid reporting for speed
+    mochaOptions.reporter = SilentReporter as any;
+  }
+
+  if (mochaOptions.reporter === 'html') {
+    const div = document.createElement('div');
+    div.id = 'mocha';
+    document.body.appendChild(div);
+
+    const style = document.createElement('style');
+    style.innerText = styles;
+    document.head.appendChild(style);
+  }
+
+  mocha.setup(mochaOptions);
+}

--- a/packages/test-runner-mocha/src/standalone.ts
+++ b/packages/test-runner-mocha/src/standalone.ts
@@ -6,24 +6,15 @@ import {
 } from '../../test-runner-core/browser/session.js';
 import '../../../node_modules/mocha/mocha.js';
 import { collectTestResults } from './collectTestResults.js';
+import { setupMocha } from './mochaSetup.js';
 
 const mocha = (window as any).mocha as BrowserMocha;
-const BaseReporter = (mocha as any).Mocha.reporters.Base;
-class QuietReporter extends BaseReporter {}
 
 sessionStarted();
 
 export async function runTests(testFn: () => unknown | Promise<unknown>) {
-  const { testFrameworkConfig } = await getConfig();
-
-  // setup mocha
-  const userOptions = typeof testFrameworkConfig === 'object' ? testFrameworkConfig : {};
-  mocha.setup({
-    ui: 'bdd',
-    allowUncaught: false,
-    reporter: QuietReporter as any,
-    ...userOptions,
-  });
+  const { debug, testFrameworkConfig } = await getConfig();
+  setupMocha(debug, testFrameworkConfig);
 
   // setup the tests
   try {


### PR DESCRIPTION
## What I did

Disabled the in-browser reporter during regular test runs, improving performance.

Defaulted to the spec reporter instead of the HTML reporter in the browser when debugging. This avoids manipulating the testing environment by default.

You can opt back into the old behavior by setting the mocha config:

```js
export default {
  testFramework: {
    config: { reporter: 'html' },
  },
};
```

Fixes https://github.com/modernweb-dev/web/issues/720