### PR TITLE
fix(test-runner): include URL params when resolving stack traces

### DIFF
--- a/.changeset/thick-teachers-fry.md
+++ b/.changeset/thick-teachers-fry.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner': patch
+---
+
+include url params when resolving stack traces

--- a/packages/test-runner/src/reporter/utils/createStackLocationRegExp.ts
+++ b/packages/test-runner/src/reporter/utils/createStackLocationRegExp.ts
@@ -10,7 +10,7 @@ export function createStackLocationRegExp(protocol: string, hostname: string, po
       `((?:${validUrlChars})*\\.\\w{2,6})` +
       // must end with a file extension
       // may optionally contain query params or hashes, which are stripped off
-      `(?:(?:${validUrlChars}|#|\\?|=)*)` +
+      `((?:${validUrlChars}|#|\\?|=)*)` +
       // must contain line and column markers
       '(?::(\\d+))(?::(\\d+))' +
       // must end at the end of the string, with an optional )

--- a/packages/test-runner/src/reporter/utils/getRelativeStackFilePath.ts
+++ b/packages/test-runner/src/reporter/utils/getRelativeStackFilePath.ts
@@ -13,14 +13,14 @@ export async function getRelativeStackFilePath(
   const match = string.match(stackLocationRegExp);
 
   if (match) {
-    const [, prefix, browserPath, line, column, suffix] = match;
-    const pathWithoutParams = browserPath.split('?')[0].split('#')[0];
-    const fullFilePath = pathWithoutParams.startsWith(rootDir)
-      ? pathWithoutParams
-      : path.join(rootDir, toFilePath(pathWithoutParams));
+    const [, prefix, browserPath, browserParams, line, column, suffix] = match;
+    const fullFilePath = browserPath.startsWith(rootDir)
+      ? browserPath
+      : path.join(rootDir, toFilePath(browserPath));
+    const fullBrowserPath = `${browserPath}${browserParams}`;
 
     const sourceMapResult = await sourceMapFunction(
-      pathWithoutParams,
+      fullBrowserPath,
       fullFilePath,
       userAgent,
       Number(line),


### PR DESCRIPTION
## What I did

When resolving source maps for logged stack traces, we now include the URL parameters which are important for example for the legacy and import map plugins.
