### PR TITLE
fix(rollup-plugin-html): handle none module script tags

### DIFF
--- a/.changeset/small-readers-mix.md
+++ b/.changeset/small-readers-mix.md
@@ -1,0 +1,6 @@
+---
+'@web/rollup-plugin-html': patch
+---
+
+- do not touch `<script>` tags with inline content/code
+- treat `<script src="...">` tags as assets

--- a/packages/rollup-plugin-html/demo/spa/index.html
+++ b/packages/rollup-plugin-html/demo/spa/index.html
@@ -1,1 +1,7 @@
 <script type="module" src="./src/my-app.js"></script>
+
+<script>
+  console.log('no module script inline');
+</script>
+
+<script src="./src/no-module.js"></script>

--- a/packages/rollup-plugin-html/demo/spa/src/no-module.js
+++ b/packages/rollup-plugin-html/demo/spa/src/no-module.js
@@ -1,0 +1,1 @@
+console.log('no-module.js');

--- a/packages/rollup-plugin-html/src/assets/utils.ts
+++ b/packages/rollup-plugin-html/src/assets/utils.ts
@@ -19,7 +19,7 @@ function isAsset(node: Node) {
       }
       break;
     case 'script':
-      if (getAttribute(node, 'type') !== 'module') {
+      if (getAttribute(node, 'type') !== 'module' && getAttribute(node, 'src')) {
         path = getAttribute(node, 'src') ?? '';
       }
       break;

--- a/packages/rollup-plugin-html/src/assets/utils.ts
+++ b/packages/rollup-plugin-html/src/assets/utils.ts
@@ -18,6 +18,11 @@ function isAsset(node: Node) {
         path = getAttribute(node, 'href') ?? '';
       }
       break;
+    case 'script':
+      if (getAttribute(node, 'type') !== 'module') {
+        path = getAttribute(node, 'src') ?? '';
+      }
+      break;
     default:
       return false;
   }
@@ -35,6 +40,8 @@ function isAsset(node: Node) {
 export function isHashedAsset(node: Node) {
   switch (getTagName(node)) {
     case 'img':
+      return true;
+    case 'script':
       return true;
     case 'link':
       return hashedLinkRels.includes(getAttribute(node, 'rel')!);
@@ -57,6 +64,9 @@ export function getSourceAttribute(node: Node) {
     }
     case 'link': {
       return 'href';
+    }
+    case 'script': {
+      return 'src';
     }
     default:
       throw new Error(`Unknown node with tagname ${getTagName(node)}`);

--- a/packages/rollup-plugin-html/src/input/extract/extractModules.ts
+++ b/packages/rollup-plugin-html/src/input/extract/extractModules.ts
@@ -16,7 +16,10 @@ function createContentHash(content: string) {
 
 export function extractModules(params: ExtractModulesParams) {
   const { document, htmlDir, rootDir } = params;
-  const scriptNodes = findElements(document, e => getTagName(e) === 'script');
+  const scriptNodes = findElements(
+    document,
+    e => getTagName(e) === 'script' && getAttribute(e, 'type') === 'module',
+  );
 
   const moduleImports: string[] = [];
   const inlineModules = new Map<string, string>();

--- a/packages/rollup-plugin-html/test/fixtures/assets/no-module.js
+++ b/packages/rollup-plugin-html/test/fixtures/assets/no-module.js
@@ -1,0 +1,1 @@
+/* no module script file */

--- a/packages/rollup-plugin-html/test/src/input/extract/extractAssets.test.ts
+++ b/packages/rollup-plugin-html/test/src/input/extract/extractAssets.test.ts
@@ -243,4 +243,24 @@ describe('extractAssets', () => {
 
     expect(assets.length).to.equal(0);
   });
+
+  it('does treat none module script tags as assets', () => {
+    const document = parse(`
+      <html>
+        <body>
+          <script src="./no-module.js"></script>
+        </body>
+      </html>
+    `);
+    const assets = extractAssets({
+      document,
+      htmlFilePath: path.join(rootDir, 'index.html'),
+      htmlDir: path.join(rootDir),
+      rootDir,
+    });
+
+    expect(assets.length).to.equal(1);
+    expect(assets[0].filePath).to.equal(path.join(rootDir, 'no-module.js'));
+    expect(assets[0].content.toString('utf-8')).to.equal('/* no module script file */\n');
+  });
 });

--- a/packages/rollup-plugin-html/test/src/input/extract/extractAssets.test.ts
+++ b/packages/rollup-plugin-html/test/src/input/extract/extractAssets.test.ts
@@ -244,7 +244,7 @@ describe('extractAssets', () => {
     expect(assets.length).to.equal(0);
   });
 
-  it('does treat none module script tags as assets', () => {
+  it('does treat non module script tags as assets', () => {
     const document = parse(`
       <html>
         <body>

--- a/packages/rollup-plugin-html/test/src/input/extract/extractModules.test.ts
+++ b/packages/rollup-plugin-html/test/src/input/extract/extractModules.test.ts
@@ -29,6 +29,28 @@ describe('extractModules()', () => {
     );
   });
 
+  it('does not touch non module scripts', () => {
+    const document = parse(
+      '<div>before</div>' +
+        '<script src="./foo.js"></script>' +
+        '<script></script>' +
+        '<div>after</div>',
+    );
+
+    const { moduleImports, inlineModules } = extractModules({
+      document,
+      htmlDir: '/',
+      rootDir: '/',
+    });
+    const htmlWithoutModules = serialize(document);
+
+    expect(inlineModules.size).to.equal(0);
+    expect(moduleImports).to.eql([]);
+    expect(htmlWithoutModules).to.eql(
+      '<html><head></head><body><div>before</div><script src="./foo.js"></script><script></script><div>after</div></body></html>',
+    );
+  });
+
   it('resolves imports relative to the root dir', () => {
     const document = parse(
       '<div>before</div>' +

--- a/packages/rollup-plugin-html/test/src/output/injectedUpdatedAssetPaths.test.ts
+++ b/packages/rollup-plugin-html/test/src/output/injectedUpdatedAssetPaths.test.ts
@@ -14,6 +14,7 @@ describe('injectedUpdatedAssetPaths()', () => {
         '<body>',
         '<img src="./foo/image-a.png">',
         '<img src="/image-b.png">',
+        '<script src="/no-module.js"></script>',
         '</body>',
         '</html>',
       ].join(''),
@@ -31,6 +32,7 @@ describe('injectedUpdatedAssetPaths()', () => {
     hashed.set(path.join(path.sep, 'root', 'styles.css'), 'styles-xxx.css');
     hashed.set(path.join(path.sep, 'root', 'foo', 'image-a.png'), 'image-a-xxx.png');
     hashed.set(path.join(path.sep, 'root', 'image-b.png'), 'image-b-xxx.png');
+    hashed.set(path.join(path.sep, 'root', 'no-module.js'), 'no-module-xxx.js');
 
     injectedUpdatedAssetPaths({
       document,
@@ -46,6 +48,7 @@ describe('injectedUpdatedAssetPaths()', () => {
       '<body>',
       '<img src="image-a-xxx.png">',
       '<img src="image-b-xxx.png">',
+      '<script src="no-module-xxx.js"></script>',
       '</body>',
       '</html>',
     ].join('');


### PR DESCRIPTION
## What I did

- do not touch `<script>` tags with inline content/code
- treat `<script src="...">` tags as assets
