### PR TITLE
fix(test-runner): run node-resolve after using plugins

### DIFF
--- a/.changeset/shy-olives-arrive.md
+++ b/.changeset/shy-olives-arrive.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner': minor
+---
+
+fix(test-runner): run node-resolve after user plugins

--- a/packages/test-runner/src/startTestRunner.ts
+++ b/packages/test-runner/src/startTestRunner.ts
@@ -212,7 +212,8 @@ export async function startTestRunner(options: StartTestRunnerOptions = {}) {
 
     if (config.nodeResolve) {
       const userOptions = typeof config.nodeResolve === 'object' ? config.nodeResolve : undefined;
-      config.plugins!.unshift(nodeResolvePlugin(rootDir, config.preserveSymlinks, userOptions));
+      // do node resolve after user plugins, to allow user plugins to resolve imports
+      config.plugins.push(nodeResolvePlugin(rootDir, config.preserveSymlinks, userOptions));
     }
 
     if (config.esbuildTarget) {


### PR DESCRIPTION
## What I did

Run node-resolve after using plugins, so that another plugin can resolve imports instead of node-resolve.
