### PR TITLE
docs(html-tests): fix error when following the docs

### DIFF
--- a/docs/docs/test-runner/writing-tests/html-tests.md
+++ b/docs/docs/test-runner/writing-tests/html-tests.md
@@ -9,7 +9,7 @@ With mocha, you need to define your tests inside the `runTests` function:
   <body>
     <script type="module">
       import { runTests } from '@web/test-runner-mocha';
-      import { expect } from "@esm-bundle/chai";
+      import { expect } from '@esm-bundle/chai';
 
       runTests(async () => {
         // write your tests inline

--- a/docs/docs/test-runner/writing-tests/html-tests.md
+++ b/docs/docs/test-runner/writing-tests/html-tests.md
@@ -9,6 +9,7 @@ With mocha, you need to define your tests inside the `runTests` function:
   <body>
     <script type="module">
       import { runTests } from '@web/test-runner-mocha';
+      import { expect } from "@esm-bundle/chai";
 
       runTests(async () => {
         // write your tests inline


### PR DESCRIPTION
## What I did

Add a package to the imports so that `expect` will be defined.

