### PR TITLE
[dev-server-legacy] Only transform modules to system js

### DIFF
--- a/.changeset/short-months-look.md
+++ b/.changeset/short-months-look.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner': patch
+---
+
+ensure user plugins are run after builtin plugins

--- a/.changeset/short-months-look.md
+++ b/.changeset/short-months-look.md
@@ -2,4 +2,4 @@
 '@web/test-runner': patch
 ---
 
-ensure user plugins are run after builtin plugins
+run user plugins after builtin plugins

--- a/.changeset/smart-spiders-smash.md
+++ b/.changeset/smart-spiders-smash.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server-legacy': patch
+---
+
+only transform modules to systemjs

--- a/.changeset/sweet-starfishes-laugh.md
+++ b/.changeset/sweet-starfishes-laugh.md
@@ -1,0 +1,6 @@
+---
+'@web/dev-server-core': patch
+'@web/dev-server': patch
+---
+
+ensure user plugins are run after builtin plugins

--- a/packages/dev-server-core/src/plugins/transformModuleImportsPlugin.ts
+++ b/packages/dev-server-core/src/plugins/transformModuleImportsPlugin.ts
@@ -127,7 +127,6 @@ export async function transformImports(
 
     if (dynamicImportIndex === -1) {
       // static import
-
       const importSpecifier = code.substring(start, end);
       const lines = code.slice(0, end).split('\n');
       const line = lines.length;
@@ -258,6 +257,7 @@ export function transformModuleImportsPlugin(plugins: Plugin[], rootDir: string)
             predicates.NOT(predicates.hasAttr('src')),
           ),
         );
+        let transformed = false;
 
         for (const node of inlineModuleNodes) {
           const code = getTextContent(node);
@@ -267,10 +267,15 @@ export function transformModuleImportsPlugin(plugins: Plugin[], rootDir: string)
             rootDir,
             importPlugins,
           );
-          setTextContent(node, resolvedCode);
+          if (code !== resolvedCode) {
+            setTextContent(node, resolvedCode);
+            transformed = true;
+          }
         }
 
-        return { body: serializeHtml(documentAst) };
+        if (transformed) {
+          return { body: serializeHtml(documentAst) };
+        }
       }
     },
   };

--- a/packages/dev-server-core/src/server/addPlugins.ts
+++ b/packages/dev-server-core/src/server/addPlugins.ts
@@ -1,23 +1,23 @@
 import { DevServerCoreConfig } from '../DevServerCoreConfig';
-import { Plugin } from '../Plugin';
 import { transformModuleImportsPlugin } from '../plugins/transformModuleImportsPlugin';
 import { webSocketsPlugin } from '../web-sockets/webSocketsPlugin';
 import { mimeTypesPlugin } from '../plugins/mimeTypesPlugin';
 
-export function createPlugins(config: DevServerCoreConfig) {
-  const plugins: Plugin[] = [];
+export function addPlugins(config: DevServerCoreConfig) {
+  if (!config.plugins) {
+    config.plugins = [];
+  }
 
   if (config.mimeTypes && Object.keys(config.mimeTypes).length > 0) {
-    plugins.push(mimeTypesPlugin(config.mimeTypes));
+    config.plugins.unshift(mimeTypesPlugin(config.mimeTypes));
   }
 
   if (config.injectWebSocket && config.plugins?.some(pl => pl.injectWebSocket)) {
-    plugins.push(webSocketsPlugin());
+    config.plugins.unshift(webSocketsPlugin());
   }
 
   if (config.plugins?.some(pl => 'resolveImport' in pl || 'transformImport' in pl)) {
-    plugins.push(transformModuleImportsPlugin(config.plugins, config.rootDir));
+    // transform module imports must happen after all other plugins did their regular transforms
+    config.plugins.push(transformModuleImportsPlugin(config.plugins, config.rootDir));
   }
-
-  return plugins;
 }

--- a/packages/dev-server-core/src/server/createPlugins.ts
+++ b/packages/dev-server-core/src/server/createPlugins.ts
@@ -11,12 +11,12 @@ export function createPlugins(config: DevServerCoreConfig) {
     plugins.push(mimeTypesPlugin(config.mimeTypes));
   }
 
-  if (config.plugins?.some(pl => 'resolveImport' in pl || 'transformImport' in pl)) {
-    plugins.push(transformModuleImportsPlugin(config.plugins, config.rootDir));
-  }
-
   if (config.injectWebSocket && config.plugins?.some(pl => pl.injectWebSocket)) {
     plugins.push(webSocketsPlugin());
+  }
+
+  if (config.plugins?.some(pl => 'resolveImport' in pl || 'transformImport' in pl)) {
+    plugins.push(transformModuleImportsPlugin(config.plugins, config.rootDir));
   }
 
   return plugins;

--- a/packages/dev-server-core/src/server/createServer.ts
+++ b/packages/dev-server-core/src/server/createServer.ts
@@ -9,7 +9,7 @@ import net, { Server, Socket, ListenOptions } from 'net';
 import { DevServerCoreConfig } from '../DevServerCoreConfig';
 import { createMiddleware } from './createMiddleware';
 import { Logger } from '../logger/Logger';
-import { createPlugins } from './createPlugins';
+import { addPlugins } from './addPlugins';
 
 /**
  * A request handler that returns a 301 HTTP Redirect to the same location as the original
@@ -28,11 +28,19 @@ function httpsRedirect(req: IncomingMessage, res: ServerResponse) {
 export function createServer(cfg: DevServerCoreConfig, logger: Logger, fileWatcher: FSWatcher) {
   const app = new Koa();
 
-  const plugins = createPlugins(cfg);
-  if (!cfg.plugins) {
-    cfg.plugins = [];
+  addPlugins(cfg);
+
+  // special case the legacy plugin, if it is given make sure the resolve module imports plugin
+  // runs before the legacy plugin because it compiles away module syntax. ideally we have a
+  // generic API for this, but we need to design that a bit more first
+  const indexOfLegacy = cfg.plugins!.findIndex(p => p.name === 'legacy');
+  let indexOfResolve = cfg.plugins!.findIndex(p => p.name === 'resolve-module-imports');
+  if (indexOfLegacy !== -1 && indexOfResolve !== -1) {
+    const legacy = cfg.plugins!.splice(indexOfLegacy, 1)[0];
+    // recompute after splicing
+    indexOfResolve = cfg.plugins!.findIndex(p => p.name === 'resolve-module-imports');
+    cfg.plugins!.splice(indexOfResolve, 1, cfg.plugins![indexOfResolve], legacy);
   }
-  cfg.plugins.unshift(...plugins);
 
   const middleware = createMiddleware(cfg, logger, fileWatcher);
   for (const m of middleware) {

--- a/packages/dev-server-core/src/server/createServer.ts
+++ b/packages/dev-server-core/src/server/createServer.ts
@@ -32,19 +32,7 @@ export function createServer(cfg: DevServerCoreConfig, logger: Logger, fileWatch
   if (!cfg.plugins) {
     cfg.plugins = [];
   }
-  cfg.plugins.push(...plugins);
-
-  // special case the legacy plugin, if it is given make sure the resolve module imports plugin
-  // runs before the legacy plugin because it compiles away module syntax. ideally we have a
-  // generic API for this, but we need to design that a bit more first
-  const indexOfLegacy = cfg.plugins.findIndex(p => p.name === 'legacy');
-  let indexOfResolve = cfg.plugins.findIndex(p => p.name === 'resolve-module-imports');
-  if (indexOfLegacy !== -1 && indexOfResolve !== -1) {
-    const legacy = cfg.plugins.splice(indexOfLegacy, 1)[0];
-    // recompute after splicing
-    indexOfResolve = cfg.plugins.findIndex(p => p.name === 'resolve-module-imports');
-    cfg.plugins.splice(indexOfResolve, 1, cfg.plugins[indexOfResolve], legacy);
-  }
+  cfg.plugins.unshift(...plugins);
 
   const middleware = createMiddleware(cfg, logger, fileWatcher);
   for (const m of middleware) {

--- a/packages/dev-server-import-maps/test/resolving.test.ts
+++ b/packages/dev-server-import-maps/test/resolving.test.ts
@@ -318,7 +318,7 @@ describe('resolving imports', () => {
     });
 
     const text = await fetchText(`${host}/index.html`);
-    expectIncludes(text, '<html><head></head><body><script src="./app.js"></script></body></html>');
+    expectIncludes(text, '<html><body><script src="./app.js"></script></body></html>');
 
     server.stop();
   });

--- a/packages/dev-server-legacy/package.json
+++ b/packages/dev-server-legacy/package.json
@@ -45,6 +45,7 @@
     "@babel/core": "^7.10.5",
     "@babel/plugin-proposal-dynamic-import": "^7.10.4",
     "@babel/plugin-syntax-class-properties": "^7.10.4",
+    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-syntax-import-meta": "^7.10.4",
     "@babel/plugin-syntax-numeric-separator": "^7.10.4",
     "@babel/plugin-transform-modules-systemjs": "^7.10.5",

--- a/packages/dev-server-legacy/src/babelTransform.ts
+++ b/packages/dev-server-legacy/src/babelTransform.ts
@@ -1,6 +1,6 @@
 import { transformAsync, TransformOptions } from '@babel/core';
 
-export const config: TransformOptions = {
+export const es5Config: TransformOptions = {
   caller: {
     name: '@web/dev-server-legacy',
     supportsStaticESM: true,
@@ -28,6 +28,14 @@ export const config: TransformOptions = {
     require.resolve('@babel/plugin-syntax-import-meta'),
     require.resolve('@babel/plugin-syntax-class-properties'),
     require.resolve('@babel/plugin-syntax-numeric-separator'),
+    require.resolve('@babel/plugin-syntax-dynamic-import'),
+  ],
+};
+
+export const systemJsConfig: TransformOptions = {
+  ...es5Config,
+  plugins: [
+    ...(es5Config.plugins ?? []),
     require.resolve('@babel/plugin-proposal-dynamic-import'),
     require.resolve('@babel/plugin-transform-modules-systemjs'),
     // systemjs adds template literals, we do systemjs after (potential)
@@ -36,7 +44,7 @@ export const config: TransformOptions = {
   ],
 };
 
-export async function babelTransform(filename: string, source: string) {
+export async function babelTransform(filename: string, source: string, config: TransformOptions) {
   const largeFile = source.length > 100000;
   const result = await transformAsync(source, {
     filename,

--- a/packages/dev-server-legacy/src/constants.ts
+++ b/packages/dev-server-legacy/src/constants.ts
@@ -1,0 +1,1 @@
+export const PARAM_TRANSFORM_SYSTEMJS = 'systemjs';

--- a/packages/dev-server-legacy/src/injectPolyfillsLoader.ts
+++ b/packages/dev-server-legacy/src/injectPolyfillsLoader.ts
@@ -9,6 +9,7 @@ import {
   GeneratedFile,
   File,
 } from 'polyfills-loader';
+import { PARAM_TRANSFORM_SYSTEMJS } from './constants';
 import { findJsScripts } from './findJsScripts';
 
 function findScripts(indexUrl: string, documentAst: DocumentAst) {
@@ -22,13 +23,17 @@ function findScripts(indexUrl: string, documentAst: DocumentAst) {
     let src = getAttribute(scriptNode, 'src');
 
     if (!src) {
-      src = `inline-script-${i}.js?source=${encodeURIComponent(indexUrl)}`;
+      const suffix = type === 'module' ? `&${PARAM_TRANSFORM_SYSTEMJS}=true` : '';
+      src = `inline-script-${i}.js?source=${encodeURIComponent(indexUrl)}${suffix}`;
       inlineScripts.push({
         path: src,
         type,
         content: getTextContent(scriptNode),
       });
       inlineScriptNodes.push(scriptNode);
+    } else if (type === 'module') {
+      const separator = src.includes('?') ? '&' : '?';
+      src = `${src}${separator}${PARAM_TRANSFORM_SYSTEMJS}=true`;
     }
 
     files.push({

--- a/packages/dev-server/src/config/parseConfig.ts
+++ b/packages/dev-server/src/config/parseConfig.ts
@@ -73,7 +73,8 @@ export async function parseConfig(
 
   if (finalConfig.nodeResolve) {
     const userOptions = typeof config.nodeResolve === 'object' ? config.nodeResolve : undefined;
-    finalConfig.plugins!.unshift(
+    // do node resolve after user plugins, to allow user plugins to resolve imports
+    finalConfig.plugins!.push(
       nodeResolvePlugin(finalConfig.rootDir!, config.preserveSymlinks, userOptions),
     );
   }

--- a/packages/dev-server/src/config/parseConfig.ts
+++ b/packages/dev-server/src/config/parseConfig.ts
@@ -71,20 +71,20 @@ export async function parseConfig(
     finalConfig.port = await getPortPromise({ port: 8000 });
   }
 
-  // map flags to plugin
-  if (finalConfig?.esbuildTarget) {
-    finalConfig.plugins!.push(esbuildPlugin(finalConfig.esbuildTarget));
-  }
-
   if (finalConfig.nodeResolve) {
     const userOptions = typeof config.nodeResolve === 'object' ? config.nodeResolve : undefined;
-    finalConfig.plugins!.push(
+    finalConfig.plugins!.unshift(
       nodeResolvePlugin(finalConfig.rootDir!, config.preserveSymlinks, userOptions),
     );
   }
 
+  // map flags to plugin
+  if (finalConfig?.esbuildTarget) {
+    finalConfig.plugins!.unshift(esbuildPlugin(finalConfig.esbuildTarget));
+  }
+
   if (finalConfig.watch) {
-    finalConfig.plugins!.push(watchPlugin());
+    finalConfig.plugins!.unshift(watchPlugin());
   }
 
   return finalConfig;

--- a/packages/test-runner/src/startTestRunner.ts
+++ b/packages/test-runner/src/startTestRunner.ts
@@ -201,25 +201,25 @@ export async function startTestRunner(options: StartTestRunnerOptions = {}) {
       config.plugins = [];
     }
 
-    if (config.esbuildTarget) {
-      config.plugins.push(esbuildPlugin(config.esbuildTarget));
-    }
-
-    if (config.nodeResolve) {
-      const userOptions = typeof config.nodeResolve === 'object' ? config.nodeResolve : undefined;
-      config.plugins!.push(nodeResolvePlugin(rootDir, config.preserveSymlinks, userOptions));
-    }
-
     // plugin with a noop transformImport hook, this will cause the dev server to analyze modules and
     // catch syntax errors. this way we still report syntax errors when the user has no flags enabled
-    config.plugins.push({
+    config.plugins.unshift({
       name: 'syntax-checker',
       transformImport() {
         return undefined;
       },
     });
 
-    config.plugins.push(setViewportPlugin(), emulateMediaPlugin(), setUserAgentPlugin());
+    if (config.nodeResolve) {
+      const userOptions = typeof config.nodeResolve === 'object' ? config.nodeResolve : undefined;
+      config.plugins!.unshift(nodeResolvePlugin(rootDir, config.preserveSymlinks, userOptions));
+    }
+
+    if (config.esbuildTarget) {
+      config.plugins.unshift(esbuildPlugin(config.esbuildTarget));
+    }
+
+    config.plugins.unshift(setViewportPlugin(), emulateMediaPlugin(), setUserAgentPlugin());
 
     const validatedConfig = validateCoreConfig<FullTestRunnerConfig>(config);
     return defaultStartTestRunner(validatedConfig, groupConfigs, { autoExitProcess });


### PR DESCRIPTION
## What I did

1. Only transform es modules to systemjs
2. Ensure user plugins are always run after builtin plugins

Fixes https://github.com/modernweb-dev/web/issues/726
Fixes https://github.com/modernweb-dev/web/issues/725