### PR TITLE
feat: add coverage failure per type when below threshold

### DIFF
--- a/.changeset/modern-chairs-dream.md
+++ b/.changeset/modern-chairs-dream.md
@@ -1,0 +1,6 @@
+---
+"@web/test-runner-cli": patch
+"@web/test-runner": patch
+---
+
+add coverage failure per type when below threshold

--- a/packages/test-runner-cli/src/reporter/getCodeCoverage.ts
+++ b/packages/test-runner-cli/src/reporter/getCodeCoverage.ts
@@ -27,6 +27,16 @@ export function getCodeCoverage(
     );
   }
 
+  if (!testCoverage.passed && coverageConfig.threshold) {
+    coverageTypes.forEach((type) => {
+      if (testCoverage.summary[type].pct < coverageConfig.threshold![type]) {
+        entries.push(`Coverage for ${type} failed with ${chalk.bold(
+          chalk.red(`${testCoverage.summary[type].pct} %`))} compared to configured ${chalk.bold(`${coverageConfig.threshold![type]} %`)
+          }`);
+      }
+    });
+  }
+
   if (!watch && coverageConfig.report) {
     entries.push(
       `View full coverage report at ${chalk.underline(

--- a/packages/test-runner-cli/src/reporter/getCodeCoverage.ts
+++ b/packages/test-runner-cli/src/reporter/getCodeCoverage.ts
@@ -30,7 +30,7 @@ export function getCodeCoverage(
   if (!testCoverage.passed && coverageConfig.threshold) {
     coverageTypes.forEach((type) => {
       if (testCoverage.summary[type].pct < coverageConfig.threshold![type]) {
-        entries.push(`Coverage for ${type} failed with ${chalk.bold(
+        entries.push(`Coverage for ${chalk.bold(type)} failed with ${chalk.bold(
           chalk.red(`${testCoverage.summary[type].pct} %`))} compared to configured ${chalk.bold(`${coverageConfig.threshold![type]} %`)
           }`);
       }

--- a/packages/test-runner-cli/src/reporter/getCodeCoverage.ts
+++ b/packages/test-runner-cli/src/reporter/getCodeCoverage.ts
@@ -28,11 +28,13 @@ export function getCodeCoverage(
   }
 
   if (!testCoverage.passed && coverageConfig.threshold) {
-    coverageTypes.forEach((type) => {
+    coverageTypes.forEach(type => {
       if (testCoverage.summary[type].pct < coverageConfig.threshold![type]) {
-        entries.push(`Coverage for ${chalk.bold(type)} failed with ${chalk.bold(
-          chalk.red(`${testCoverage.summary[type].pct} %`))} compared to configured ${chalk.bold(`${coverageConfig.threshold![type]} %`)
-          }`);
+        entries.push(
+          `Coverage for ${chalk.bold(type)} failed with ${chalk.bold(
+            chalk.red(`${testCoverage.summary[type].pct} %`),
+          )} compared to configured ${chalk.bold(`${coverageConfig.threshold![type]} %`)}`,
+        );
       }
     });
   }


### PR DESCRIPTION
## What I did

1. Add message when coverage not met for a specific type of threshold as discussed in https://github.com/modernweb-dev/web/issues/688

Tested with: https://github.com/Bubbit/web/blob/example/coverage/packages/test-runner/demo/babel-coverage.config.js#L12

Which results in:
<img width="575" alt="Screenshot 2020-10-25 at 15 42 25" src="https://user-images.githubusercontent.com/7201983/97110290-b5932b00-16d8-11eb-884e-bab11846c828.png">
