### PR TITLE
feat(test-runner-selenium): add heartbeat timeout

### DIFF
--- a/.changeset/spotty-dolphins-sin.md
+++ b/.changeset/spotty-dolphins-sin.md
@@ -1,0 +1,7 @@
+---
+'@web/test-runner-selenium': patch
+'@web/test-runner-browserstack': patch
+'@web/test-runner-saucelabs': patch
+---
+
+add heartbeat interval to keep connection alive

--- a/packages/test-runner-selenium/src/seleniumLauncher.ts
+++ b/packages/test-runner-selenium/src/seleniumLauncher.ts
@@ -114,7 +114,7 @@ export class SeleniumLauncher implements BrowserLauncher {
         await this.driver.getTitle();
       } catch (e) {
         // Do nothing, just clear the timeout
-        clearTimeout(this.pendingHeartbeat);
+        clearInterval(this.pendingHeartbeat);
       }
       return;
     }, 60000);

--- a/packages/test-runner-selenium/src/seleniumLauncher.ts
+++ b/packages/test-runner-selenium/src/seleniumLauncher.ts
@@ -16,7 +16,7 @@ export class SeleniumLauncher implements BrowserLauncher {
   private iframeManager?: IFrameManager;
   private __iframeManagerPromise?: Promise<IFrameManager>;
   private isIE = false;
-  private pendingHeartbeat!: NodeJS.Timeout;
+  private pendingHeartbeat!: ReturnType<typeof setInterval>;
 
   constructor(private driverBuilder: Builder) {}
 
@@ -48,7 +48,6 @@ export class SeleniumLauncher implements BrowserLauncher {
 
   async startSession(id: string, url: string) {
     await this.ensureIframeManagerInitialized();
-    this.heartbeat();
     return this.iframeManager!.queueStartSession(id, url);
   }
 
@@ -66,7 +65,7 @@ export class SeleniumLauncher implements BrowserLauncher {
   async stopSession(id: string) {
     // If there is still pending heartbeat, clear the timeout
     if (this.pendingHeartbeat) {
-      clearTimeout(this.pendingHeartbeat);
+      clearInterval(this.pendingHeartbeat);
     }
     return this.iframeManager!.queueStopSession(id);
   }
@@ -92,6 +91,8 @@ export class SeleniumLauncher implements BrowserLauncher {
     this.__iframeManagerPromise = this.createiframeManager();
     await this.__iframeManagerPromise;
     this.__iframeManagerPromise = undefined;
+
+    this.heartbeat();
   }
 
   private async createiframeManager() {
@@ -104,16 +105,13 @@ export class SeleniumLauncher implements BrowserLauncher {
   }
 
   private heartbeat() {
-    const driver = this.driver;
-
     // Heartbeat function to keep alive sessions on Sauce Labs via WebDriver calls
-    this.pendingHeartbeat = setTimeout(async () => {
-      if (!driver) {
+    this.pendingHeartbeat = setInterval(async () => {
+      if (!this.driver) {
         return;
       }
       try {
-        await driver.getTitle();
-        this.heartbeat();
+        await this.driver.getTitle();
       } catch (e) {
         // Do nothing, just clear the timeout
         clearTimeout(this.pendingHeartbeat);


### PR DESCRIPTION
## What I did

1. Added heartbeat timeout to `test-runner-selenium` for keeping connection alive in SauceLabs

Fixes #945 

Note: it would make more sense to implement this in `@web/test-runner-saucelabs` but that would require some refactoring, e.g. we need to expose `driver` instance, which is currently private, to setup the heartbeat interval.