### PR TITLE
Feature/javascript start test runner

### DIFF
--- a/packages/test-runner/src/index.ts
+++ b/packages/test-runner/src/index.ts
@@ -1,4 +1,4 @@
 export * from '@web/test-runner-core';
 export { chromeLauncher } from '@web/test-runner-chrome';
 export { defaultReporter } from '@web/test-runner-cli';
-export { TestRunnerConfig, startTestRunner } from './startTestRunner';
+export { TestRunnerConfig, startTestRunner, TestRunnerOptions } from './startTestRunner';

--- a/packages/test-runner/src/index.ts
+++ b/packages/test-runner/src/index.ts
@@ -1,4 +1,9 @@
 export * from '@web/test-runner-core';
 export { chromeLauncher } from '@web/test-runner-chrome';
 export { defaultReporter } from '@web/test-runner-cli';
-export { TestRunnerConfig, startTestRunner, TestRunnerOptions } from './startTestRunner';
+export {
+  TestRunnerConfig,
+  startTestRunner,
+  TestRunnerOptions,
+  startTestRunnerWithOptions,
+} from './startTestRunner';


### PR DESCRIPTION
I am writing a plugin and would like to be able to start the test runner from javascript instead of using the cli.  

The public export to users outside of this package will exports the startTestRunner method and also a TestRunnerConfig interface. But the startTestRunner does not accept the TestRunnerConfig interface. (It accepts some cli like params).

I re-factored startTestRunner to accept a config object in a backward compatible way. (startTestRunner() and additionally startTestRunnerWithOptions().)  Where startTestRunner reuses the startTestRunnerWithOptions.