### PR TITLE
fix cli command for typescript init

### DIFF
--- a/docs/guides/test-runner/using-typescript.md
+++ b/docs/guides/test-runner/using-typescript.md
@@ -17,7 +17,7 @@ npm i --save-dev @web/test-runner @esm-bundle/chai @types/mocha typescript
 Next, we need to run initialize typescript for our project:
 
 ```
-npx typescript --init
+npx tsc --init
 ```
 
 This will create a `tsconfig.json` for your project in the current working directory.


### PR DESCRIPTION
`npx typescript --init` doesn't work; it is `npx tsc --init`

## What I did

1. fix CLI command in docs
