### PR TITLE
[hmr] implement bubbles option

### DIFF
--- a/packages/dev-server-core/src/test-helpers.ts
+++ b/packages/dev-server-core/src/test-helpers.ts
@@ -10,6 +10,7 @@ import { Plugin } from './Plugin';
 
 const defaultConfig: Omit<DevServerCoreConfig, 'port' | 'rootDir'> = {
   hostname: 'localhost',
+  injectWebSocket: true,
   middleware: [],
   plugins: [],
 };

--- a/packages/dev-server-hmr/package.json
+++ b/packages/dev-server-hmr/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@types/puppeteer": "^3.0.5",
-    "puppeteer": "^5.2.1",
-    "lit-html": "^1.3.0"
+    "lit-html": "^1.3.0",
+    "puppeteer": "^5.2.1"
   }
 }

--- a/packages/dev-server-hmr/package.json
+++ b/packages/dev-server-hmr/package.json
@@ -42,6 +42,8 @@
     "@web/dev-server-core": "^0.2.15"
   },
   "devDependencies": {
+    "@types/puppeteer": "^3.0.5",
+    "puppeteer": "^5.2.1",
     "lit-html": "^1.3.0"
   }
 }

--- a/packages/dev-server-hmr/scripts/hmrClientScript.js
+++ b/packages/dev-server-hmr/scripts/hmrClientScript.js
@@ -34,14 +34,23 @@ export class HotModule {
     });
   }
 
-  accept(callback) {
+  accept(callbackOrOptions, options) {
+    let callback;
+
+    if (typeof callbackOrOptions === 'function') {
+      callback = callbackOrOptions;
+    } else {
+      options = callbackOrOptions;
+      callback = () => {};
+    }
+
     if (this[moduleState] === HmrState.Accepted) {
       return;
     }
 
-    sendMessage({ type: 'hmr:accept', id: this.id });
+    sendMessage({ type: 'hmr:accept', id: this.id, options });
     this[moduleState] = HmrState.Accepted;
-    this[acceptHandlers].add(callback || (() => {}));
+    this[acceptHandlers].add(callback);
   }
 
   dispose(handler) {

--- a/packages/dev-server-hmr/test/HmrPlugin.test.ts
+++ b/packages/dev-server-hmr/test/HmrPlugin.test.ts
@@ -268,7 +268,6 @@ describe('HmrPlugin', () => {
       rootDir: __dirname,
       plugins: [
         mockFile('/foo.html', '<script src="/foo.js" type="module"></script>'),
-        mockFile('/bar.html', '<script src="/bar.js" type="module"></script>'),
         mockFile('/foo.js', `import '/bar.js'; import.meta.hot.accept();`),
         mockFile('/bar.js', `import.meta.hot.accept({ bubbles: true })`),
         hmrPlugin(),
@@ -278,8 +277,7 @@ describe('HmrPlugin', () => {
     const stub = stubMethod(webSockets, 'send');
     const page = await browser.newPage();
     try {
-      await page.goto(`${host}/foo.html`);
-      await page.goto(`${host}/bar.html`);
+      await page.goto(`${host}/foo.html`, { waitUntil: 'networkidle0' });
       fileWatcher.emit('change', pathUtil.join(__dirname, '/bar.js'));
 
       expect(stub.callCount).to.equal(2);

--- a/packages/dev-server-hmr/test/HmrPlugin.test.ts
+++ b/packages/dev-server-hmr/test/HmrPlugin.test.ts
@@ -1,3 +1,4 @@
+import * as puppeteer from 'puppeteer';
 import { expect } from 'chai';
 import { Context } from 'koa';
 import fetch from 'node-fetch';
@@ -17,8 +18,15 @@ const mockFile = (path: string, source: string) => ({
 });
 
 describe('HmrPlugin', () => {
-  afterEach(() => {
+  let browser: puppeteer.Browser;
+
+  beforeEach(async () => {
+    browser = await puppeteer.launch();
+  });
+
+  afterEach(async () => {
     restoreStubs();
+    await browser.close();
   });
 
   it('should emit update for tracked files', async () => {
@@ -250,6 +258,43 @@ describe('HmrPlugin', () => {
       const body = await response.text();
 
       expect(body.includes('__WDS_HMR__')).to.equal(false);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('should bubble when bubbles is true', async () => {
+    const { server, host } = await createTestServer({
+      rootDir: __dirname,
+      plugins: [
+        mockFile('/foo.html', '<script src="/foo.js" type="module"></script>'),
+        mockFile('/bar.html', '<script src="/bar.js" type="module"></script>'),
+        mockFile('/foo.js', `import '/bar.js'; import.meta.hot.accept();`),
+        mockFile('/bar.js', `import.meta.hot.accept({ bubbles: true })`),
+        hmrPlugin(),
+      ],
+    });
+    const { fileWatcher, webSockets } = server;
+    const stub = stubMethod(webSockets, 'send');
+    const page = await browser.newPage();
+    try {
+      await page.goto(`${host}/foo.html`);
+      await page.goto(`${host}/bar.html`);
+      fileWatcher.emit('change', pathUtil.join(__dirname, '/bar.js'));
+
+      expect(stub.callCount).to.equal(2);
+      expect(stub.getCall(0)!.args[0]).to.equal(
+        JSON.stringify({
+          type: 'hmr:update',
+          url: '/bar.js',
+        }),
+      );
+      expect(stub.getCall(1)!.args[0]).to.equal(
+        JSON.stringify({
+          type: 'hmr:update',
+          url: '/foo.js',
+        }),
+      );
     } finally {
       await server.stop();
     }

--- a/packages/dev-server-hmr/test/HmrPlugin.test.ts
+++ b/packages/dev-server-hmr/test/HmrPlugin.test.ts
@@ -1,4 +1,4 @@
-import * as puppeteer from 'puppeteer';
+import { Browser, launch as launchPuppeteer } from 'puppeteer';
 import { expect } from 'chai';
 import { Context } from 'koa';
 import fetch from 'node-fetch';
@@ -18,10 +18,10 @@ const mockFile = (path: string, source: string) => ({
 });
 
 describe('HmrPlugin', () => {
-  let browser: puppeteer.Browser;
+  let browser: Browser;
 
   beforeEach(async () => {
-    browser = await puppeteer.launch();
+    browser = await launchPuppeteer();
   });
 
   afterEach(async () => {


### PR DESCRIPTION
This reworks the bubbling mechanism a bit.

By default, a module will now stop bubbling if it accepts updates.

You can override this default by passing a `bubbles` option: `accept(fn, { bubbles: true })`