### PR TITLE
feat: filter out non-object plugins from config

### DIFF
--- a/.changeset/tender-houses-repair.md
+++ b/.changeset/tender-houses-repair.md
@@ -1,0 +1,6 @@
+---
+'@web/dev-server': patch
+'@web/test-runner': patch
+---
+
+filter out non-objects from config

--- a/packages/dev-server/src/config/parseConfig.ts
+++ b/packages/dev-server/src/config/parseConfig.ts
@@ -60,6 +60,8 @@ export async function parseConfig(
 ): Promise<DevServerConfig> {
   const mergedConfigs = mergeConfigs(defaultConfig, config, cliArgs);
   const finalConfig = validateConfig(mergedConfigs);
+  // filter out non-objects from plugin list
+  finalConfig.plugins = (finalConfig.plugins ?? []).filter(pl => typeof pl === 'object');
 
   // ensure rootDir is always resolved
   if (typeof finalConfig.rootDir === 'string') {

--- a/packages/test-runner/src/config/parseConfig.ts
+++ b/packages/test-runner/src/config/parseConfig.ts
@@ -135,6 +135,8 @@ export async function parseConfig(
 
   const mergedConfigs = mergeConfigs(defaultConfig, config, cliArgsConfig);
   const finalConfig = validateConfig(mergedConfigs);
+  // filter out non-objects from plugin list
+  finalConfig.plugins = (finalConfig.plugins ?? []).filter(pl => typeof pl === 'object');
 
   // ensure rootDir is always resolved
   if (typeof finalConfig.rootDir === 'string') {


### PR DESCRIPTION
## What I did

Dev server and test runner now filter out non-object plugins from the config. This allow patterns like `foo && myPlugin` or `foo ? myPlugin : undefined`.