### PR TITLE
feat(test-runner-visual-regression): add webdriver support

### DIFF
--- a/.changeset/young-ducks-raise.md
+++ b/.changeset/young-ducks-raise.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-visual-regression': patch
+---
+
+Add Webdriver launcher support

--- a/packages/test-runner-visual-regression/package.json
+++ b/packages/test-runner-visual-regression/package.json
@@ -57,6 +57,7 @@
   "devDependencies": {
     "@web/test-runner-chrome": "^0.7.2",
     "@web/test-runner-playwright": "^0.6.4",
+    "@web/test-runner-webdriver": "^0.0.3",
     "mocha": "^8.2.1"
   }
 }

--- a/packages/test-runner-visual-regression/tsconfig.json
+++ b/packages/test-runner-visual-regression/tsconfig.json
@@ -36,6 +36,9 @@
     },
     {
       "path": "../test-runner-commands/tsconfig.json"
+    },
+    {
+      "path": "../test-runner-webdriver/tsconfig.json"
     }
   ],
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -68,6 +68,9 @@
       "path": "./packages/dev-server/tsconfig.json"
     },
     {
+      "path": "./packages/test-runner-webdriver/tsconfig.json"
+    },
+    {
       "path": "./packages/rollup-plugin-copy/tsconfig.json"
     },
     {
@@ -96,9 +99,6 @@
     },
     {
       "path": "./packages/test-runner-visual-regression/tsconfig.json"
-    },
-    {
-      "path": "./packages/test-runner-webdriver/tsconfig.json"
     }
   ]
 }


### PR DESCRIPTION
## What I did

1. Added Webdriver launcher support to `@web/test-runner-visual-regression`.

This feature is recommended to be used with `concurrency: 1` to avoid permanent switching between iframes.