### PR TITLE
feat(test-runner-visual-regression): selenium support

### DIFF
--- a/packages/test-runner-selenium/src/seleniumLauncher.ts
+++ b/packages/test-runner-selenium/src/seleniumLauncher.ts
@@ -61,6 +61,13 @@ export class SeleniumLauncher implements BrowserLauncher {
     return this.iframeManager.getBrowserUrl(sessionId);
   }
 
+  takeScreenshot(sessionId: string, locator: string) {
+    if (!this.iframeManager) {
+      throw new Error('Not initialized');
+    }
+    return this.iframeManager.takeScreenshot(sessionId, locator);
+  }
+
   async stopSession(id: string) {
     return this.iframeManager!.queueStopSession(id);
   }

--- a/packages/test-runner-visual-regression/package.json
+++ b/packages/test-runner-visual-regression/package.json
@@ -50,6 +50,7 @@
   "devDependencies": {
     "@web/test-runner-chrome": "^0.7.2",
     "@web/test-runner-playwright": "^0.6.4",
+    "@web/test-runner-selenium": "^0.3.1",
     "mocha": "^8.1.1"
   },
   "exports": {


### PR DESCRIPTION
Fixes #806 

## What I did

1. Added Selenium support to `@web/test-runner-visual-regression`

There is now a `takeScreenshot` method which contains all the logic. I'm not so happy about the implementation as it calls `driver.switchTo()` every time to focus the iframe and then switch back to the parent frame.

Any suggestions how this could be improved?