### PR TITLE
(web-dev-hmr) - Windows compatability

### DIFF
--- a/.changeset/chilly-lemons-learn.md
+++ b/.changeset/chilly-lemons-learn.md
@@ -1,0 +1,5 @@
+---
+"@web/dev-server-hmr": patch
+---
+
+fix windows paths issue

--- a/packages/dev-server-hmr/src/HmrPlugin.ts
+++ b/packages/dev-server-hmr/src/HmrPlugin.ts
@@ -9,7 +9,7 @@ import type {
 import WebSocket from 'ws';
 import type { Context } from 'koa';
 import { hmrClientScript } from './hmrClientScript';
-import { posix as pathUtil } from 'path';
+import path, { posix as pathUtil } from 'path';
 
 export interface HmrReloadMessage {
   type: 'hmr:reload';
@@ -173,8 +173,8 @@ export class HmrPlugin implements Plugin {
       return;
     }
 
-    const relativePath = pathUtil.relative(this._config.rootDir, filePath);
-    const browserPath = relativePath.split(pathUtil.sep).join('/');
+    const relativePath = path.relative(this._config.rootDir, filePath);
+    const browserPath = relativePath.split(path.sep).join('/');
     this._triggerUpdate(`/${browserPath}`);
   }
 


### PR DESCRIPTION
In the `_dependencyTree` you seem to rely on paths being converted to how they look on the OS for Windows this is look a bit different, hence why we can't use posix here.