### PR TITLE
chore: cleanup dev-server-cli leftovers

### DIFF
--- a/.changeset/heavy-swans-arrive.md
+++ b/.changeset/heavy-swans-arrive.md
@@ -1,0 +1,5 @@
+---
+"@web/dev-server": patch
+---
+
+chore: cleanup dev-server-cli leftovers

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -53,7 +53,6 @@
     "@rollup/plugin-node-resolve": "^8.4.0",
     "@types/command-line-args": "^5.0.0",
     "@web/config-loader": "^0.1.1",
-    "@web/dev-server-cli": "^0.0.3",
     "@web/dev-server-core": "^0.2.17",
     "@web/dev-server-rollup": "^0.2.11",
     "camelcase": "^6.0.0",

--- a/packages/tsconfig.project.json
+++ b/packages/tsconfig.project.json
@@ -33,9 +33,6 @@
       "path": "./dev-server/tsconfig.json"
     },
     {
-      "path": "./dev-server-cli/tsconfig.json"
-    },
-    {
       "path": "./dev-server-esbuild/tsconfig.json"
     },
     {


### PR DESCRIPTION
## What I did

1. Removed obsolete `@wev/dev-server-cli` dependency to get rid of warning:

```sh
$ npm i @web/dev-server -D
npm WARN deprecated @web/dev-server-cli@0.0.3: This packages is merged into @web/dev-server
```