### PR TITLE
fix(rollup-plugin-html): prevent remote URLs from counting as assets

### DIFF
--- a/.changeset/strong-moles-approve.md
+++ b/.changeset/strong-moles-approve.md
@@ -1,0 +1,5 @@
+---
+"@web/rollup-plugin-html": patch
+---
+
+Prevent remote URLs from counting as assets

--- a/packages/rollup-plugin-html/src/assets/utils.ts
+++ b/packages/rollup-plugin-html/src/assets/utils.ts
@@ -7,13 +7,27 @@ import { serialize } from 'v8';
 const linkRels = ['stylesheet', 'icon', 'manifest', 'apple-touch-icon', 'mask-icon'];
 
 function isAsset(node: Node) {
+  let path = '';
   switch (getTagName(node)) {
     case 'img':
-      return !!getAttribute(node, 'src');
+      path = getAttribute(node, 'src') ?? '';
+      break;
     case 'link':
-      return linkRels.includes(getAttribute(node, 'rel') ?? '');
+      if (linkRels.includes(getAttribute(node, 'rel') ?? '')) {
+        path = getAttribute(node, 'href') ?? '';
+      }
+      break;
     default:
       return false;
+  }
+  if (!path) {
+    return false;
+  }
+  try {
+    new URL(path);
+    return false;
+  } catch (e) {
+    return true;
   }
 }
 

--- a/packages/rollup-plugin-html/test/src/input/extract/extractAssets.test.ts
+++ b/packages/rollup-plugin-html/test/src/input/extract/extractAssets.test.ts
@@ -182,4 +182,22 @@ describe('extractAssets', () => {
     expect(assets[0].content.toString('utf-8').replace(/\s/g, '')).to.equal(':root{color:x;}');
     expect(assets[1].content.toString('utf-8').replace(/\s/g, '')).to.equal(':root{color:blue;}');
   });
+
+  it('does not count remote URLs as assets', () => {
+    const document = parse(`
+      <html>
+        <body>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/">
+        </body>
+      </html>
+    `);
+    const assets = extractAssets({
+      document,
+      htmlFilePath: path.join(rootDir, 'foo', 'index.html'),
+      htmlDir: path.join(rootDir, 'foo'),
+      rootDir,
+    });
+
+    expect(assets.length).to.equal(0);
+  });
 });


### PR DESCRIPTION
## What I did

1. Updated the `isAsset` test to return `false` when the path to the file pointed to a remote location.