### PR TITLE
fix: don't clear scrollback history

### DIFF
--- a/.changeset/unlucky-ads-share.md
+++ b/.changeset/unlucky-ads-share.md
@@ -1,0 +1,6 @@
+---
+'@web/dev-server': patch
+'@web/test-runner-cli': patch
+---
+
+don't clear scrollback buffer

--- a/packages/dev-server/src/logger/createLogger.ts
+++ b/packages/dev-server/src/logger/createLogger.ts
@@ -2,7 +2,7 @@ import { Plugin } from '@web/dev-server-core';
 import { DevServerLogger } from './DevServerLogger';
 import { logStartMessage } from './logStartMessage';
 
-const CLEAR_COMMAND = process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H';
+const CLEAR_COMMAND = process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[H';
 
 export interface LoggerArgs {
   debugLogging: boolean;

--- a/packages/test-runner-cli/src/terminal/DynamicTerminal.ts
+++ b/packages/test-runner-cli/src/terminal/DynamicTerminal.ts
@@ -3,7 +3,7 @@ import logUpdate from 'log-update';
 import cliCursor from 'cli-cursor';
 import { BufferedConsole } from './BufferedConsole';
 
-const CLEAR_COMMAND = process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H';
+const CLEAR_COMMAND = process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[H';
 
 interface EventMap {
   input: string;


### PR DESCRIPTION
## What I did

- Updated the ANSI escape codes in `dev-server` and `test-runner-cli` so it doesn't clear the scrollback history.

When I'm developing, I sometimes need to scroll up to see the results of a previous command. This isn't possible if `dev-server` clears the scrollback history. In addition, my terminal emulator (iTerm) blocks this escape code from working by default and displays a warning message. I think `dev-server` should not try to clear the scrollback history.

<img width="557" alt="Screenshot of the iTerm terminal app with an alert message: 'A control sequence attempted to clear scrollback history. Allow this in the future?'" src="https://user-images.githubusercontent.com/4148577/100521267-6d9c7380-3170-11eb-8bed-b2371c1d9642.png">

The ANSI escape codes used are the following:
- `\x1B[2J`: clear entire screen
- `\x1B[3J`: clear entire screen and erase scrollback history
- `\x1B[H`: move the cursor to the top-left corner

I deleted the second escape code. This still clears the screen and moves the cursor, but it doesn't erase the scrollback history.

I verified that this change works on my Mac with both iTerm and Terminal.app.