### PR TITLE
fix(test-runner-saucelabs): lazily create webdriver connection

### DIFF
--- a/.changeset/twenty-camels-train.md
+++ b/.changeset/twenty-camels-train.md
@@ -1,0 +1,7 @@
+---
+'@web/test-runner-webdriver': patch
+'@web/test-runner-browserstack': patch
+'@web/test-runner-saucelabs': patch
+---
+
+lazily create webdriver connection


### PR DESCRIPTION
## What I did

Lazily create webdriver connection. This avoids opening a connection for each browser from the start, instead creating them only when we start running tests on a browser.