### PR TITLE
fix(rollup-plugin-copy): adds copied files to watch list

### DIFF
--- a/.changeset/odd-crabs-nail.md
+++ b/.changeset/odd-crabs-nail.md
@@ -1,0 +1,5 @@
+---
+"@web/rollup-plugin-copy": minor
+---
+
+adds copied files to watch list

--- a/packages/rollup-plugin-copy/src/copy.js
+++ b/packages/rollup-plugin-copy/src/copy.js
@@ -22,17 +22,18 @@ const { patternsToFiles } = require('./patternsToFiles.js');
  */
 function copy({ patterns = [], rootDir = process.cwd() }) {
   const resolvedRootDir = path.resolve(rootDir);
+  /** @type {string[]} */
+  let filesToCopy = [];
   return {
     name: '@web/rollup-plugin-copy',
     async buildStart() {
-      const files = await patternsToFiles(patterns, rootDir);
-      for (const filePath of files) {
+      filesToCopy = await patternsToFiles(patterns, rootDir);
+      for (const filePath of filesToCopy) {
         this.addWatchFile(filePath);
       }
     },
     async generateBundle() {
-      const files = await patternsToFiles(patterns, rootDir);
-      for (const filePath of files) {
+      for (const filePath of filesToCopy) {
         const fileName = path.relative(resolvedRootDir, filePath);
         this.emitFile({
           type: 'asset',

--- a/packages/rollup-plugin-copy/src/copy.js
+++ b/packages/rollup-plugin-copy/src/copy.js
@@ -24,6 +24,12 @@ function copy({ patterns = [], rootDir = process.cwd() }) {
   const resolvedRootDir = path.resolve(rootDir);
   return {
     name: '@web/rollup-plugin-copy',
+    async buildStart() {
+      const files = await patternsToFiles(patterns, rootDir);
+      for (const filePath of files) {
+        this.addWatchFile(filePath);
+      }
+    },
     async generateBundle() {
       const files = await patternsToFiles(patterns, rootDir);
       for (const filePath of files) {


### PR DESCRIPTION
Adds the copied files to the rollup watch list, this enables 'watched' rollup bundle scripts.