### PR TITLE
fix(dev-server-core): Fix fileWatcher listener of PluginTransformCach…

### DIFF
--- a/.changeset/big-snails-joke.md
+++ b/.changeset/big-snails-joke.md
@@ -1,0 +1,6 @@
+---
+"@web/dev-server-core": patch
+"@web/dev-server": patch
+---
+
+Bust cache when a file is deleted

--- a/packages/dev-server-core/src/middleware/PluginTransformCache.ts
+++ b/packages/dev-server-core/src/middleware/PluginTransformCache.ts
@@ -43,14 +43,17 @@ export class PluginTransformCache {
     });
 
     // remove file from cache on change
-    fileWatcher.addListener('change', (filePath: string) => {
+    const removeCacheListener = (filePath: string) => {
       const cacheKeys = this.cacheKeysPerFilePath.get(filePath);
       if (cacheKeys) {
         for (const cacheKey of cacheKeys) {
           this.lruCache.del(cacheKey);
         }
       }
-    });
+    };
+
+    fileWatcher.addListener('change', removeCacheListener);
+    fileWatcher.addListener('unlink', removeCacheListener);
   }
 
   async get(cacheKey: string) {


### PR DESCRIPTION
Fix fileWatcher listener of PluginTransformCache when file is removed or renamed.

## What I did

1. Move `change` listener to const `removeCacheListener`
2. Set listener `removeCacheListener` to `change` and `unlink` event.
