### PR TITLE
fix(test-runner-webdriver): rename launcher type

### DIFF
--- a/.changeset/metal-terms-poke.md
+++ b/.changeset/metal-terms-poke.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-webdriver': patch
+---
+
+Update launcher type to webdriver

--- a/packages/test-runner-webdriver/src/webdriverLauncher.ts
+++ b/packages/test-runner-webdriver/src/webdriverLauncher.ts
@@ -6,7 +6,7 @@ import { getBrowserLabel } from './utils';
 
 export class WebdriverLauncher implements BrowserLauncher {
   public name = 'Initializing...';
-  public type = 'wdio';
+  public type = 'webdriver';
   private config?: TestRunnerCoreConfig;
   private driver?: BrowserObject;
   private debugDriver: undefined | BrowserObject = undefined;


### PR DESCRIPTION
## What I did

1. Updated type from `wdio` to `webdriver` (this will be used later in the visual regression plugin)
