### PR TITLE
feat(dev-server-core): handle modules resolved outside root dir

### DIFF
--- a/.changeset/four-seals-refuse.md
+++ b/.changeset/four-seals-refuse.md
@@ -1,0 +1,9 @@
+---
+'@web/dev-server': minor
+'@web/dev-server-core': minor
+'@web/dev-server-rollup': minor
+'@web/test-runner': minor
+'@web/test-runner-core': minor
+---
+
+handle modules resolved outside root dir

--- a/.eslintignore
+++ b/.eslintignore
@@ -9,7 +9,8 @@
 /integration/test-runner/tests/*/browser-tests
 /packages/dev-server-storybook/storybook-static/**/*
 /packages/dev-server-hmr/scripts/**/*
-node_modules
+/node_modules/
+/packages/*/node_modules/
 dist
 demo
 CHANGELOG.md

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@
 coverage/
 
 ## npm
-node_modules/
+/node_modules/
+/packages/*/node_modules/
 npm-debug.log
 yarn-error.log
 

--- a/packages/dev-server-core/package.json
+++ b/packages/dev-server-core/package.json
@@ -67,6 +67,7 @@
     "isbinaryfile": "^4.0.6",
     "koa": "^2.13.0",
     "koa-etag": "^4.0.0",
+    "koa-send": "^5.0.1",
     "koa-static": "^5.0.0",
     "lru-cache": "^6.0.0",
     "mime-types": "^2.1.27",

--- a/packages/dev-server-core/src/middleware/serveFilesMiddleware.ts
+++ b/packages/dev-server-core/src/middleware/serveFilesMiddleware.ts
@@ -1,0 +1,39 @@
+import { Middleware } from 'koa';
+import path from 'path';
+import send from 'koa-send';
+import koaStatic, { Options as KoaStaticOptions } from 'koa-static';
+
+const OUTSIDE_ROOT_KEY = '/__wds-outside-root__/';
+
+export function serveFilesMiddleware(rootDir: string): Middleware[] {
+  const koaStaticOptions: KoaStaticOptions = {
+    hidden: true,
+    defer: true,
+    brotli: false,
+    gzip: false,
+    setHeaders(res) {
+      res.setHeader('cache-control', 'no-cache');
+    },
+  };
+
+  // the wds-root-dir parameter indicates using a different root directory as a path relative
+  // from the regular root dir or as an absolute path
+  const serveCustomRootDirMiddleware: Middleware = async (ctx, next) => {
+    if (ctx.path.startsWith(OUTSIDE_ROOT_KEY)) {
+      const [, , depthString] = ctx.path.split('/');
+      const depth = Number(depthString);
+      if (depth == null || Number.isNaN(depth)) {
+        throw new Error(`Invalid wds-root-dir path: ${ctx.path}`);
+      }
+
+      ctx.path = ctx.path.replace(`${OUTSIDE_ROOT_KEY}${depth}`, '');
+      const localRootDir = path.resolve(rootDir, `..${path.sep}`.repeat(depth));
+      await send(ctx, ctx.path, { ...koaStaticOptions, root: localRootDir });
+      return;
+    }
+    return next();
+  };
+
+  // serve static files from the regular root dir
+  return [serveCustomRootDirMiddleware, koaStatic(rootDir, koaStaticOptions)];
+}

--- a/packages/dev-server-core/src/server/createMiddleware.ts
+++ b/packages/dev-server-core/src/server/createMiddleware.ts
@@ -1,6 +1,5 @@
 import { Middleware } from 'koa';
 import koaEtag from 'koa-etag';
-import koaStatic from 'koa-static';
 import { FSWatcher } from 'chokidar';
 
 import { DevServerCoreConfig } from '../DevServerCoreConfig';
@@ -13,6 +12,7 @@ import { pluginTransformMiddleware } from '../middleware/pluginTransformMiddlewa
 import { Logger } from '../logger/Logger';
 import { watchServedFilesMiddleware } from '../middleware/watchServedFilesMiddleware';
 import { pluginFileParsedMiddleware } from '../middleware/pluginFileParsedMiddleware';
+import { serveFilesMiddleware } from '../middleware/serveFilesMiddleware';
 
 /**
  * Creates middlewares based on the given configuration. The middlewares can be
@@ -60,19 +60,7 @@ export function createMiddleware(
   middlewares.push(pluginTransformMiddleware(logger, config, fileWatcher));
   middlewares.push(pluginMimeTypeMiddleware(logger, plugins));
   middlewares.push(pluginServeMiddleware(logger, plugins));
-
-  // serve static files
-  middlewares.push(
-    koaStatic(config.rootDir, {
-      hidden: true,
-      defer: true,
-      brotli: false,
-      gzip: false,
-      setHeaders(res) {
-        res.setHeader('cache-control', 'no-cache');
-      },
-    }),
-  );
+  middlewares.push(...serveFilesMiddleware(config.rootDir));
 
   return middlewares;
 }

--- a/packages/dev-server-core/test/fixtures/outside-root-dir/node_modules/foo/index.js
+++ b/packages/dev-server-core/test/fixtures/outside-root-dir/node_modules/foo/index.js
@@ -1,0 +1,1 @@
+export default 'foo';

--- a/packages/dev-server-core/test/helpers.ts
+++ b/packages/dev-server-core/test/helpers.ts
@@ -10,8 +10,8 @@ import { DevServerCoreConfig } from '../src/DevServerCoreConfig';
 
 export function createTestServer(config: Partial<DevServerCoreConfig> = {}) {
   return originalCreateTestServer({
-    ...config,
     rootDir: path.resolve(__dirname, 'fixtures', 'basic'),
+    ...config,
   });
 }
 

--- a/packages/dev-server-core/test/middleware/serveFilesMiddleware.test.ts
+++ b/packages/dev-server-core/test/middleware/serveFilesMiddleware.test.ts
@@ -1,0 +1,31 @@
+import { expect } from 'chai';
+import fetch from 'node-fetch';
+import path from 'path';
+
+import { createTestServer } from '../helpers';
+
+describe('serveFilesMiddleware', () => {
+  it('can serve files outside of the root directory', async () => {
+    const { host, server } = await createTestServer({
+      plugins: [{ name: 'test' }],
+      rootDir: path.resolve(
+        __dirname,
+        '..',
+        'fixtures',
+        'outside-root-dir',
+        'packages',
+        'package-a',
+      ),
+    });
+
+    try {
+      const response = await fetch(`${host}/__wds-outside-root__/2/node_modules/foo/index.js`);
+      const responseText = await response.text();
+
+      expect(response.status).to.equal(200);
+      expect(responseText).to.include("export default 'foo'");
+    } finally {
+      server.stop();
+    }
+  });
+});

--- a/packages/dev-server-rollup/src/utils.ts
+++ b/packages/dev-server-rollup/src/utils.ts
@@ -8,7 +8,7 @@ const REGEXP_ABSOLUTE = /^(?:\/|(?:[A-Za-z]:)?[\\|/])/;
  * @returns {string}
  */
 export function toBrowserPath(filePath: string) {
-  return filePath.replace(new RegExp(path.sep === '\\' ? '\\\\' : path.sep, 'g'), '/');
+  return filePath.split(path.sep).join('/');
 }
 
 export function isAbsoluteFilePath(path: string) {

--- a/packages/dev-server/demo/node-resolve/config.mjs
+++ b/packages/dev-server/demo/node-resolve/config.mjs
@@ -1,8 +1,8 @@
-import path from 'path';
 import { fileURLToPath } from 'url';
+import { resolve } from 'path';
 
 export default {
-  rootDir: fileURLToPath(path.join(import.meta.url, '../../../../..')),
-  appIndex: '/packages/dev-server/demo/node-resolve/index.html',
+  rootDir: resolve(fileURLToPath(import.meta.url), '..', '..', '..'),
+  appIndex: '/demo/node-resolve/index.html',
   nodeResolve: true,
 };

--- a/packages/test-runner/demo/test/chai.js
+++ b/packages/test-runner/demo/test/chai.js
@@ -1,4 +1,4 @@
-import '../../../../node_modules/chai/chai.js';
+import 'chai/chai.js';
 
 export const expect = window.chai.expect;
 export const assert = window.chai.assert;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7163,7 +7163,7 @@ koa-etag@^4.0.0:
   dependencies:
     etag "^1.8.1"
 
-koa-send@^5.0.0:
+koa-send@^5.0.0, koa-send@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/koa-send/-/koa-send-5.0.1.tgz#39dceebfafb395d0d60beaffba3a70b4f543fe79"
   integrity sha512-tmcyQ/wXXuxpDxyNXv5yNNkdAMdFRqwtegBXUaowiQzUKqJehttS0x2j0eOZDQAyloAth5w6wwBImnFzkUz3pQ==


### PR DESCRIPTION
## What I did

This fixes a long-standing issue with es-dev-server, web dev server and web test runner where it can't serve modules outside of the root directory of the web server.

When we encounter a file resolved to a path outside of the root dir we rewrite it with the following pattern:
```
/__wds-outside-root__/${depth}/${originalPath}
``` 

When we see an import with this path server side, we look at the depth walk up the file system with the specified depth:

```js
const newRootDir = path.join(rootDir, '../'.repeat(depth));
```

This avoids dumping the whole file path in the browser URL.

Resolving modules becomes a more plug-and-play experience. Users won't need to expand the root directory anymore in monorepo projects (`--root-dir ../../`) and for demo pages the URL doesn't need to include the package name anymore (`/packages/package-foo/demo/`).

Fixes https://github.com/modernweb-dev/web/issues/1039