### PR TITLE
fix(dev-server-core): match dotfiles when resolving mimetypes

### DIFF
--- a/.changeset/soft-ants-confess.md
+++ b/.changeset/soft-ants-confess.md
@@ -1,0 +1,8 @@
+---
+'@web/dev-server-core': patch
+'@web/dev-server': patch
+'@web/test-runner': patch
+'@web/test-runner-core': patch
+---
+
+match dotfiles when resolving mimetypes

--- a/packages/dev-server-core/src/plugins/mimeTypesPlugin.ts
+++ b/packages/dev-server-core/src/plugins/mimeTypesPlugin.ts
@@ -8,7 +8,7 @@ import { getRequestFilePath } from '../utils';
 function createMatcher(rootDir: string, pattern: string) {
   const resolvedPattern =
     !isAbsolute(pattern) && !pattern.startsWith('*') ? posix.join(rootDir, pattern) : pattern;
-  return picoMatch(resolvedPattern);
+  return picoMatch(resolvedPattern, { dot: true });
 }
 
 interface Matcher {


### PR DESCRIPTION
## What I did

1. Match dotfiles when resolving mimetypes fixes https://github.com/modernweb-dev/web/issues/1125
