### PR TITLE
(dev-server-hmr) - fix hmr bubbling and a syntax issue in the hmrClientScript

### DIFF
--- a/.changeset/afraid-carrots-guess.md
+++ b/.changeset/afraid-carrots-guess.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server-hmr': patch
+---
+
+Prevent dependencies from being cleared eagerly on serve, this prevented from updates to bubble to parents that do accept updates.

--- a/packages/dev-server-hmr/src/HmrPlugin.ts
+++ b/packages/dev-server-hmr/src/HmrPlugin.ts
@@ -80,11 +80,6 @@ export class HmrPlugin implements Plugin {
       }
       return hmrClientScript(this._webSockets);
     }
-
-    // We are serving a new file or it has changed, so clear all the
-    // dependencies we previously tracked (if any).
-    this._clearDependencies(context.path);
-    this._logger?.debug(`[hmr] Cleared dependency tree cache of ${context.path}`);
   }
 
   resolveImport({ source }: { source: string }) {
@@ -199,6 +194,11 @@ export class HmrPlugin implements Plugin {
       return;
     }
 
+    const dependents = new Set<string>(mod.dependents);
+
+    this._clearDependencies(path);
+    this._logger?.debug(`[hmr] Cleared dependency tree cache of ${path}`);
+
     // We're not aware of this module so can't handle it
     if (!mod) {
       this._broadcast({ type: 'hmr:reload' });
@@ -216,8 +216,8 @@ export class HmrPlugin implements Plugin {
     }
 
     // Trigger an update for every module that depends on this one
-    if (mod.dependents.size > 0) {
-      for (const dep of mod.dependents) {
+    if (dependents.size > 0) {
+      for (const dep of dependents) {
         this._triggerUpdate(dep, visited);
       }
       return;

--- a/packages/dev-server-hmr/src/hmrClientScript.ts
+++ b/packages/dev-server-hmr/src/hmrClientScript.ts
@@ -44,7 +44,7 @@ export class HotModule {
 
     sendMessage({ type: 'hmr:accept', id: this.id });
     this[moduleState] = HmrState.Accepted;
-    this[acceptHandlers].add(callback ?? () => {});
+    this[acceptHandlers].add(callback || function() {});
   }
 
   dispose(handler) {

--- a/packages/dev-server-hmr/src/hmrClientScript.ts
+++ b/packages/dev-server-hmr/src/hmrClientScript.ts
@@ -44,7 +44,7 @@ export class HotModule {
 
     sendMessage({ type: 'hmr:accept', id: this.id });
     this[moduleState] = HmrState.Accepted;
-    this[acceptHandlers].add(callback || function() {});
+    this[acceptHandlers].add(callback ?? (() => {}));
   }
 
   dispose(handler) {


### PR DESCRIPTION
Fixes a syntax issue in the client script and bubbling by not eagerly clearing deps

Fixes: https://github.com/modernweb-dev/web/issues/883