### PR TITLE
fix: don't run actions that need secrets on pull requests

### DIFF
--- a/.github/workflows/verify-browserstack.yml
+++ b/.github/workflows/verify-browserstack.yml
@@ -1,6 +1,10 @@
 name: Verify Browserstack
 
-on: pull_request
+on:
+  # Run the workflow whenever commits are pushed to the main branch
+  push:
+    branches:
+      - master
 
 jobs:
   verify-browserstack:

--- a/.github/workflows/verify-browserstack.yml
+++ b/.github/workflows/verify-browserstack.yml
@@ -1,15 +1,23 @@
 name: Verify Browserstack
 
 on:
-  # Run the workflow whenever commits are pushed to the main branch
+  # Run the workflow when commits are pushed to the main branch
   push:
     branches:
       - master
+  # Also run when a PR is opened
+  pull_request:
 
 jobs:
   verify-browserstack:
     name: Verify Browserstack
+
+    # Run the job if it's not triggered by a PR or if the PR is from the same repository
+    # This is because this job requires a secret, and secrets cannot be shared with forks
+    if: github.event.pull_request == null || github.event.pull_request.head.repo.full_name == github.repository
+
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/verify-browserstack.yml
+++ b/.github/workflows/verify-browserstack.yml
@@ -1,12 +1,6 @@
 name: Verify Browserstack
 
-on:
-  # Run the workflow when commits are pushed to the main branch
-  push:
-    branches:
-      - master
-  # Also run when a PR is opened
-  pull_request:
+on: pull_request
 
 jobs:
   verify-browserstack:

--- a/.github/workflows/verify-saucelabs.yml
+++ b/.github/workflows/verify-saucelabs.yml
@@ -1,12 +1,6 @@
 name: Verify Saucelabs
 
-on:
-  # Run the workflow when commits are pushed to the main branch
-  push:
-    branches:
-      - master
-  # Also run when a PR is opened
-  pull_request:
+on: pull_request
 
 jobs:
   verify-saucelabs:

--- a/.github/workflows/verify-saucelabs.yml
+++ b/.github/workflows/verify-saucelabs.yml
@@ -1,15 +1,23 @@
 name: Verify Saucelabs
 
 on:
-  # Run the workflow whenever commits are pushed to the main branch
+  # Run the workflow when commits are pushed to the main branch
   push:
     branches:
       - master
+  # Also run when a PR is opened
+  pull_request:
 
 jobs:
   verify-saucelabs:
     name: Verify Sauce Labs
+
+    # Run the job if it's not triggered by a PR or if the PR is from the same repository
+    # This is because this job requires a secret, and secrets cannot be shared with forks
+    if: github.event.pull_request == null || github.event.pull_request.head.repo.full_name == github.repository
+
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/verify-saucelabs.yml
+++ b/.github/workflows/verify-saucelabs.yml
@@ -1,6 +1,10 @@
 name: Verify Saucelabs
 
-on: pull_request
+on:
+  # Run the workflow whenever commits are pushed to the main branch
+  push:
+    branches:
+      - master
 
 jobs:
   verify-saucelabs:


### PR DESCRIPTION
Any pull request from a fork will fail to run the BrowserStack and Sauce Labs tests, because secrets are not shared with actions run on forks.

## What I did

Change the behavior of the BrowserStack and Sauce Labs tests to run only when the PR is from the `modernweb-dev/web` repository.
