### PR TITLE
Visual regression diff fix

### DIFF
--- a/.changeset/strong-mayflies-cheat.md
+++ b/.changeset/strong-mayflies-cheat.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-visual-regression': patch
+---
+
+Fixing bugs related to writing failed and diff images

--- a/packages/test-runner-visual-regression/src/pixelMatchDiff.ts
+++ b/packages/test-runner-visual-regression/src/pixelMatchDiff.ts
@@ -25,7 +25,7 @@ export function pixelMatchDiff({ baselineImage, image, options }: DiffArgs): Dif
   const diffPercentage = (numDiffPixels / (width * height)) * 100;
 
   return {
-    diffImage: diff.data,
+    diffImage: PNG.sync.write(diff),
     diffPercentage,
   };
 }

--- a/packages/test-runner-visual-regression/src/visualDiffCommand.ts
+++ b/packages/test-runner-visual-regression/src/visualDiffCommand.ts
@@ -64,7 +64,7 @@ export async function visualDiffCommand(
       filePath: resolveImagePath(baseDir, failedName),
       baseDir,
       name: failedName,
-      content: diffImage,
+      content: image,
     });
   }
 


### PR DESCRIPTION
## Problem
The generated artifacts for the failed and diff images couldn't be viewed.
The diff image was written both as the failed and as the diff.
The diff image was written incorrectly.

## What I did

1. Fixed bugs for diff and failed images generated by the visual-regression package
