### PR TITLE
test(dev-server-core): add test for dynamic import with space

### DIFF
--- a/packages/dev-server-core/test/plugins/transformModuleImportsPlugin.test.ts
+++ b/packages/dev-server-core/test/plugins/transformModuleImportsPlugin.test.ts
@@ -63,6 +63,7 @@ describe('transformImports()', () => {
       [
         'function lazyLoad() { return import("my-module-2"); }',
         'import("my-module");',
+        'import(\n\t"my-module"\n);',
         'import("./local-module.js");',
       ].join('\n'),
       defaultFilePath,
@@ -72,6 +73,7 @@ describe('transformImports()', () => {
     expect(result.split('\n')).to.eql([
       'function lazyLoad() { return import("RESOLVED__my-module-2"); }',
       'import("RESOLVED__my-module");',
+      'import(\n\t"RESOLVED__my-module"\n);',
       'import("RESOLVED__./local-module.js");',
     ]);
   });


### PR DESCRIPTION
This adds a test case which demonstrates an issue where spacing characters within a dynamic import, causes it to not resolve as expected.
In it's current form this is a bug report, with an included test case.

minimal example of https://github.com/elmsln/issues/issues/420