### PR TITLE
fix(dev-server-storybook): fix loading multiple stories

### DIFF
--- a/.changeset/stale-pandas-boil.md
+++ b/.changeset/stale-pandas-boil.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server-storybook': patch
+---
+
+fix loading multiple stories

--- a/packages/dev-server-storybook/src/html/createPreviewHtml.ts
+++ b/packages/dev-server-storybook/src/html/createPreviewHtml.ts
@@ -121,7 +121,7 @@ export function createPreviewHtml(
         pluginConfig.type
       }.js';
       ${previewImport}
-      ${storyImports.map((s, i) => `import * as stories${i} from '${s}';`)}
+      ${storyImports.map((s, i) => `import * as stories${i} from '${s}';`).join('')}
       configure(() => [${storyImports.map((s, i) => `stories${i}`)}], {}, false);
     </script>
   </body>


### PR DESCRIPTION
## What I did

1. Fixed a bug where loading multiple stories creates invalid syntax
