### PR TITLE
docs(dev-server): fix typo

### DIFF
--- a/docs/docs/dev-server/plugins/import-maps.md
+++ b/docs/docs/dev-server/plugins/import-maps.md
@@ -122,7 +122,7 @@ export default {
   plugins: [
     importMapsPlugin({
       inject: {
-        incude: '/pages/*.html',
+        include: '/pages/*.html',
         importMap: {
           imports: { foo: './bar.js' },
         },


### PR DESCRIPTION
## What I did

1. Fixed a typo in `include` key of importMapsPlugin documentation.