### PR TITLE
docs: group example naming consistency

### DIFF
--- a/docs/docs/test-runner/cli-and-configuration.md
+++ b/docs/docs/test-runner/cli-and-configuration.md
@@ -225,7 +225,7 @@ export default {
       files: 'packages/a/test/**/*.test.js',
     },
     {
-      name: 'package-a',
+      name: 'package-b',
       files: 'packages/b/test/**/*.test.js',
     },
   ],


### PR DESCRIPTION
Guess this makes the example clearer. Hope I'm seeing it in the correct way :)
Otherwise we could have only one group `package-a` and improving the glob to something like `'packages/{a,b}/test/**/*.test.js'`

## What I did

1. Renamed the group name to `package-b` in order to match the directory example.
