### PR TITLE
feat(test-runner): allow configuring test runner HTML per group

### DIFF
--- a/.changeset/shiny-gorillas-smash.md
+++ b/.changeset/shiny-gorillas-smash.md
@@ -1,0 +1,6 @@
+---
+'@web/test-runner': patch
+'@web/test-runner-core': patch
+---
+
+added option to configure test runner HTML per group

--- a/integration/test-runner/index.ts
+++ b/integration/test-runner/index.ts
@@ -1,22 +1,28 @@
 import { BrowserLauncher, TestRunnerCoreConfig } from '@web/test-runner-core';
 import { runBasicTest } from './tests/basic/runBasicTest';
+import { runConfigGroupsTest } from './tests/config-groups/runConfigGroupsTest';
 import { runParallelTest } from './tests/parallel/runParallelTest';
 import { runTestFailureTest } from './tests/test-failure/runTestFailureTest';
 import { runLocationChangeTest } from './tests/location-change/runLocationChangeTest';
 
-interface Tests {
-  basic?: boolean;
-  parallel?: boolean;
-  testFailure?: boolean;
-  locationChanged?: boolean;
+export interface Tests {
+  basic: boolean;
+  groups: boolean;
+  parallel: boolean;
+  testFailure: boolean;
+  locationChanged: boolean;
 }
 
 export function runIntegrationTests(
   createConfig: () => Partial<TestRunnerCoreConfig> & { browsers: BrowserLauncher[] },
-  tests: Tests = {},
+  tests: Tests,
 ) {
   if (tests.basic !== false) {
     runBasicTest(createConfig());
+  }
+
+  if (tests.groups !== false) {
+    runConfigGroupsTest(createConfig());
   }
 
   if (tests.parallel !== false) {

--- a/integration/test-runner/tests/config-groups/browser-tests/test-runner-html-a.test.js
+++ b/integration/test-runner/tests/config-groups/browser-tests/test-runner-html-a.test.js
@@ -1,0 +1,7 @@
+import { expect } from '../../../../../node_modules/@esm-bundle/chai/esm/chai.js';
+
+describe('basic test', () => {
+  it('works', () => {
+    expect(window.__group__).to.equal('a');
+  });
+});

--- a/integration/test-runner/tests/config-groups/browser-tests/test-runner-html-b.test.js
+++ b/integration/test-runner/tests/config-groups/browser-tests/test-runner-html-b.test.js
@@ -1,0 +1,7 @@
+import { expect } from '../../../../../node_modules/@esm-bundle/chai/esm/chai.js';
+
+describe('basic test', () => {
+  it('works', () => {
+    expect(window.__group__).to.equal('b');
+  });
+});

--- a/integration/test-runner/tests/config-groups/runConfigGroupsTest.ts
+++ b/integration/test-runner/tests/config-groups/runConfigGroupsTest.ts
@@ -1,0 +1,44 @@
+import {
+  BrowserLauncher,
+  TestRunnerCoreConfig,
+  TestRunnerGroupConfig,
+} from '@web/test-runner-core';
+import { runTests } from '@web/test-runner-core/test-helpers';
+import { legacyPlugin } from '@web/dev-server-legacy';
+import { resolve } from 'path';
+import { expect } from 'chai';
+
+export function runConfigGroupsTest(
+  config: Partial<TestRunnerCoreConfig> & { browsers: BrowserLauncher[] },
+) {
+  describe('groups', async function () {
+    it('can create a test runner html per group', async () => {
+      const groupConfigs: TestRunnerGroupConfig[] = [
+        {
+          name: 'a',
+          testRunnerHtml: path =>
+            `<html><body><script>window.__group__ = "a";</script><script type="module" src=${path}></script></body></html>`,
+          files: [resolve(__dirname, 'browser-tests', 'test-runner-html-a.test.js')],
+        },
+        {
+          name: 'b',
+          testRunnerHtml: path =>
+            `<html><body><script>window.__group__ = "b";</script><script type="module" src=${path}></script></body></html>`,
+          files: [resolve(__dirname, 'browser-tests', 'test-runner-html-b.test.js')],
+        },
+      ];
+      const result = await runTests(
+        {
+          ...config,
+          plugins: [...(config.plugins ?? []), legacyPlugin()],
+        },
+        groupConfigs,
+      );
+
+      expect(result.sessions.every(s => s.passed)).to.equal(
+        true,
+        'All sessions should have passed',
+      );
+    });
+  });
+}

--- a/packages/test-runner-browserstack/test-remote/browserstackLauncher.test.ts
+++ b/packages/test-runner-browserstack/test-remote/browserstackLauncher.test.ts
@@ -23,8 +23,8 @@ const sharedCapabilities = {
 describe('test-runner-browserstack', function () {
   this.timeout(200000);
 
-  runIntegrationTests(
-    () => ({
+  function createConfig() {
+    return {
       browserStartTimeout: 1000 * 60 * 2,
       testsStartTimeout: 1000 * 60 * 2,
       testsFinishTimeout: 1000 * 60 * 2,
@@ -57,7 +57,14 @@ describe('test-runner-browserstack', function () {
           },
         }),
       ],
-    }),
-    { testFailure: false, parallel: false, locationChanged: false },
-  );
+    };
+  }
+
+  runIntegrationTests(createConfig, {
+    basic: true,
+    groups: false,
+    parallel: false,
+    testFailure: false,
+    locationChanged: false,
+  });
 });

--- a/packages/test-runner-chrome/test/chromeLauncher.test.ts
+++ b/packages/test-runner-chrome/test/chromeLauncher.test.ts
@@ -4,7 +4,17 @@ import { chromeLauncher } from '../src/index';
 describe('test-runner-chrome', function testRunnerChrome() {
   this.timeout(20000);
 
-  runIntegrationTests(() => ({
-    browsers: [chromeLauncher()],
-  }));
+  function createConfig() {
+    return {
+      browsers: [chromeLauncher()],
+    };
+  }
+
+  runIntegrationTests(createConfig, {
+    basic: true,
+    groups: true,
+    parallel: true,
+    testFailure: true,
+    locationChanged: true,
+  });
 });

--- a/packages/test-runner-core/src/config/TestRunnerGroupConfig.ts
+++ b/packages/test-runner-core/src/config/TestRunnerGroupConfig.ts
@@ -1,8 +1,14 @@
 import { BrowserLauncher } from '../browser-launcher/BrowserLauncher';
+import { TestRunnerCoreConfig } from './TestRunnerCoreConfig';
 
 export interface TestRunnerGroupConfig {
   name: string;
   configFilePath?: string;
   files?: string | string[];
   browsers?: BrowserLauncher[];
+  testRunnerHtml?: (
+    testRunnerImport: string,
+    config: TestRunnerCoreConfig,
+    group: TestRunnerGroupConfig,
+  ) => string;
 }

--- a/packages/test-runner-core/src/runner/createSessionGroups.ts
+++ b/packages/test-runner-core/src/runner/createSessionGroups.ts
@@ -35,6 +35,7 @@ export function createTestSessions(
     const mergedGroupConfig: GroupConfigWithoutOptionals = {
       name: groupConfig.name,
       configFilePath: groupConfig.configFilePath,
+      testRunnerHtml: config.testRunnerHtml,
       browsers: config.browsers,
       files: config.files,
     };
@@ -49,6 +50,10 @@ export function createTestSessions(
 
     if (groupConfig.files != null) {
       mergedGroupConfig.files = groupConfig.files;
+    }
+
+    if (groupConfig.testRunnerHtml != null) {
+      mergedGroupConfig.testRunnerHtml = groupConfig.testRunnerHtml;
     }
 
     groups.push(mergedGroupConfig);
@@ -78,6 +83,7 @@ export function createTestSessions(
       name: group.name,
       browsers: group.browsers,
       testFiles: testFilesForGroup,
+      testRunnerHtml: group.testRunnerHtml,
       sessionIds: [],
     };
 

--- a/packages/test-runner-core/src/test-session/TestSessionGroup.ts
+++ b/packages/test-runner-core/src/test-session/TestSessionGroup.ts
@@ -1,7 +1,15 @@
 import { BrowserLauncher } from '../browser-launcher/BrowserLauncher';
+import { TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig';
+import { TestRunnerGroupConfig } from '../config/TestRunnerGroupConfig';
+
 export interface TestSessionGroup {
   name: string;
   testFiles: string[];
   browsers: BrowserLauncher[];
   sessionIds: string[];
+  testRunnerHtml?: (
+    testRunnerImport: string,
+    config: TestRunnerCoreConfig,
+    group: TestRunnerGroupConfig,
+  ) => string;
 }

--- a/packages/test-runner-playwright/test/playwrightLauncher.test.ts
+++ b/packages/test-runner-playwright/test/playwrightLauncher.test.ts
@@ -5,9 +5,17 @@ import { playwrightLauncher } from '../src/index';
 describe('test-runner-playwright chromium', function testRunnerPlaywright() {
   this.timeout(100000);
 
-  runIntegrationTests(() => ({
-    browsers: [playwrightLauncher({ product: 'chromium' })],
-  }));
+  function createConfig() {
+    return { browsers: [playwrightLauncher({ product: 'chromium' })] };
+  }
+
+  runIntegrationTests(createConfig, {
+    basic: true,
+    groups: true,
+    parallel: true,
+    testFailure: true,
+    locationChanged: true,
+  });
 });
 
 // we don't run all tests in the windows CI
@@ -15,37 +23,55 @@ if (os.platform() !== 'win32') {
   describe('test-runner-playwright webkit', function testRunnerPlaywright() {
     this.timeout(100000);
 
-    runIntegrationTests(() => ({
-      browsers: [playwrightLauncher({ product: 'webkit' })],
-    }));
+    function createConfig() {
+      return { browsers: [playwrightLauncher({ product: 'webkit' })] };
+    }
+
+    runIntegrationTests(createConfig, {
+      basic: true,
+      groups: true,
+      parallel: true,
+      testFailure: true,
+      locationChanged: true,
+    });
   });
 
   describe('test-runner-playwright firefox', function testRunnerPlaywright() {
     this.timeout(100000);
 
-    runIntegrationTests(
-      () => ({
-        browsers: [playwrightLauncher({ product: 'firefox' })],
-      }),
-      {
-        // firefox doesn't like parallel in the CI
-        parallel: false,
-      },
-    );
+    function createConfig() {
+      return { browsers: [playwrightLauncher({ product: 'firefox' })] };
+    }
+
+    runIntegrationTests(createConfig, {
+      basic: true,
+      groups: true,
+      // firefox doesn't like parallel in the CI
+      parallel: false,
+      testFailure: true,
+      locationChanged: true,
+    });
   });
 
   describe('test-runner-playwright all', function testRunnerPlaywright() {
     this.timeout(100000);
 
-    runIntegrationTests(
-      () => ({
+    function createConfig() {
+      return {
         browsers: [
           playwrightLauncher({ product: 'chromium' }),
           playwrightLauncher({ product: 'firefox' }),
           ...(os.platform() !== 'win32' ? [playwrightLauncher({ product: 'webkit' })] : []),
         ],
-      }),
-      { parallel: false, testFailure: false, locationChanged: false },
-    );
+      };
+    }
+
+    runIntegrationTests(createConfig, {
+      basic: true,
+      groups: true,
+      parallel: false,
+      testFailure: false,
+      locationChanged: false,
+    });
   });
 }

--- a/packages/test-runner-puppeteer/test/puppeteerLauncher.test.ts
+++ b/packages/test-runner-puppeteer/test/puppeteerLauncher.test.ts
@@ -4,7 +4,17 @@ import { puppeteerLauncher } from '../src/index';
 describe('test-runner-puppeteer', function testRunnerPuppeteer() {
   this.timeout(20000);
 
-  runIntegrationTests(() => ({
-    browsers: [puppeteerLauncher()],
-  }));
+  function createConfig() {
+    return {
+      browsers: [puppeteerLauncher()],
+    };
+  }
+
+  runIntegrationTests(createConfig, {
+    basic: true,
+    groups: true,
+    parallel: true,
+    testFailure: true,
+    locationChanged: true,
+  });
 });

--- a/packages/test-runner-saucelabs/test-remote/saucelabsLauncher.test.ts
+++ b/packages/test-runner-saucelabs/test-remote/saucelabsLauncher.test.ts
@@ -27,8 +27,8 @@ const sharedCapabilities = {
 describe('test-runner-saucelabs', function () {
   this.timeout(200000);
 
-  runIntegrationTests(
-    () => ({
+  function createConfig() {
+    return {
       browserStartTimeout: 1000 * 60 * 2,
       testsStartTimeout: 1000 * 60 * 2,
       testsFinishTimeout: 1000 * 60 * 2,
@@ -52,7 +52,14 @@ describe('test-runner-saucelabs', function () {
           platformName: 'Windows 7',
         }),
       ],
-    }),
-    { testFailure: false, parallel: false, locationChanged: false },
-  );
+    };
+  }
+
+  runIntegrationTests(createConfig, {
+    basic: true,
+    groups: false,
+    parallel: false,
+    testFailure: false,
+    locationChanged: false,
+  });
 });

--- a/packages/test-runner-selenium/test/seleniumLauncher.test.ts
+++ b/packages/test-runner-selenium/test/seleniumLauncher.test.ts
@@ -40,25 +40,35 @@ if (os.platform() !== 'win32') {
   describe('test-runner-selenium', function testRunnerSelenium() {
     this.timeout(50000);
 
-    runIntegrationTests(() => ({
-      browserStartTimeout: 1000 * 60 * 2,
-      testsStartTimeout: 1000 * 60 * 2,
-      testsFinishTimeout: 1000 * 60 * 2,
-      browsers: [
-        seleniumLauncher({
-          driverBuilder: new Builder()
-            .forBrowser('chrome')
-            .setChromeOptions(new ChromeOptions().headless())
-            .usingServer('http://localhost:4444/wd/hub'),
-        }),
-        seleniumLauncher({
-          driverBuilder: new Builder()
-            .forBrowser('firefox')
-            .setFirefoxOptions(new FirefoxOptions().headless())
-            .usingServer('http://localhost:4444/wd/hub'),
-        }),
-      ],
-    }));
+    function createConfig() {
+      return {
+        browserStartTimeout: 1000 * 60 * 2,
+        testsStartTimeout: 1000 * 60 * 2,
+        testsFinishTimeout: 1000 * 60 * 2,
+        browsers: [
+          seleniumLauncher({
+            driverBuilder: new Builder()
+              .forBrowser('chrome')
+              .setChromeOptions(new ChromeOptions().headless())
+              .usingServer('http://localhost:4444/wd/hub'),
+          }),
+          seleniumLauncher({
+            driverBuilder: new Builder()
+              .forBrowser('firefox')
+              .setFirefoxOptions(new FirefoxOptions().headless())
+              .usingServer('http://localhost:4444/wd/hub'),
+          }),
+        ],
+      };
+    }
+
+    runIntegrationTests(createConfig, {
+      basic: true,
+      groups: true,
+      parallel: true,
+      testFailure: true,
+      locationChanged: true,
+    });
   });
 
   after(() => {


### PR DESCRIPTION
## What I did

Added the ability to configure the test runner HTML per test group. This is useful for running the same tests multiple times in different HTML pages, for instance loading different polyfils.

This fixes a part of https://github.com/modernweb-dev/web/issues/678
