### PR TITLE
fix(test-runner-core): add clear scrollback history back

### DIFF
--- a/.changeset/six-moons-film.md
+++ b/.changeset/six-moons-film.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-core': patch
+---
+
+add clearing scroll history back

--- a/packages/test-runner-core/src/cli/terminal/DynamicTerminal.ts
+++ b/packages/test-runner-core/src/cli/terminal/DynamicTerminal.ts
@@ -4,7 +4,7 @@ import cliCursor from 'cli-cursor';
 import { BufferedConsole } from './BufferedConsole';
 import { EventEmitter } from '../../utils/EventEmitter';
 
-const CLEAR_COMMAND = process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[H';
+const CLEAR_COMMAND = process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H';
 
 interface EventMap {
   input: string;


### PR DESCRIPTION
## What I did

Reverts https://github.com/modernweb-dev/web/pull/1024 because it was creating double logs when scrolling up. I notice that both Jest and TSC also don't allow scrolling up either. Perhaps they use a different method, something to look into.
