### PR TITLE
fix(hmr): clean up bubbling logic

### DIFF
--- a/.changeset/chilled-otters-stare.md
+++ b/.changeset/chilled-otters-stare.md
@@ -1,0 +1,5 @@
+---
+"@web/dev-server-hmr": patch
+---
+
+clean up bubbling logic


### PR DESCRIPTION
This is a slight cleanup of the hmr bubbling logic.

We had cases where the update method could return without emitting a message. I have now removed this so we can assume if an update runs, a message is ultimately triggered one way or another.

This now means the recent check that was added (`dependents.size === 0`) is valid since, if we reach that point, it is guaranteed nothing else has emitted a message.