### PR TITLE
remove sinon in place of smaller module

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "dev-to-git": "^1.4.1",
     "eslint": "^7.13.0",
     "eslint-config-prettier": "^6.15.0",
+    "hanbi": "^0.4.0",
     "husky": "^1.3.1",
     "lint-staged": "^10.5.1",
     "mocha": "^8.2.1",
@@ -68,7 +69,6 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.33.2",
     "rollup-plugin-terser": "^6.1.0",
-    "sinon": "^9.2.1",
     "ts-node": "^8.10.2",
     "typescript": "^4.0.5"
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@types/chai": "^4.2.14",
     "@types/mocha": "^8.0.01",
     "@types/node": "^14.6.0",
-    "@types/sinon": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^3.10.1",
     "@typescript-eslint/parser": "^3.10.1",
     "alex": "^8.2.0",

--- a/packages/dev-server-hmr/test/HmrPlugin.test.ts
+++ b/packages/dev-server-hmr/test/HmrPlugin.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { Context } from 'koa';
 import fetch from 'node-fetch';
-import * as sinon from 'sinon';
+import * as hanbi from 'hanbi';
 import { createTestServer } from '@web/dev-server-core/test-helpers';
 import { hmrPlugin } from '../src/index';
 import { NAME_HMR_CLIENT_IMPORT } from '../src/HmrPlugin';
@@ -18,7 +18,7 @@ const mockFile = (path: string, source: string) => ({
 
 describe('HmrPlugin', () => {
   afterEach(() => {
-    sinon.restore();
+    hanbi.restore();
   });
 
   it('should emit reload for untracked files', async () => {
@@ -35,12 +35,12 @@ describe('HmrPlugin', () => {
       ],
     });
     const { fileWatcher, webSockets } = server;
-    const stub = sinon.stub(webSockets, 'send');
+    const stub = hanbi.stubMethod(webSockets, 'send');
     try {
       await fetch(`${host}/foo.js`);
       fileWatcher.emit('change', pathUtil.join(__dirname, '/foo.js'));
 
-      expect(stub.firstCall.args[0]).to.equal(
+      expect(stub.firstCall!.args[0]).to.equal(
         JSON.stringify({
           type: 'hmr:update',
           url: '/foo.js',
@@ -65,12 +65,12 @@ describe('HmrPlugin', () => {
       ],
     });
     const { fileWatcher, webSockets } = server;
-    const stub = sinon.stub(webSockets, 'send');
+    const stub = hanbi.stubMethod(webSockets, 'send');
     try {
       await fetch(`${host}/foo.js`);
       fileWatcher.emit('change', pathUtil.join(__dirname, '/foo.js'));
 
-      expect(stub.firstCall.args[0]).to.equal(
+      expect(stub.firstCall!.args[0]).to.equal(
         JSON.stringify({
           type: 'hmr:reload',
         }),

--- a/packages/dev-server-hmr/test/HmrPlugin.test.ts
+++ b/packages/dev-server-hmr/test/HmrPlugin.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { Context } from 'koa';
 import fetch from 'node-fetch';
-import * as hanbi from 'hanbi';
+import { stubMethod, restore as restoreStubs } from 'hanbi';
 import { createTestServer } from '@web/dev-server-core/test-helpers';
 import { hmrPlugin } from '../src/index';
 import { NAME_HMR_CLIENT_IMPORT } from '../src/HmrPlugin';
@@ -18,7 +18,7 @@ const mockFile = (path: string, source: string) => ({
 
 describe('HmrPlugin', () => {
   afterEach(() => {
-    hanbi.restore();
+    restoreStubs();
   });
 
   it('should emit reload for untracked files', async () => {
@@ -35,7 +35,7 @@ describe('HmrPlugin', () => {
       ],
     });
     const { fileWatcher, webSockets } = server;
-    const stub = hanbi.stubMethod(webSockets, 'send');
+    const stub = stubMethod(webSockets, 'send');
     try {
       await fetch(`${host}/foo.js`);
       fileWatcher.emit('change', pathUtil.join(__dirname, '/foo.js'));
@@ -65,7 +65,7 @@ describe('HmrPlugin', () => {
       ],
     });
     const { fileWatcher, webSockets } = server;
-    const stub = hanbi.stubMethod(webSockets, 'send');
+    const stub = stubMethod(webSockets, 'send');
     try {
       await fetch(`${host}/foo.js`);
       fileWatcher.emit('change', pathUtil.join(__dirname, '/foo.js'));

--- a/packages/dev-server-import-maps/test-browser/test/import-map-a.test.html
+++ b/packages/dev-server-import-maps/test-browser/test/import-map-a.test.html
@@ -14,12 +14,12 @@
       import { runTests } from '@web/test-runner-mocha';
       import { expect } from '@esm-bundle/chai';
       import { sendMessage } from '../src/sendMessage.js';
-      import { postData, __importMeta } from '../src/postData.js';
+      import { postData, __postDataSpy __importMeta } from '../src/postData.js';
 
       runTests(() => {
         describe('sendMessage()', () => {
           beforeEach(() => {
-            postData.reset();
+            __postDataSpy.reset();
           });
 
           it('serves a mocked module', () => {
@@ -30,14 +30,14 @@
 
           it('calls postData with message a', async () => {
             await sendMessage('a');
-            expect(postData.callCount).to.equal(1);
-            expect(postData.getCall(0).args).to.eql(['message', { message: 'a' }]);
+            expect(__postDataSpy.callCount).to.equal(1);
+            expect(__postDataSpy.getCall(0).args).to.eql(['message', { message: 'a' }]);
           });
 
           it('calls postData with message b', async () => {
             await sendMessage('b');
-            expect(postData.callCount).to.equal(1);
-            expect(postData.getCall(0).args).to.eql(['message', { message: 'b' }]);
+            expect(__postDataSpy.callCount).to.equal(1);
+            expect(__postDataSpy.getCall(0).args).to.eql(['message', { message: 'b' }]);
           });
         });
       });

--- a/packages/dev-server-import-maps/test-browser/test/import-map-a.test.html
+++ b/packages/dev-server-import-maps/test-browser/test/import-map-a.test.html
@@ -14,7 +14,7 @@
       import { runTests } from '@web/test-runner-mocha';
       import { expect } from '@esm-bundle/chai';
       import { sendMessage } from '../src/sendMessage.js';
-      import { postData, __postDataSpy __importMeta } from '../src/postData.js';
+      import { postData, __postDataSpy, __importMeta } from '../src/postData.js';
 
       runTests(() => {
         describe('sendMessage()', () => {

--- a/packages/dev-server-import-maps/test-browser/test/mocks/postData.js
+++ b/packages/dev-server-import-maps/test-browser/test/mocks/postData.js
@@ -1,5 +1,9 @@
-import { stub } from 'sinon';
+import { spy } from 'hanbi';
 
-export const postData = stub();
+export const __postDataSpy = spy();
+
+__postDataSpy.returns(Promise.resolve());
+
+export const postData = __postDataSpy.handler;
 
 export const __importMeta = import.meta;

--- a/packages/dev-server-import-maps/test-browser/web-test-runner.config.mjs
+++ b/packages/dev-server-import-maps/test-browser/web-test-runner.config.mjs
@@ -11,7 +11,7 @@ export default {
         importMap: {
           imports: {
             'chai/': '/node_modules/chai/',
-            sinon: '/node_modules/sinon/pkg/sinon-esm.js',
+            hanbi: '/node_modules/hanbi/lib/esm/main.js',
             '@web/test-runner-mocha': '/packages/test-runner-mocha/dist/standalone.js',
             '@esm-bundle/chai': '/node_modules/@esm-bundle/chai/esm/chai.js',
           },

--- a/packages/dev-server-import-maps/test/resolving.test.ts
+++ b/packages/dev-server-import-maps/test/resolving.test.ts
@@ -351,7 +351,7 @@ describe('resolving imports', () => {
       warn: loggerSpies.warn.handler,
       group: loggerSpies.group.handler,
       groupEnd: loggerSpies.groupEnd.handler,
-      logSyntaxError: loggerSpies.logSyntaxError.handler
+      logSyntaxError: loggerSpies.logSyntaxError.handler,
     };
     const { server, host } = await createTestServer(
       {

--- a/packages/dev-server-rollup/package.json
+++ b/packages/dev-server-rollup/package.json
@@ -63,8 +63,7 @@
     "@web/test-runner-core": "^0.8.0",
     "chai": "^4.2.0",
     "node-fetch": "v3.0.0-beta.9",
-    "rollup-plugin-postcss": "^3.1.8",
-    "sinon": "^9.2.1"
+    "rollup-plugin-postcss": "^3.1.8"
   },
   "exports": {
     ".": {

--- a/packages/dev-server-rollup/test/node/unit.test.ts
+++ b/packages/dev-server-rollup/test/node/unit.test.ts
@@ -5,7 +5,7 @@ import path from 'path';
 
 import { createTestServer, fetchText, expectIncludes } from './test-helpers';
 import { fromRollup } from '../../src/index';
-import { stub } from 'sinon';
+import { spy } from 'hanbi';
 
 describe('@web/dev-server-rollup', () => {
   describe('resolveId', () => {
@@ -93,14 +93,23 @@ describe('@web/dev-server-rollup', () => {
           return resolvedId;
         },
       };
+      const mockLoggerSpies = {
+        log: spy(),
+        debug: spy(),
+        error: spy(),
+        warn: spy(),
+        group: spy(),
+        groupEnd: spy(),
+        logSyntaxError: spy(),
+      };
       const mockLogger = {
-        log: stub(),
-        debug: stub(),
-        error: stub(),
-        warn: stub(),
-        group: stub(),
-        groupEnd: stub(),
-        logSyntaxError: stub(),
+        log: mockLoggerSpies.log.handler,
+        debug: mockLoggerSpies.debug.handler,
+        error: mockLoggerSpies.error.handler,
+        warn: mockLoggerSpies.warn.handler,
+        group: mockLoggerSpies.group.handler,
+        groupEnd: mockLoggerSpies.groupEnd.handler,
+        logSyntaxError: mockLoggerSpies.logSyntaxError.handler,
       };
       const { server, host } = await createTestServer(
         {
@@ -112,7 +121,7 @@ describe('@web/dev-server-rollup', () => {
       try {
         const response = await fetch(`${host}/app.js`);
         expect(response.status).to.equal(500);
-        expect(mockLogger.logSyntaxError.calledOnce).to.be.true;
+        expect(mockLoggerSpies.logSyntaxError.callCount).to.equal(1);
       } finally {
         server.stop();
       }

--- a/packages/rollup-plugin-import-meta-assets/test/integration.test.js
+++ b/packages/rollup-plugin-import-meta-assets/test/integration.test.js
@@ -2,11 +2,9 @@ const fs = require('fs');
 const path = require('path');
 const rollup = require('rollup');
 const { expect } = require('chai');
-const { createSandbox } = require('sinon');
+const hanbi = require('hanbi');
 
 const { importMetaAssets } = require('../src/rollup-plugin-import-meta-assets.js');
-
-const sandbox = createSandbox();
 
 const outputConfig = {
   format: 'es',
@@ -32,12 +30,14 @@ function expectAsset(output, snapshotUrl, assetName, distName) {
 }
 
 describe('rollup-plugin-import-meta-assets', () => {
+  let consoleStub;
+
   beforeEach(() => {
-    sandbox.stub(console, 'warn');
+    consoleStub = hanbi.stubMethod(console, 'warn');
   });
 
   afterEach(() => {
-    sandbox.restore();
+    hanbi.restore();
   });
 
   it("simple bundle with different new URL('', import.meta.url)", async () => {
@@ -220,11 +220,11 @@ describe('rollup-plugin-import-meta-assets', () => {
     const bundle = await rollup.rollup(config);
     await bundle.generate(outputConfig);
 
-    expect(console.warn.callCount).to.equal(2);
-    expect(console.warn.getCall(0).args[0]).to.match(
+    expect(consoleStub.callCount).to.equal(2);
+    expect(consoleStub.getCall(0).args[0]).to.match(
       /ENOENT: no such file or directory, open '.*[/\\]absolute-path\.svg'/,
     );
-    expect(console.warn.getCall(1).args[0]).to.match(
+    expect(consoleStub.getCall(1).args[0]).to.match(
       /ENOENT: no such file or directory, open '.*[/\\]missing-relative-path\.svg'/,
     );
   });

--- a/packages/test-runner-core/package.json
+++ b/packages/test-runner-core/package.json
@@ -53,11 +53,8 @@
   "devDependencies": {
     "@types/co-body": "^5.1.0",
     "@types/istanbul-lib-coverage": "^2.0.3",
-    "@types/sinon-chai": "^3.2.5",
     "@types/uuid": "^8.0.0",
-    "portfinder": "^1.0.28",
-    "sinon": "^9.2.1",
-    "sinon-chai": "^3.5.0"
+    "portfinder": "^1.0.28"
   },
   "exports": {
     ".": {

--- a/packages/test-runner-core/test/src/runner/TestRunner.test.ts
+++ b/packages/test-runner-core/test/src/runner/TestRunner.test.ts
@@ -26,7 +26,7 @@ function createBrowserStub(): [BrowserStubs, BrowserLauncher] {
     startDebugSession: hanbi.spy(),
     startSession: hanbi.spy(),
     stopSession: hanbi.spy(),
-    isActive: hanbi.spy()
+    isActive: hanbi.spy(),
   };
   spies.stop.returns(Promise.resolve());
   spies.getBrowserUrl.returns('');
@@ -34,16 +34,19 @@ function createBrowserStub(): [BrowserStubs, BrowserLauncher] {
   spies.startSession.returns(Promise.resolve());
   spies.stopSession.returns(Promise.resolve({}));
   spies.isActive.returns(true);
-  return [spies, {
-    name: 'myBrowser',
-    type: 'myBrowser',
-    stop: spies.stop.handler,
-    getBrowserUrl: spies.getBrowserUrl.handler,
-    startDebugSession: spies.startDebugSession.handler,
-    startSession: spies.startSession.handler,
-    stopSession: spies.stopSession.handler,
-    isActive: spies.isActive.handler
-  }];
+  return [
+    spies,
+    {
+      name: 'myBrowser',
+      type: 'myBrowser',
+      stop: spies.stop.handler,
+      getBrowserUrl: spies.getBrowserUrl.handler,
+      startDebugSession: spies.startDebugSession.handler,
+      startSession: spies.startSession.handler,
+      stopSession: spies.stopSession.handler,
+      isActive: spies.isActive.handler,
+    },
+  ];
 }
 
 const logger: Logger = {

--- a/packages/test-runner-core/test/src/runner/TestRunner.test.ts
+++ b/packages/test-runner-core/test/src/runner/TestRunner.test.ts
@@ -89,7 +89,7 @@ async function createTestRunner(
 }
 
 it('can run a single test file', async () => {
-  const { browser, runner, browserStubs } = await createTestRunner();
+  const { runner, browserStubs } = await createTestRunner();
 
   await runner.start();
   expect(runner.started).to.equal(true, 'runner is started');
@@ -101,7 +101,7 @@ it('can run a single test file', async () => {
 });
 
 it('closes test runner for a successful test', async () => {
-  const { browser, runner, browserStubs } = await createTestRunner();
+  const { runner, browserStubs } = await createTestRunner();
   let resolveStopped: (passed: boolean) => void;
   const stopped = new Promise<boolean>(resolve => {
     resolveStopped = resolve;
@@ -126,7 +126,7 @@ it('closes test runner for a successful test', async () => {
 });
 
 it('closes test runner for a failed test', async () => {
-  const { browser, runner, browserStubs } = await createTestRunner();
+  const { runner, browserStubs } = await createTestRunner();
   let resolveStopped: (passed: boolean) => void;
   const stopped = new Promise<boolean>(resolve => {
     resolveStopped = resolve;

--- a/packages/test-runner-core/test/src/runner/TestScheduler.test.ts
+++ b/packages/test-runner-core/test/src/runner/TestScheduler.test.ts
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai';
+import { expect } from 'chai';
 import * as hanbi from 'hanbi';
 
 import { BrowserLauncher } from '../../../src/browser-launcher/BrowserLauncher';

--- a/packages/test-runner-core/test/src/runner/TestScheduler.test.ts
+++ b/packages/test-runner-core/test/src/runner/TestScheduler.test.ts
@@ -40,7 +40,7 @@ describe('TestScheduler', () => {
       startSession: hanbi.spy(),
       stopSession: hanbi.spy(),
       isActive: hanbi.spy(),
-      getBrowserUrl: hanbi.spy()
+      getBrowserUrl: hanbi.spy(),
     };
     spies.stop.returns(timeout(1));
     spies.startDebugSession.returns(timeout(1));
@@ -48,16 +48,19 @@ describe('TestScheduler', () => {
     spies.stopSession.returns(timeout(1).then(() => ({ testCoverage: {} })));
     spies.isActive.returns(true);
     spies.getBrowserUrl.returns('');
-    return [spies, {
-      name,
-      type: name,
-      stop: spies.stop.handler,
-      startDebugSession: spies.startDebugSession.handler,
-      startSession: spies.startSession.handler,
-      stopSession: spies.stopSession.handler,
-      isActive: spies.isActive.handler,
-      getBrowserUrl: spies.getBrowserUrl.handler
-    }];
+    return [
+      spies,
+      {
+        name,
+        type: name,
+        stop: spies.stop.handler,
+        startDebugSession: spies.startDebugSession.handler,
+        startSession: spies.startSession.handler,
+        stopSession: spies.stopSession.handler,
+        isActive: spies.isActive.handler,
+        getBrowserUrl: spies.getBrowserUrl.handler,
+      },
+    ];
   }
 
   beforeEach(() => {
@@ -110,9 +113,7 @@ describe('TestScheduler', () => {
     it('when a session goes to status test finished, the browser is stopped and results is stored', async () => {
       const [scheduler, sessions, [session1], stubs] = createTestFixture('1');
       const testCoverage = {};
-      stubs.stopSession.returns(
-        timeout(1).then(() => ({ testCoverage })),
-      );
+      stubs.stopSession.returns(timeout(1).then(() => ({ testCoverage })));
       scheduler.schedule(1, [session1]);
 
       await timeout(2);
@@ -200,9 +201,7 @@ describe('TestScheduler', () => {
 
     it('error while starting browser marks session as failed', async () => {
       const [scheduler, sessions, [session1], stubs] = createTestFixture('1');
-      stubs.startSession.callsFake(() =>
-        Promise.reject(new Error('mock error')),
-      );
+      stubs.startSession.callsFake(() => Promise.reject(new Error('mock error')));
       scheduler.schedule(1, [session1]);
 
       await timeout(4);
@@ -241,9 +240,7 @@ describe('TestScheduler', () => {
 
     it('error while stopping browser marks session as failed', async () => {
       const [scheduler, sessions, [session1], stubs] = createTestFixture('1');
-      stubs.stopSession.callsFake(() =>
-        Promise.reject(new Error('mock error')),
-      );
+      stubs.stopSession.callsFake(() => Promise.reject(new Error('mock error')));
       scheduler.schedule(1, [session1]);
 
       await timeout(2);
@@ -327,7 +324,11 @@ describe('TestScheduler', () => {
       }
 
       const sessionManager = new TestSessionManager([], sessions);
-      const scheduler = new TestScheduler(mockConfig, sessionManager, browsers.map((b) => b[1]));
+      const scheduler = new TestScheduler(
+        mockConfig,
+        sessionManager,
+        browsers.map(b => b[1]),
+      );
       return [scheduler, sessionManager, browsers, sessions];
     }
 

--- a/packages/test-runner-core/test/src/runner/TestScheduler.test.ts
+++ b/packages/test-runner-core/test/src/runner/TestScheduler.test.ts
@@ -1,6 +1,5 @@
 import chai, { expect } from 'chai';
-import { SinonStub, stub } from 'sinon';
-import sinonChai from 'sinon-chai';
+import * as hanbi from 'hanbi';
 
 import { BrowserLauncher } from '../../../src/browser-launcher/BrowserLauncher';
 
@@ -10,10 +9,17 @@ import { TestSession } from '../../../src/test-session/TestSession';
 import { TestSessionManager } from '../../../src/test-session/TestSessionManager';
 import { SESSION_STATUS } from '../../../src/test-session/TestSessionStatus';
 
-chai.use(sinonChai);
-
-function timeout(ms = 0) {
+function timeout(ms = 0): Promise<void> {
   return new Promise(r => setTimeout(r, ms));
+}
+
+interface BrowserStubs {
+  stop: hanbi.Stub<Exclude<BrowserLauncher['stop'], undefined>>;
+  startDebugSession: hanbi.Stub<BrowserLauncher['startDebugSession']>;
+  startSession: hanbi.Stub<BrowserLauncher['startSession']>;
+  stopSession: hanbi.Stub<BrowserLauncher['stopSession']>;
+  isActive: hanbi.Stub<BrowserLauncher['isActive']>;
+  getBrowserUrl: hanbi.Stub<BrowserLauncher['getBrowserUrl']>;
 }
 
 describe('TestScheduler', () => {
@@ -27,17 +33,31 @@ describe('TestScheduler', () => {
     } as Partial<TestSession>) as TestSession;
   }
 
-  function createBrowserStub(name: string) {
-    return {
+  function createBrowserStub(name: string): [BrowserStubs, BrowserLauncher] {
+    const spies = {
+      stop: hanbi.spy(),
+      startDebugSession: hanbi.spy(),
+      startSession: hanbi.spy(),
+      stopSession: hanbi.spy(),
+      isActive: hanbi.spy(),
+      getBrowserUrl: hanbi.spy()
+    };
+    spies.stop.returns(timeout(1));
+    spies.startDebugSession.returns(timeout(1));
+    spies.startSession.returns(timeout(1));
+    spies.stopSession.returns(timeout(1).then(() => ({ testCoverage: {} })));
+    spies.isActive.returns(true);
+    spies.getBrowserUrl.returns('');
+    return [spies, {
       name,
       type: name,
-      stop: stub().returns(timeout(1)),
-      startDebugSession: stub().returns(timeout(1)),
-      startSession: stub().returns(timeout(1)),
-      stopSession: stub().returns(timeout(1).then(() => ({ testCoverage: {} }))),
-      isActive: stub().returns(true),
-      getBrowserUrl: stub().returns(''),
-    };
+      stop: spies.stop.handler,
+      startDebugSession: spies.startDebugSession.handler,
+      startSession: spies.startSession.handler,
+      stopSession: spies.stopSession.handler,
+      isActive: spies.isActive.handler,
+      getBrowserUrl: spies.getBrowserUrl.handler
+    }];
   }
 
   beforeEach(() => {
@@ -65,32 +85,32 @@ describe('TestScheduler', () => {
 
   function createTestFixture(
     ...ids: string[]
-  ): [TestScheduler, TestSessionManager, ...TestSession[]] {
-    const browsers: BrowserLauncher[] = [createBrowserStub('a')];
+  ): [TestScheduler, TestSessionManager, TestSession[], BrowserStubs] {
+    const [browserStubs, browser] = createBrowserStub('a');
     const sessions: TestSession[] = [];
     for (const id of ids) {
-      const session = createSession({ id, browser: browsers[0] });
+      const session = createSession({ id, browser });
       sessions.push(session);
     }
     const sessionManager = new TestSessionManager([], sessions);
-    const scheduler = new TestScheduler(mockConfig, sessionManager, browsers);
-    return [scheduler, sessionManager, ...sessions];
+    const scheduler = new TestScheduler(mockConfig, sessionManager, [browser]);
+    return [scheduler, sessionManager, sessions, browserStubs];
   }
 
   describe('single browser', () => {
     it('scheduling a session starts the browser and marks initializing', async () => {
-      const [scheduler, sessions, session1] = createTestFixture('1');
+      const [scheduler, sessions, [session1], stubs] = createTestFixture('1');
       scheduler.schedule(1, [session1]);
 
       const finalSession1 = sessions.get(session1.id)!;
       expect(finalSession1.status).to.equal(SESSION_STATUS.INITIALIZING);
-      expect(finalSession1.browser.startSession).to.be.calledOnce;
+      expect(stubs.startSession.callCount).to.equal(1);
     });
 
     it('when a session goes to status test finished, the browser is stopped and results is stored', async () => {
-      const [scheduler, sessions, session1] = createTestFixture('1');
-      const testCoverage = { foo: 'bar' };
-      (session1.browser.stopSession as SinonStub).returns(
+      const [scheduler, sessions, [session1], stubs] = createTestFixture('1');
+      const testCoverage = {};
+      stubs.stopSession.returns(
         timeout(1).then(() => ({ testCoverage })),
       );
       scheduler.schedule(1, [session1]);
@@ -106,7 +126,7 @@ describe('TestScheduler', () => {
     });
 
     it('batches test execution', async () => {
-      const [scheduler, sessions, ...sessionsToSchedule] = createTestFixture('1', '2', '3');
+      const [scheduler, sessions, sessionsToSchedule] = createTestFixture('1', '2', '3');
       scheduler.schedule(1, sessionsToSchedule);
 
       expect(sessions.get('1')!.status).to.equal(SESSION_STATUS.INITIALIZING);
@@ -136,7 +156,7 @@ describe('TestScheduler', () => {
 
     it('scheduling new tests while executing keeps batching', async () => {
       const sessionIds = ['1', '2', '3', '4', '5', '6'];
-      const [scheduler, sessions, ...sessionsToSchedule] = createTestFixture(...sessionIds);
+      const [scheduler, sessions, sessionsToSchedule] = createTestFixture(...sessionIds);
 
       // schedule 2 sessions
       scheduler.schedule(1, sessionsToSchedule.slice(0, 2));
@@ -179,8 +199,8 @@ describe('TestScheduler', () => {
     });
 
     it('error while starting browser marks session as failed', async () => {
-      const [scheduler, sessions, session1] = createTestFixture('1');
-      (session1.browser.startSession as SinonStub).callsFake(() =>
+      const [scheduler, sessions, [session1], stubs] = createTestFixture('1');
+      stubs.startSession.callsFake(() =>
         Promise.reject(new Error('mock error')),
       );
       scheduler.schedule(1, [session1]);
@@ -195,9 +215,9 @@ describe('TestScheduler', () => {
     });
 
     it('error while starting browser after a session changed state gets logged', async () => {
-      const errorStub = stub(mockConfig.logger, 'error');
-      const [scheduler, sessions, session1] = createTestFixture('1');
-      (session1.browser.startSession as SinonStub).returns(
+      const errorStub = hanbi.stubMethod(mockConfig.logger, 'error');
+      const [scheduler, sessions, [session1], stubs] = createTestFixture('1');
+      stubs.startSession.returns(
         timeout(5).then(() => {
           throw new Error('mock error');
         }),
@@ -214,14 +234,14 @@ describe('TestScheduler', () => {
 
       await timeout(20);
 
-      expect(errorStub).to.be.calledOnce;
+      expect(errorStub.callCount).to.equal(1);
       expect(errorStub.getCall(0).args[0]).to.an.instanceof(Error);
       expect((errorStub.getCall(0).args[0] as Error).message).to.equal('mock error');
     });
 
     it('error while stopping browser marks session as failed', async () => {
-      const [scheduler, sessions, session1] = createTestFixture('1');
-      (session1.browser.stopSession as SinonStub).callsFake(() =>
+      const [scheduler, sessions, [session1], stubs] = createTestFixture('1');
+      stubs.stopSession.callsFake(() =>
         Promise.reject(new Error('mock error')),
       );
       scheduler.schedule(1, [session1]);
@@ -239,8 +259,8 @@ describe('TestScheduler', () => {
 
     it('timeout starting the browser marks the session as failed', async () => {
       mockConfig.browserStartTimeout = 2;
-      const [scheduler, sessions, session1] = createTestFixture('1');
-      (session1.browser.startSession as SinonStub).returns(timeout(4));
+      const [scheduler, sessions, [session1], stubs] = createTestFixture('1');
+      stubs.startSession.returns(timeout(4));
       scheduler.schedule(1, [session1]);
 
       await timeout(3);
@@ -256,7 +276,7 @@ describe('TestScheduler', () => {
 
     it('timeout starting the tests marks the session as failed', async () => {
       mockConfig.testsStartTimeout = 2;
-      const [scheduler, sessions, session1] = createTestFixture('1');
+      const [scheduler, sessions, [session1]] = createTestFixture('1');
       scheduler.schedule(1, [session1]);
 
       await timeout(8);
@@ -272,7 +292,7 @@ describe('TestScheduler', () => {
 
     it('timeout finishing the tests marks the session as failed', async () => {
       mockConfig.testsFinishTimeout = 2;
-      const [scheduler, sessions, session1] = createTestFixture('1');
+      const [scheduler, sessions, [session1]] = createTestFixture('1');
       scheduler.schedule(1, [session1]);
 
       await timeout(1);
@@ -292,13 +312,13 @@ describe('TestScheduler', () => {
   describe('multi browsers', () => {
     function createTestFixture(
       fixtures: { name: string; ids: string[] }[],
-    ): [TestScheduler, TestSessionManager, BrowserLauncher[], ...TestSession[]] {
-      const browsers: BrowserLauncher[] = [];
+    ): [TestScheduler, TestSessionManager, Array<[BrowserStubs, BrowserLauncher]>, TestSession[]] {
+      const browsers: Array<[BrowserStubs, BrowserLauncher]> = [];
       const sessions: TestSession[] = [];
 
       for (const fixture of fixtures) {
-        const browser = createBrowserStub(fixture.name);
-        browsers.push(browser);
+        const [stubs, browser] = createBrowserStub(fixture.name);
+        browsers.push([stubs, browser]);
 
         for (const id of fixture.ids) {
           const session = createSession({ id, browser });
@@ -307,12 +327,12 @@ describe('TestScheduler', () => {
       }
 
       const sessionManager = new TestSessionManager([], sessions);
-      const scheduler = new TestScheduler(mockConfig, sessionManager, browsers);
-      return [scheduler, sessionManager, browsers, ...sessions];
+      const scheduler = new TestScheduler(mockConfig, sessionManager, browsers.map((b) => b[1]));
+      return [scheduler, sessionManager, browsers, sessions];
     }
 
     it('can schedule sessions on multiple browsers', async () => {
-      const [scheduler, sessionManager, browsers, ...sessions] = createTestFixture([
+      const [scheduler, sessionManager, browsers, sessions] = createTestFixture([
         { name: 'a', ids: ['1', '2', '3'] },
         { name: 'b', ids: ['4', '5', '6'] },
         { name: 'c', ids: ['7', '8', '9'] },
@@ -322,39 +342,39 @@ describe('TestScheduler', () => {
       const session1 = sessionManager.get('1')!;
       const session2 = sessionManager.get('2')!;
       const session3 = sessionManager.get('3')!;
-      expect(session1.browser).to.equal(browsers[0]);
-      expect(session2.browser).to.equal(browsers[0]);
-      expect(session3.browser).to.equal(browsers[0]);
+      expect(session1.browser).to.equal(browsers[0][1]);
+      expect(session2.browser).to.equal(browsers[0][1]);
+      expect(session3.browser).to.equal(browsers[0][1]);
       expect(session1.status).to.equal(SESSION_STATUS.INITIALIZING);
       expect(session2.status).to.equal(SESSION_STATUS.INITIALIZING);
       expect(session3.status).to.equal(SESSION_STATUS.SCHEDULED);
-      expect(browsers[0].startSession).to.be.calledTwice;
+      expect(browsers[0][0].startSession.callCount).to.equal(2);
 
       const session4 = sessionManager.get('4')!;
       const session5 = sessionManager.get('5')!;
       const session6 = sessionManager.get('6')!;
-      expect(session4.browser).to.equal(browsers[1]);
-      expect(session5.browser).to.equal(browsers[1]);
-      expect(session6.browser).to.equal(browsers[1]);
+      expect(session4.browser).to.equal(browsers[1][1]);
+      expect(session5.browser).to.equal(browsers[1][1]);
+      expect(session6.browser).to.equal(browsers[1][1]);
       expect(session4.status).to.equal(SESSION_STATUS.INITIALIZING);
       expect(session5.status).to.equal(SESSION_STATUS.INITIALIZING);
       expect(session6.status).to.equal(SESSION_STATUS.SCHEDULED);
-      expect(browsers[1].startSession).to.be.calledTwice;
+      expect(browsers[1][0].startSession.callCount).to.equal(2);
 
       const session7 = sessionManager.get('7')!;
       const session8 = sessionManager.get('8')!;
       const session9 = sessionManager.get('9')!;
-      expect(session7.browser).to.equal(browsers[2]);
-      expect(session8.browser).to.equal(browsers[2]);
-      expect(session9.browser).to.equal(browsers[2]);
+      expect(session7.browser).to.equal(browsers[2][1]);
+      expect(session8.browser).to.equal(browsers[2][1]);
+      expect(session9.browser).to.equal(browsers[2][1]);
       expect(session7.status).to.equal(SESSION_STATUS.SCHEDULED);
       expect(session8.status).to.equal(SESSION_STATUS.SCHEDULED);
       expect(session9.status).to.equal(SESSION_STATUS.SCHEDULED);
-      expect(browsers[2].startSession).to.not.be.called;
+      expect(browsers[2][0].startSession.called).to.equal(false);
     });
 
     it('finishing a test schedules a new one', async () => {
-      const [scheduler, sessionManager, browsers, ...sessions] = createTestFixture([
+      const [scheduler, sessionManager, browsers, sessions] = createTestFixture([
         { name: 'a', ids: ['1', '2', '3'] },
         { name: 'b', ids: ['4', '5', '6'] },
         { name: 'c', ids: ['7', '8', '9'] },
@@ -366,13 +386,13 @@ describe('TestScheduler', () => {
       await timeout(4);
 
       const session3 = sessionManager.get('3')!;
-      expect(session3.browser).to.equal(browsers[0]);
+      expect(session3.browser).to.equal(browsers[0][1]);
       expect(session3.status).to.equal(SESSION_STATUS.INITIALIZING);
-      expect(browsers[0].startSession).to.be.calledThrice;
+      expect(browsers[0][0].startSession.callCount).to.equal(3);
     });
 
     it('overflow of concurrency budget does not trigger a new browser to start', async () => {
-      const [scheduler, sessionManager, browsers, ...sessions] = createTestFixture([
+      const [scheduler, sessionManager, browsers, sessions] = createTestFixture([
         { name: 'a', ids: ['1', '2', '3'] },
         { name: 'b', ids: ['4', '5', '6'] },
         { name: 'c', ids: ['7', '8', '9'] },
@@ -385,13 +405,13 @@ describe('TestScheduler', () => {
       await timeout(4);
 
       const session7 = sessionManager.get('7')!;
-      expect(session7.browser).to.equal(browsers[2]);
+      expect(session7.browser).to.equal(browsers[2][1]);
       expect(session7.status).to.equal(SESSION_STATUS.SCHEDULED);
-      expect(browsers[2].startSession).to.not.be.called;
+      expect(browsers[2][0].startSession.called).to.equal(false);
     });
 
     it('finishing one browsers schedules a new browser', async () => {
-      const [scheduler, sessionManager, browsers, ...sessions] = createTestFixture([
+      const [scheduler, sessionManager, browsers, sessions] = createTestFixture([
         { name: 'a', ids: ['1', '2', '3'] },
         { name: 'b', ids: ['4', '5', '6'] },
         { name: 'c', ids: ['7', '8', '9'] },
@@ -406,9 +426,9 @@ describe('TestScheduler', () => {
       await timeout(4);
 
       const session7 = sessionManager.get('7')!;
-      expect(session7.browser).to.equal(browsers[2]);
+      expect(session7.browser).to.equal(browsers[2][1]);
       expect(session7.status).to.equal(SESSION_STATUS.INITIALIZING);
-      expect(browsers[2].startSession).to.be.calledTwice;
+      expect(browsers[2][0].startSession.callCount).to.equal(2);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6738,6 +6738,11 @@ hamljs@^0.6.2:
   resolved "https://registry.yarnpkg.com/hamljs/-/hamljs-0.6.2.tgz#7b7116cf6dbe7278e42b3f6ef8725a33e177c8e3"
   integrity sha1-e3EWz22+cnjkKz9u+HJaM+F3yOM=
 
+hanbi@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/hanbi/-/hanbi-0.4.0.tgz#66144623ad2170e66bae7a537b11547773c23867"
+  integrity sha512-2FR1EGl+xwhB1IGpqZzktpypbJOuwUuSpUY+2ibQK4xmh/pNb/4Liwf+Vx7CAMEVrWEgIruA4V09qxVN/yhrHQ==
+
 handlebars@^4.7.6:
   version "4.7.6"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2386,51 +2386,6 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-3.1.2.tgz#548650de521b344e3781fbdb0ece4aa6f729afb8"
   integrity sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ==
 
-"@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.1":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
-  integrity sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==
-  dependencies:
-    type-detect "4.0.8"
-
-"@sinonjs/fake-timers@^6.0.0", "@sinonjs/fake-timers@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
-  integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
-  dependencies:
-    "@sinonjs/commons" "^1.7.0"
-
-"@sinonjs/formatio@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-5.0.1.tgz#f13e713cb3313b1ab965901b01b0828ea6b77089"
-  integrity sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==
-  dependencies:
-    "@sinonjs/commons" "^1"
-    "@sinonjs/samsam" "^5.0.2"
-
-"@sinonjs/samsam@^5.0.2":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.1.0.tgz#3afe719232b541bb6cf3411a4c399a188de21ec0"
-  integrity sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==
-  dependencies:
-    "@sinonjs/commons" "^1.6.0"
-    lodash.get "^4.4.2"
-    type-detect "^4.0.8"
-
-"@sinonjs/samsam@^5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.2.0.tgz#fcff83ab86f83b5498f4a967869c079408d9b5eb"
-  integrity sha512-CaIcyX5cDsjcW/ab7HposFWzV1kC++4HNsfnEdFJa7cP1QIuILAKV+BgfeqRXhcnSAc76r/Rh/O5C+300BwUIw==
-  dependencies:
-    "@sinonjs/commons" "^1.6.0"
-    lodash.get "^4.4.2"
-    type-detect "^4.0.8"
-
-"@sinonjs/text-encoding@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
-  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
-
 "@surma/rollup-plugin-off-main-thread@^1.1.1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-1.4.1.tgz#bf1343e5a926e5a1da55e3affd761dda4ce143ef"
@@ -2554,7 +2509,7 @@
   resolved "https://registry.yarnpkg.com/@types/caniuse-api/-/caniuse-api-3.0.0.tgz#af31cc52062be0ab24583be072fd49b634dcc2fe"
   integrity sha512-wT1VfnScjAftZsvLYaefu/UuwYJdYBwD2JDL2OQd01plGmuAoir5V6HnVHgrfh7zEwcasoiyO2wQ+W58sNh2sw==
 
-"@types/chai@*", "@types/chai@^4.2.12":
+"@types/chai@^4.2.12":
   version "4.2.12"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.12.tgz#6160ae454cd89dae05adc3bb97997f488b608201"
   integrity sha512-aN5IAC8QNtSUdQzxu7lGBgYAOuU1tmRU4c9dIq5OKGf/SBVjXo+ffM2wEjudAWbgpOhy60nLoAGH1xm8fpCKFQ==
@@ -3010,33 +2965,6 @@
   dependencies:
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
-
-"@types/sinon-chai@^3.2.5":
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/@types/sinon-chai/-/sinon-chai-3.2.5.tgz#df21ae57b10757da0b26f512145c065f2ad45c48"
-  integrity sha512-bKQqIpew7mmIGNRlxW6Zli/QVyc3zikpGzCa797B/tRnD9OtHvZ/ts8sYXV+Ilj9u3QRaUEM8xrjgd1gwm1BpQ==
-  dependencies:
-    "@types/chai" "*"
-    "@types/sinon" "*"
-
-"@types/sinon@*":
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-9.0.5.tgz#56b2a12662dd8c7d081cdc511af5f872cb37377f"
-  integrity sha512-4CnkGdM/5/FXDGqL32JQ1ttVrGvhOoesLLF7VnTh4KdjK5N5VQOtxaylFqqTjnHx55MnD9O02Nbk5c1ELC8wlQ==
-  dependencies:
-    "@types/sinonjs__fake-timers" "*"
-
-"@types/sinon@^9.0.8":
-  version "9.0.8"
-  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-9.0.8.tgz#1ed0038d356784f75b086104ef83bfd4130bb81b"
-  integrity sha512-IVnI820FZFMGI+u1R+2VdRaD/82YIQTdqLYC9DLPszZuynAJDtCvCtCs3bmyL66s7FqRM3+LPX7DhHnVTaagDw==
-  dependencies:
-    "@types/sinonjs__fake-timers" "*"
-
-"@types/sinonjs__fake-timers@*":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz#681df970358c82836b42f989188d133e218c458e"
-  integrity sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==
 
 "@types/ua-parser-js@^0.7.33":
   version "0.7.33"
@@ -8065,11 +7993,6 @@ junk@^1.0.1:
   resolved "https://registry.yarnpkg.com/junk/-/junk-1.0.3.tgz#87be63488649cbdca6f53ab39bec9ccd2347f592"
   integrity sha1-h75jSIZJy9ym9Tqzm+yczSNH9ZI=
 
-just-extend@^4.0.2:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.1.0.tgz#7278a4027d889601640ee0ce0e5a00b992467da4"
-  integrity sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==
-
 keygrip@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.1.0.tgz#871b1681d5e159c62a445b0c74b615e0917e7226"
@@ -8415,11 +8338,6 @@ lodash.difference@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
   integrity sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=
-
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
 lodash.intersection@^4.4.0:
   version "4.4.0"
@@ -9016,17 +8934,6 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-
-nise@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/nise/-/nise-4.0.4.tgz#d73dea3e5731e6561992b8f570be9e363c4512dd"
-  integrity sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==
-  dependencies:
-    "@sinonjs/commons" "^1.7.0"
-    "@sinonjs/fake-timers" "^6.0.0"
-    "@sinonjs/text-encoding" "^0.7.1"
-    just-extend "^4.0.2"
-    path-to-regexp "^1.7.0"
 
 nlcst-is-literal@^1.1.0:
   version "1.2.1"
@@ -9638,13 +9545,6 @@ path-root@^0.1.1:
   integrity sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=
   dependencies:
     path-root-regex "^0.1.0"
-
-path-to-regexp@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
-  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
-  dependencies:
-    isarray "0.0.1"
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -11924,24 +11824,6 @@ singleton-manager@1.1.2:
   resolved "https://registry.yarnpkg.com/singleton-manager/-/singleton-manager-1.1.2.tgz#35c90b9f86012e4bc3342183a39fae27e8f05f24"
   integrity sha512-U1nD22iUUVSWY7ST5iB0ca+qFZcXwtP6nf8Gp0WP/u4gqOs83gdOsOS6d4glhvcJ751ERJfDbaMoqDA0pPk+yA==
 
-sinon-chai@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-3.5.0.tgz#c9a78304b0e15befe57ef68e8a85a00553f5c60e"
-  integrity sha512-IifbusYiQBpUxxFJkR3wTU68xzBN0+bxCScEaKMjBvAQERg6FnTTc1F17rseLb1tjmkJ23730AXpFI0c47FgAg==
-
-sinon@^9.2.1:
-  version "9.2.1"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-9.2.1.tgz#64cc88beac718557055bd8caa526b34a2231be6d"
-  integrity sha512-naPfsamB5KEE1aiioaoqJ6MEhdUs/2vtI5w1hPAXX/UwvoPjXcwh1m5HiKx0HGgKR8lQSoFIgY5jM6KK8VrS9w==
-  dependencies:
-    "@sinonjs/commons" "^1.8.1"
-    "@sinonjs/fake-timers" "^6.0.1"
-    "@sinonjs/formatio" "^5.0.1"
-    "@sinonjs/samsam" "^5.2.0"
-    diff "^4.0.2"
-    nise "^4.0.4"
-    supports-color "^7.1.0"
-
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -12983,7 +12865,7 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
-type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
+type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==


### PR DESCRIPTION
Here's the branch i mentioned recently, trying to drop sinon for its size.

If its something you're interested in, let me know.

Note that because how some of the tests in this repo are written, they may look a bit more complex now. it would be solved by better keeping track of stubs/spies rather than using the "override" style sinon uses (`real.method.callCount`).

Also sinon is still referenced in the test runner docs and what looks like an example file/repo from those docs.