### PR TITLE
fix(test-runner-cli): avoid under 1 concurrency

### DIFF
--- a/.changeset/sweet-insects-buy.md
+++ b/.changeset/sweet-insects-buy.md
@@ -1,0 +1,6 @@
+---
+"@web/test-runner-cli": patch
+"@web/test-runner": patch
+---
+
+avoid under 1 concurrency

--- a/packages/test-runner-cli/src/config/readConfig.ts
+++ b/packages/test-runner-cli/src/config/readConfig.ts
@@ -16,7 +16,7 @@ const defaultBaseConfig: Partial<TestRunnerCoreConfig> = {
   protocol: 'http:',
   hostname: 'localhost',
   concurrentBrowsers: 2,
-  concurrency: cpus().length / 2,
+  concurrency: Math.max(1, cpus().length / 2),
   browserStartTimeout: minuteMs / 2,
   testsStartTimeout: secondMs * 20,
   testsFinishTimeout: minuteMs * 2,


### PR DESCRIPTION
Ensures that minimal concurrency is 1. On small VM (with 1 cpu), max concurrency could be 0.5 so the test suite never starts. 
