### PR TITLE
fix(dev-server-esbuild): handle calling without parameters

### DIFF
--- a/packages/dev-server-esbuild/src/esbuildPluginFactory.ts
+++ b/packages/dev-server-esbuild/src/esbuildPluginFactory.ts
@@ -15,7 +15,7 @@ export interface EsBuildPluginArgs {
   define?: { [key: string]: string };
 }
 
-export function esbuildPlugin(args: EsBuildPluginArgs): Plugin {
+export function esbuildPlugin(args: EsBuildPluginArgs = {}): Plugin {
   const target = args.target ?? 'auto';
   const loaders: Record<string, Loader> = {};
   for (const [key, value] of Object.entries(args.loaders ?? {})) {


### PR DESCRIPTION
## Motivation
Kinda surprised when I call `hmrPlugin()` and found this error
```
@web/dev-server-esbuild/dist/esbuildPluginFactory.js:7
    const target = (_a = args.target) !== null && _a !== void 0 ? _a : 'auto';
                              ^

TypeError: Cannot read property 'target' of undefined
```
Although calling `hmrPlugin({})` works fine.

## What I did

1. add `{}` as default args since all keys are optional


