### PR TITLE
[dev-server-hmr] add acceptDeps callback to hmr client

### DIFF
--- a/.changeset/thirty-maps-double.md
+++ b/.changeset/thirty-maps-double.md
@@ -1,0 +1,5 @@
+---
+"@web/dev-server-hmr": minor
+---
+
+[dev-server-hmr] add acceptDeps callback to hmr client

--- a/docs/docs/dev-server/plugins/hmr.md
+++ b/docs/docs/dev-server/plugins/hmr.md
@@ -56,7 +56,7 @@ export let add = (a, b) => {
 };
 
 if (import.meta.hot) {
-  import.meta.hot.accept(({ module }) => {
+  import.meta.hot.accept(module => {
     add = module.add;
   });
 }
@@ -103,7 +103,7 @@ window.someGlobal = 303;
 import.meta.hot.accept();
 ```
 
-### `import.meta.hot.accept(({ module }) => { ... })`
+### `import.meta.hot.accept((module) => { ... })`
 
 If you pass a callback to `accept`, it will be passed the updated module
 any time an update occurs.
@@ -115,12 +115,12 @@ Example:
 
 ```ts
 export let foo = 808;
-import.meta.hot.accept(({ module }) => {
+import.meta.hot.accept(module => {
   foo = module.foo;
 });
 ```
 
-### `import.meta.hot.accept(['./dep1.js', './dep2.js'], ({ deps, module }) => { ... })`
+### `import.meta.hot.acceptDeps(['./dep1.js', './dep2.js'], ([dep1, dep2]) => { ... })`
 
 If you specify a list of dependencies as well as a callback, your callback
 will be provided with the up-to-date version of each of those modules.
@@ -135,7 +135,7 @@ import { add } from './add.js';
 
 export let foo = add(10, 10);
 
-import.meta.hot.accept(['./add.js'], ({ deps, module }) => {
+import.meta.hot.acceptDeps(['./add.js'], deps => {
   foo = deps[0].add(10, 10);
 });
 ```
@@ -150,7 +150,7 @@ Example:
 ```ts
 export let foo = 303;
 
-import.meta.hot.accept(({ module }) => {
+import.meta.hot.accept(module => {
   if (!module.foo) {
     import.meta.hot.invalidate();
   } else {
@@ -187,7 +187,7 @@ export let foo = new Server();
 
 foo.start();
 
-import.meta.hot.accept(({ module }) => {
+import.meta.hot.accept(module => {
   foo = module.foo;
   foo.start();
 });

--- a/packages/dev-server-hmr/src/hmrClientScript.ts
+++ b/packages/dev-server-hmr/src/hmrClientScript.ts
@@ -44,7 +44,7 @@ export class HotModule {
 
     sendMessage({ type: 'hmr:accept', id: this.id });
     this[moduleState] = HmrState.Accepted;
-    this[acceptHandlers].add(callback);
+    this[acceptHandlers].add(callback ?? () => {});
   }
 
   dispose(handler) {

--- a/packages/dev-server-hmr/src/hmrClientScript.ts
+++ b/packages/dev-server-hmr/src/hmrClientScript.ts
@@ -88,7 +88,7 @@ export class HotModule {
         Promise.resolve(handler.callback),
         Promise.all(handler.deps.map((path) => import(\`\${path}?m=\${time}\`)))
       ]);
-    ));
+    }));
 
     for (const [callback, modules] of results) {
       if (callback) {

--- a/packages/dev-server-hmr/src/hmrClientScript.ts
+++ b/packages/dev-server-hmr/src/hmrClientScript.ts
@@ -24,23 +24,27 @@ export class HotModule {
     this[moduleState] = HmrState.None;
   }
 
-  accept(deps, callback) {
+  acceptDeps(deps, callback) {
     if (this[moduleState] === HmrState.Accepted) {
       return;
     }
 
     sendMessage({ type: 'hmr:accept', id: this.id });
     this[moduleState] = HmrState.Accepted;
-
-    if (!callback) {
-      callback = deps;
-      deps = [];
-    }
-
-    this[acceptHandlers].add([
+    this[acceptHandlers].add({
       deps,
       callback
-    ]);
+    });
+  }
+
+  accept(callback) {
+    if (this[moduleState] === HmrState.Accepted) {
+      return;
+    }
+
+    sendMessage({ type: 'hmr:accept', id: this.id });
+    this[moduleState] = HmrState.Accepted;
+    this[acceptHandlers].add(callback);
   }
 
   dispose(handler) {
@@ -73,16 +77,22 @@ export class HotModule {
 
     const time = Date.now();
     const handlers = [...this[acceptHandlers]];
-    const results = await Promise.all(handlers.map(([depPaths, callback]) =>
-      Promise.all([
-        Promise.resolve(callback),
-        import(\`\${this.id}?m=\${time}\`),
-        ...depPaths.map((path) => import(\`\${path}?m=\${time}\`))
-    ])));
+    const results = await Promise.all(handlers.map((handler) => {
+      if (typeof handler === 'function') {
+        return Promise.all([
+          Promise.resolve(handler),
+          import(\`\${this.id}?m=\${time}\`)
+        ]);
+      }
+      return Promise.all([
+        Promise.resolve(handler.callback),
+        Promise.all(handler.deps.map((path) => import(\`\${path}?m=\${time}\`)))
+      ]);
+    ));
 
-    for (const [callback, module, ...deps] of results) {
+    for (const [callback, modules] of results) {
       if (callback) {
-        callback({deps, module});
+        callback(modules);
       }
     }
   }


### PR DESCRIPTION
Fixes #805.

This separates the 'catch all' accept() we have right now to:

```ts
acceptDeps([dep1, dep2], ([dep1, dep2]) => { ... });
accept((module) => { ... });
```

this does mean we've diverged from the esm-hmr repo but i will feed back into that as vite has also done this same implementation.