### PR TITLE
Renovate: automerge minor updates that aren't 0.x

### DIFF
--- a/packages/dev-server-core/package.json
+++ b/packages/dev-server-core/package.json
@@ -67,7 +67,7 @@
     "@types/parse5": "^5.0.3",
     "@types/uuid": "^8.0.0",
     "abort-controller": "^3.0.0",
-    "node-fetch": "v3.0.0-beta.9",
+    "node-fetch": "3.0.0-beta.9",
     "portfinder": "^1.0.28",
     "uuid": "^8.2.0"
   },

--- a/packages/dev-server-esbuild/package.json
+++ b/packages/dev-server-esbuild/package.json
@@ -54,7 +54,7 @@
     "@types/ua-parser-js": "^0.7.33",
     "es-dev-server": "^1.57.8",
     "lit-element": "^2.4.0",
-    "node-fetch": "v3.0.0-beta.9",
+    "node-fetch": "3.0.0-beta.9",
     "preact": "^10.5.7"
   },
   "exports": {

--- a/packages/dev-server-rollup/package.json
+++ b/packages/dev-server-rollup/package.json
@@ -62,7 +62,7 @@
     "@web/test-runner-chrome": "^0.7.0",
     "@web/test-runner-core": "^0.8.0",
     "chai": "^4.2.0",
-    "node-fetch": "v3.0.0-beta.9",
+    "node-fetch": "3.0.0-beta.9",
     "rollup-plugin-postcss": "^3.1.8"
   },
   "exports": {

--- a/renovate.json5
+++ b/renovate.json5
@@ -4,16 +4,26 @@
     "config:base"
   ],
 
+  // this allows us to configure settings for minor and patch updates separately
+  "separateMinorPatch": true,
+
   // rules for specific subsets of packages
   "packageRules": [
-    // for everything except major or minor updates
     {
-      "updateTypes": ["patch", "pin", "digest"],
-
-      // automatically merge, as long as tests pass
-      "automerge": true,
+      // for all patch updates
+      "updateTypes": ["patch"],
 
       // create a branch, wait for test results, and automerge if tests pass
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
+      // for minor updates that aren't 0.x
+      "updateTypes": ["minor"],
+      "matchCurrentVersion": "!/^[~^]?0/",
+
+      // create a branch, wait for test results, and automerge if tests pass
+      "automerge": true,
       "automergeType": "branch"
     }
   ],


### PR DESCRIPTION
## What I did

1. Changed the version string for `node-fetch` to remove the "v" (https://github.com/renovatebot/renovate/issues/7755)
2. Automatically merge minor updates that aren't `0.x` (patch updates will always be merged)
