### PR TITLE
fix(rollup-plugin-polyfills-loader): correctly preload non-module entrypoints

### DIFF
--- a/.changeset/thin-fireants-scream.md
+++ b/.changeset/thin-fireants-scream.md
@@ -1,0 +1,5 @@
+---
+'@web/rollup-plugin-polyfills-loader': patch
+---
+
+correctly preload non-module entrypoints

--- a/packages/rollup-plugin-polyfills-loader/src/createPolyfillsLoaderConfig.ts
+++ b/packages/rollup-plugin-polyfills-loader/src/createPolyfillsLoaderConfig.ts
@@ -5,7 +5,7 @@ import { ModuleFormat } from 'rollup';
 import { RollupPluginPolyfillsLoaderConfig } from './types';
 import { createError } from './utils';
 
-function formatToFileType(format: ModuleFormat) {
+export function formatToFileType(format: ModuleFormat) {
   switch (format) {
     case 'es':
     case 'esm':
@@ -46,12 +46,11 @@ export function createPolyfillsLoaderConfig(
 
   // @web/rollup-plugin-html outputs `bundle` when there is a single output,
   // otherwise it outputs `bundles`
-
   if (bundle) {
     if (modernOutput || legacyOutput) {
       throw createError(
-        'Options modernOutput or legacyOutput was set, but @open-wc/rollup-plugin-html' +
-          ` did not output multiple builds. Make sure you use html.addOutput('my-output') for each rollup output.`,
+        'Options modernOutput or legacyOutput was set, but @web/rollup-plugin-html' +
+          ` did not output multiple builds. Make sure you use html.api.addOutput('my-output') for each rollup output.`,
       );
     }
 

--- a/packages/rollup-plugin-polyfills-loader/src/rollupPluginPolyfillsLoader.ts
+++ b/packages/rollup-plugin-polyfills-loader/src/rollupPluginPolyfillsLoader.ts
@@ -1,11 +1,11 @@
 import { RollupPluginHtml } from '@web/rollup-plugin-html';
 import { Plugin } from 'rollup';
-import { GeneratedFile, injectPolyfillsLoader, File } from '@web/polyfills-loader';
+import { GeneratedFile, injectPolyfillsLoader, File, fileTypes } from '@web/polyfills-loader';
 import path from 'path';
 
 import { RollupPluginPolyfillsLoaderConfig } from './types';
 import { createError, shouldInjectLoader } from './utils';
-import { createPolyfillsLoaderConfig } from './createPolyfillsLoaderConfig';
+import { createPolyfillsLoaderConfig, formatToFileType } from './createPolyfillsLoaderConfig';
 
 export function polyfillsLoader(pluginOptions: RollupPluginPolyfillsLoaderConfig = {}): Plugin {
   let generatedFiles: GeneratedFile[] | undefined;
@@ -64,10 +64,13 @@ export function polyfillsLoader(pluginOptions: RollupPluginPolyfillsLoaderConfig
         }
         preloaded = [...new Set(preloaded)];
 
+        const type =
+          pluginOptions.modernOutput?.type ?? formatToFileType(bundle?.options.format ?? 'esm');
+        const crossorigin = type === fileTypes.MODULE ? ' crossorigin="anonymous"' : '';
         return htmlString.replace(
           '</head>',
           `\n${preloaded
-            .map(i => `<link rel="preload" href="${i}" as="script" crossorigin="anonymous">\n`)
+            .map(i => `<link rel="preload" href="${i}" as="script"${crossorigin}>\n`)
             .join('')}</head>`,
         );
       });

--- a/packages/rollup-plugin-polyfills-loader/test/fixtures/entrypoint-a.js
+++ b/packages/rollup-plugin-polyfills-loader/test/fixtures/entrypoint-a.js
@@ -1,1 +1,1 @@
-console.log('entrypoint-a.js');
+import './shared.js';

--- a/packages/rollup-plugin-polyfills-loader/test/fixtures/entrypoint-b.js
+++ b/packages/rollup-plugin-polyfills-loader/test/fixtures/entrypoint-b.js
@@ -1,1 +1,2 @@
+import './shared.js';
 console.log('entrypoint-b.js');

--- a/packages/rollup-plugin-polyfills-loader/test/fixtures/shared.js
+++ b/packages/rollup-plugin-polyfills-loader/test/fixtures/shared.js
@@ -1,0 +1,1 @@
+console.log('shared');

--- a/packages/rollup-plugin-polyfills-loader/test/snapshots/multiple-entrypoints.html
+++ b/packages/rollup-plugin-polyfills-loader/test/snapshots/multiple-entrypoints.html
@@ -1,5 +1,8 @@
 <html><head>
-<link rel="preload" href="./entrypoint-a.js" as="script">
+            
+<link rel="preload" href="./entrypoint-a.js" as="script" crossorigin="anonymous">
+<link rel="preload" href="shared-ed942ddb.js" as="script" crossorigin="anonymous">
+<link rel="preload" href="./entrypoint-b.js" as="script" crossorigin="anonymous">
 </head><body><script>(function () {
   function loadScript(src, type) {
     return new Promise(function (resolve) {
@@ -32,20 +35,14 @@
     polyfills.push(loadScript('./polyfills/fetch.js'));
   }
 
-  if (!('attachShadow' in Element.prototype) || !('getRootNode' in Element.prototype) || window.ShadyDOM && window.ShadyDOM.force) {
-    polyfills.push(loadScript('./polyfills/webcomponents.js'));
-  }
-
-  if (!('noModule' in HTMLScriptElement.prototype) && 'getRootNode' in Element.prototype) {
-    polyfills.push(loadScript('./polyfills/custom-elements-es5-adapter.js'));
-  }
-
   function loadFiles() {
-    if (!('noModule' in HTMLScriptElement.prototype)) {
-      loadScript('./entrypoint-a.js');
-    } else {
-      loadScript('./entrypoint-a.js');
-    }
+    [function () {
+      return loadScript('./entrypoint-a.js', 'module');
+    }, function () {
+      return loadScript('./entrypoint-b.js', 'module');
+    }].reduce(function (a, c) {
+      return a.then(c);
+    }, Promise.resolve());
   }
 
   if (polyfills.length) {

--- a/packages/rollup-plugin-polyfills-loader/test/snapshots/no-polyfills.html
+++ b/packages/rollup-plugin-polyfills-loader/test/snapshots/no-polyfills.html
@@ -1,6 +1,10 @@
 <html><head>
+            
 <link rel="preload" href="./entrypoint-a.js" as="script" crossorigin="anonymous">
+<link rel="preload" href="shared-ed942ddb.js" as="script" crossorigin="anonymous">
+<link rel="preload" href="./entrypoint-b.js" as="script" crossorigin="anonymous">
 </head><body>
 <script type="module" src="./entrypoint-a.js"></script>
+<script type="module" src="./entrypoint-b.js"></script>
 
 </body></html>

--- a/packages/rollup-plugin-polyfills-loader/test/snapshots/systemjs.html
+++ b/packages/rollup-plugin-polyfills-loader/test/snapshots/systemjs.html
@@ -1,5 +1,8 @@
 <html><head>
+            
 <link rel="preload" href="./entrypoint-a.js" as="script">
+<link rel="preload" href="shared-37ad104a.js" as="script">
+<link rel="preload" href="./entrypoint-b.js" as="script">
 </head><body><script>(function () {
   function loadScript(src, type) {
     return new Promise(function (resolve) {
@@ -27,25 +30,16 @@
   }
 
   var polyfills = [];
-
-  if (!('fetch' in window)) {
-    polyfills.push(loadScript('./polyfills/fetch.js'));
-  }
-
-  if (!('attachShadow' in Element.prototype) || !('getRootNode' in Element.prototype) || window.ShadyDOM && window.ShadyDOM.force) {
-    polyfills.push(loadScript('./polyfills/webcomponents.js'));
-  }
-
-  if (!('noModule' in HTMLScriptElement.prototype) && 'getRootNode' in Element.prototype) {
-    polyfills.push(loadScript('./polyfills/custom-elements-es5-adapter.js'));
-  }
+  polyfills.push(loadScript('./polyfills/systemjs.185310413168d25ec7f5d19586923639.js'));
 
   function loadFiles() {
-    if (!('noModule' in HTMLScriptElement.prototype)) {
-      loadScript('./entrypoint-a.js');
-    } else {
-      loadScript('./entrypoint-a.js');
-    }
+    [function () {
+      return System.import('./entrypoint-a.js');
+    }, function () {
+      return System.import('./entrypoint-b.js');
+    }].reduce(function (a, c) {
+      return a.then(c);
+    }, Promise.resolve());
   }
 
   if (polyfills.length) {

--- a/packages/rollup-plugin-polyfills-loader/test/src/rollupPluginPolyfillsLoader.test.ts
+++ b/packages/rollup-plugin-polyfills-loader/test/src/rollupPluginPolyfillsLoader.test.ts
@@ -80,6 +80,57 @@ describe('rollup-plugin-polyfills-loader', function describe() {
     });
   });
 
+  it('can inject a polyfills loader with multiple entrypoints', async () => {
+    const inputOptions: RollupOptions = {
+      plugins: [
+        html({
+          input: {
+            html: `
+            <script type="module" src="${relativeUrl}/fixtures/entrypoint-a.js"></script>
+            <script type="module" src="${relativeUrl}/fixtures/entrypoint-b.js"></script>`,
+          },
+        }),
+        polyfillsLoader({
+          polyfills: { hash: false, fetch: true },
+        }),
+      ],
+    };
+
+    await testSnapshot({
+      name: 'multiple-entrypoints',
+      fileName: 'index.html',
+      inputOptions,
+      outputOptions: defaultOutputOptions,
+    });
+  });
+
+  it('injects the correct preload for systemjs output', async () => {
+    const inputOptions: RollupOptions = {
+      plugins: [
+        html({
+          input: {
+            html: `
+            <script type="module" src="${relativeUrl}/fixtures/entrypoint-a.js"></script>
+            <script type="module" src="${relativeUrl}/fixtures/entrypoint-b.js"></script>`,
+          },
+        }),
+        polyfillsLoader(),
+      ],
+    };
+
+    await testSnapshot({
+      name: 'systemjs',
+      fileName: 'index.html',
+      inputOptions,
+      outputOptions: [
+        {
+          format: 'system',
+          dir: 'dist',
+        },
+      ],
+    });
+  });
+
   it('can set polyfills to load', async () => {
     const inputOptions = {
       plugins: [
@@ -191,12 +242,14 @@ describe('rollup-plugin-polyfills-loader', function describe() {
     });
   });
 
-  it('a regular module script is added when no polyfills need to be loaded', async () => {
-    const inputOptions = {
+  it('injects preload when there are no polyfills to inject', async () => {
+    const inputOptions: RollupOptions = {
       plugins: [
         html({
           input: {
-            html: `<script type="module" src="${relativeUrl}/fixtures/entrypoint-a.js"></script>`,
+            html: `
+            <script type="module" src="${relativeUrl}/fixtures/entrypoint-a.js"></script>
+            <script type="module" src="${relativeUrl}/fixtures/entrypoint-b.js"></script>`,
           },
         }),
         polyfillsLoader(),


### PR DESCRIPTION
## What I did

Fixed preloading of non-module entrypoints, using the correct crossorigin attribute.
