### PR TITLE
fix(test-runner-core): reduce delay when clearing terminal between test runs

### DIFF
--- a/.changeset/six-moons-film.md
+++ b/.changeset/six-moons-film.md
@@ -1,5 +1,6 @@
 ---
+'@web/test-runner': patch
 '@web/test-runner-core': patch
 ---
 
-add clearing scroll history back
+reduce delay when clearing terminal between test runs

--- a/packages/test-runner-core/src/cli/TestRunnerCli.ts
+++ b/packages/test-runner-core/src/cli/TestRunnerCli.ts
@@ -172,25 +172,21 @@ export class TestRunnerCli {
 
       if (session.status === SESSION_STATUS.FINISHED) {
         this.reportTestResult(session.testFile);
+        this.reportTestProgress();
       }
-      this.reportTestProgress();
     });
 
     this.runner.on('test-run-started', ({ testRun }) => {
       for (const reporter of this.config.reporters) {
         reporter.onTestRunStarted?.({ testRun });
       }
-
       if (this.activeMenu !== MENUS.OVERVIEW) {
         return;
       }
 
-      if (testRun !== 0 && this.config.watch) {
-        this.terminal.clear();
-      }
-
+      const clearTerminal = testRun !== 0 && this.config.watch;
+      this.reportTestProgress(false, clearTerminal);
       this.reportTestResults();
-      this.reportTestProgress();
     });
 
     this.runner.on('test-run-finished', ({ testRun, testCoverage }) => {
@@ -301,7 +297,7 @@ export class TestRunnerCli {
     return reportPromises;
   }
 
-  private reportTestProgress(final = false) {
+  private reportTestProgress(final = false, clearTerminal = false) {
     if (this.config.manual) {
       return;
     }
@@ -349,6 +345,9 @@ export class TestRunnerCli {
       );
     }
 
+    if (clearTerminal) {
+      this.terminal.clear();
+    }
     if (logStatic) {
       this.terminal.logStatic(reports);
     } else {

--- a/packages/test-runner-core/src/runner/TestRunner.ts
+++ b/packages/test-runner-core/src/runner/TestRunner.ts
@@ -13,7 +13,7 @@ import { BrowserLauncher } from '../browser-launcher/BrowserLauncher';
 import { TestRunnerGroupConfig } from '../config/TestRunnerGroupConfig';
 
 interface EventMap {
-  'test-run-started': { testRun: number; sessions: Iterable<TestSession> };
+  'test-run-started': { testRun: number };
   'test-run-finished': { testRun: number; testCoverage?: TestCoverage };
   finished: boolean;
   stopped: boolean;
@@ -129,8 +129,8 @@ export class TestRunner extends EventEmitter<EventMap> {
       this.testRun += 1;
       this.running = true;
 
-      await this.scheduler.schedule(this.testRun, sessionsToRun);
-      this.emit('test-run-started', { testRun: this.testRun, sessions: sessionsToRun });
+      this.scheduler.schedule(this.testRun, sessionsToRun);
+      this.emit('test-run-started', { testRun: this.testRun });
     } catch (error) {
       this.running = false;
       this.stop(error);

--- a/packages/test-runner/demo/tsc/config.mjs
+++ b/packages/test-runner/demo/tsc/config.mjs
@@ -1,0 +1,4 @@
+export default {
+  files: 'demo/tsc/dist/test/**/*.test.js',
+  nodeResolve: true,
+};

--- a/packages/test-runner/demo/tsc/test/chai.ts
+++ b/packages/test-runner/demo/tsc/test/chai.ts
@@ -1,0 +1,1 @@
+export { expect } from '@esm-bundle/chai';

--- a/packages/test-runner/demo/tsc/test/pass-1.test.ts
+++ b/packages/test-runner/demo/tsc/test/pass-1.test.ts
@@ -1,0 +1,45 @@
+import { expect } from './chai.js';
+import './shared-a.js';
+import './shared-b.js';
+
+it('test 1', () => {
+  expect(true).to.be.true;
+});
+
+it('test 2', () => {
+  expect('foo').to.be.a('string');
+});
+
+it('test 3', () => {
+  expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+});
+
+it('test 4', () => {
+  expect(4).to.equal(4);
+});
+
+it('test 5', () => {
+  expect(() => {}).to.be.a('function');
+});
+
+describe('scoped tests', () => {
+  it('test 6', () => {
+    expect(true).to.be.true;
+  });
+
+  it('test 7', () => {
+    expect('foo').to.be.a('string');
+  });
+
+  it('test 8', () => {
+    expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+  });
+
+  it('test 9', () => {
+    expect(4).to.equal(4);
+  });
+
+  it('test 10', () => {
+    expect(() => {}).to.be.a('function');
+  });
+});

--- a/packages/test-runner/demo/tsc/test/pass-10.test.ts
+++ b/packages/test-runner/demo/tsc/test/pass-10.test.ts
@@ -1,0 +1,45 @@
+import { expect } from './chai.js';
+import './shared-a.js';
+import './shared-b.js';
+
+it('test 1', () => {
+  expect(true).to.be.true;
+});
+
+it('test 2', () => {
+  expect('foo').to.be.a('string');
+});
+
+it('test 3', () => {
+  expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+});
+
+it('test 4', () => {
+  expect(4).to.equal(4);
+});
+
+it('test 5', () => {
+  expect(() => {}).to.be.a('function');
+});
+
+describe('scoped tests', () => {
+  it('test 6', () => {
+    expect(true).to.be.true;
+  });
+
+  it('test 7', () => {
+    expect('foo').to.be.a('string');
+  });
+
+  it('test 8', () => {
+    expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+  });
+
+  it('test 9', () => {
+    expect(4).to.equal(4);
+  });
+
+  it('test 10', () => {
+    expect(() => {}).to.be.a('function');
+  });
+});

--- a/packages/test-runner/demo/tsc/test/pass-11.test.ts
+++ b/packages/test-runner/demo/tsc/test/pass-11.test.ts
@@ -1,0 +1,45 @@
+import { expect } from './chai.js';
+import './shared-a.js';
+import './shared-b.js';
+
+it('test 1', () => {
+  expect(true).to.be.true;
+});
+
+it('test 2', () => {
+  expect('foo').to.be.a('string');
+});
+
+it('test 3', () => {
+  expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+});
+
+it('test 4', () => {
+  expect(4).to.equal(4);
+});
+
+it('test 5', () => {
+  expect(() => {}).to.be.a('function');
+});
+
+describe('scoped tests', () => {
+  it('test 6', () => {
+    expect(true).to.be.true;
+  });
+
+  it('test 7', () => {
+    expect('foo').to.be.a('string');
+  });
+
+  it('test 8', () => {
+    expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+  });
+
+  it('test 9', () => {
+    expect(4).to.equal(4);
+  });
+
+  it('test 10', () => {
+    expect(() => {}).to.be.a('function');
+  });
+});

--- a/packages/test-runner/demo/tsc/test/pass-12.test.ts
+++ b/packages/test-runner/demo/tsc/test/pass-12.test.ts
@@ -1,0 +1,45 @@
+import { expect } from './chai.js';
+import './shared-a.js';
+import './shared-b.js';
+
+it('test 1', () => {
+  expect(true).to.be.true;
+});
+
+it('test 2', () => {
+  expect('foo').to.be.a('string');
+});
+
+it('test 3', () => {
+  expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+});
+
+it('test 4', () => {
+  expect(4).to.equal(4);
+});
+
+it('test 5', () => {
+  expect(() => {}).to.be.a('function');
+});
+
+describe('scoped tests', () => {
+  it('test 6', () => {
+    expect(true).to.be.true;
+  });
+
+  it('test 7', () => {
+    expect('foo').to.be.a('string');
+  });
+
+  it('test 8', () => {
+    expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+  });
+
+  it('test 9', () => {
+    expect(4).to.equal(4);
+  });
+
+  it('test 10', () => {
+    expect(() => {}).to.be.a('function');
+  });
+});

--- a/packages/test-runner/demo/tsc/test/pass-13.test.ts
+++ b/packages/test-runner/demo/tsc/test/pass-13.test.ts
@@ -1,0 +1,45 @@
+import { expect } from './chai.js';
+import './shared-a.js';
+import './shared-b.js';
+
+it('test 1', () => {
+  expect(true).to.be.true;
+});
+
+it('test 2', () => {
+  expect('foo').to.be.a('string');
+});
+
+it('test 3', () => {
+  expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+});
+
+it('test 4', () => {
+  expect(4).to.equal(4);
+});
+
+it('test 5', () => {
+  expect(() => {}).to.be.a('function');
+});
+
+describe('scoped tests', () => {
+  it('test 6', () => {
+    expect(true).to.be.true;
+  });
+
+  it('test 7', () => {
+    expect('foo').to.be.a('string');
+  });
+
+  it('test 8', () => {
+    expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+  });
+
+  it('test 9', () => {
+    expect(4).to.equal(4);
+  });
+
+  it('test 10', () => {
+    expect(() => {}).to.be.a('function');
+  });
+});

--- a/packages/test-runner/demo/tsc/test/pass-14.test.ts
+++ b/packages/test-runner/demo/tsc/test/pass-14.test.ts
@@ -1,0 +1,45 @@
+import { expect } from './chai.js';
+import './shared-a.js';
+import './shared-b.js';
+
+it('test 1', () => {
+  expect(true).to.be.true;
+});
+
+it('test 2', () => {
+  expect('foo').to.be.a('string');
+});
+
+it('test 3', () => {
+  expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+});
+
+it('test 4', () => {
+  expect(4).to.equal(4);
+});
+
+it('test 5', () => {
+  expect(() => {}).to.be.a('function');
+});
+
+describe('scoped tests', () => {
+  it('test 6', () => {
+    expect(true).to.be.true;
+  });
+
+  it('test 7', () => {
+    expect('foo').to.be.a('string');
+  });
+
+  it('test 8', () => {
+    expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+  });
+
+  it('test 9', () => {
+    expect(4).to.equal(4);
+  });
+
+  it('test 10', () => {
+    expect(() => {}).to.be.a('function');
+  });
+});

--- a/packages/test-runner/demo/tsc/test/pass-15.test.ts
+++ b/packages/test-runner/demo/tsc/test/pass-15.test.ts
@@ -1,0 +1,45 @@
+import { expect } from './chai.js';
+import './shared-a.js';
+import './shared-b.js';
+
+it('test 1', () => {
+  expect(true).to.be.true;
+});
+
+it('test 2', () => {
+  expect('foo').to.be.a('string');
+});
+
+it('test 3', () => {
+  expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+});
+
+it('test 4', () => {
+  expect(4).to.equal(4);
+});
+
+it('test 5', () => {
+  expect(() => {}).to.be.a('function');
+});
+
+describe('scoped tests', () => {
+  it('test 6', () => {
+    expect(true).to.be.true;
+  });
+
+  it('test 7', () => {
+    expect('foo').to.be.a('string');
+  });
+
+  it('test 8', () => {
+    expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+  });
+
+  it('test 9', () => {
+    expect(4).to.equal(4);
+  });
+
+  it('test 10', () => {
+    expect(() => {}).to.be.a('function');
+  });
+});

--- a/packages/test-runner/demo/tsc/test/pass-16.test.ts
+++ b/packages/test-runner/demo/tsc/test/pass-16.test.ts
@@ -1,0 +1,44 @@
+import { expect } from './chai.js';
+import './shared-a.js';
+
+it('test 1', () => {
+  expect(true).to.be.true;
+});
+
+it('test 2', () => {
+  expect('foo').to.be.a('string');
+});
+
+it('test 3', () => {
+  expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+});
+
+it('test 4', () => {
+  expect(4).to.equal(4);
+});
+
+it('test 5', () => {
+  expect(() => {}).to.be.a('function');
+});
+
+describe('scoped tests', () => {
+  it('test 6', () => {
+    expect(true).to.be.true;
+  });
+
+  it('test 7', () => {
+    expect('foo').to.be.a('string');
+  });
+
+  it('test 8', () => {
+    expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+  });
+
+  it('test 9', () => {
+    expect(4).to.equal(4);
+  });
+
+  it('test 10', () => {
+    expect(() => {}).to.be.a('function');
+  });
+});

--- a/packages/test-runner/demo/tsc/test/pass-17.test.ts
+++ b/packages/test-runner/demo/tsc/test/pass-17.test.ts
@@ -1,0 +1,44 @@
+import { expect } from './chai.js';
+import './shared-a.js';
+
+it('test 1', () => {
+  expect(true).to.be.true;
+});
+
+it('test 2', () => {
+  expect('foo').to.be.a('string');
+});
+
+it('test 3', () => {
+  expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+});
+
+it('test 4', () => {
+  expect(4).to.equal(4);
+});
+
+it('test 5', () => {
+  expect(() => {}).to.be.a('function');
+});
+
+describe('scoped tests', () => {
+  it('test 6', () => {
+    expect(true).to.be.true;
+  });
+
+  it('test 7', () => {
+    expect('foo').to.be.a('string');
+  });
+
+  it('test 8', () => {
+    expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+  });
+
+  it('test 9', () => {
+    expect(4).to.equal(4);
+  });
+
+  it('test 10', () => {
+    expect(() => {}).to.be.a('function');
+  });
+});

--- a/packages/test-runner/demo/tsc/test/pass-18.test.ts
+++ b/packages/test-runner/demo/tsc/test/pass-18.test.ts
@@ -1,0 +1,44 @@
+import { expect } from './chai.js';
+import './shared-a.js';
+
+it('test 1', () => {
+  expect(true).to.be.true;
+});
+
+it('test 2', () => {
+  expect('foo').to.be.a('string');
+});
+
+it('test 3', () => {
+  expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+});
+
+it('test 4', () => {
+  expect(4).to.equal(4);
+});
+
+it('test 5', () => {
+  expect(() => {}).to.be.a('function');
+});
+
+describe('scoped tests', () => {
+  it('test 6', () => {
+    expect(true).to.be.true;
+  });
+
+  it('test 7', () => {
+    expect('foo').to.be.a('string');
+  });
+
+  it('test 8', () => {
+    expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+  });
+
+  it('test 9', () => {
+    expect(4).to.equal(4);
+  });
+
+  it('test 10', () => {
+    expect(() => {}).to.be.a('function');
+  });
+});

--- a/packages/test-runner/demo/tsc/test/pass-19.test.ts
+++ b/packages/test-runner/demo/tsc/test/pass-19.test.ts
@@ -1,0 +1,44 @@
+import { expect } from './chai.js';
+import './shared-a.js';
+
+it('test 1', () => {
+  expect(true).to.be.true;
+});
+
+it('test 2', () => {
+  expect('foo').to.be.a('string');
+});
+
+it('test 3', () => {
+  expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+});
+
+it('test 4', () => {
+  expect(4).to.equal(4);
+});
+
+it('test 5', () => {
+  expect(() => {}).to.be.a('function');
+});
+
+describe('scoped tests', () => {
+  it('test 6', () => {
+    expect(true).to.be.true;
+  });
+
+  it('test 7', () => {
+    expect('foo').to.be.a('string');
+  });
+
+  it('test 8', () => {
+    expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+  });
+
+  it('test 9', () => {
+    expect(4).to.equal(4);
+  });
+
+  it('test 10', () => {
+    expect(() => {}).to.be.a('function');
+  });
+});

--- a/packages/test-runner/demo/tsc/test/pass-2.test.ts
+++ b/packages/test-runner/demo/tsc/test/pass-2.test.ts
@@ -1,0 +1,45 @@
+import { expect } from './chai.js';
+import './shared-a.js';
+import './shared-b.js';
+
+it('test 1', () => {
+  expect(true).to.be.true;
+});
+
+it('test 2', () => {
+  expect('foo').to.be.a('string');
+});
+
+it('test 3', () => {
+  expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+});
+
+it('test 4', () => {
+  expect(4).to.equal(4);
+});
+
+it('test 5', () => {
+  expect(() => {}).to.be.a('function');
+});
+
+describe('scoped tests', () => {
+  it('test 6', () => {
+    expect(true).to.be.true;
+  });
+
+  it('test 7', () => {
+    expect('foo').to.be.a('string');
+  });
+
+  it('test 8', () => {
+    expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+  });
+
+  it('test 9', () => {
+    expect(4).to.equal(4);
+  });
+
+  it('test 10', () => {
+    expect(() => {}).to.be.a('function');
+  });
+});

--- a/packages/test-runner/demo/tsc/test/pass-20.test.ts
+++ b/packages/test-runner/demo/tsc/test/pass-20.test.ts
@@ -1,0 +1,44 @@
+import { expect } from './chai.js';
+import './shared-a.js';
+
+it('test 1', () => {
+  expect(true).to.be.true;
+});
+
+it('test 2', () => {
+  expect('foo').to.be.a('string');
+});
+
+it('test 3', () => {
+  expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+});
+
+it('test 4', () => {
+  expect(4).to.equal(4);
+});
+
+it('test 5', () => {
+  expect(() => {}).to.be.a('function');
+});
+
+describe('scoped tests', () => {
+  it('test 6', () => {
+    expect(true).to.be.true;
+  });
+
+  it('test 7', () => {
+    expect('foo').to.be.a('string');
+  });
+
+  it('test 8', () => {
+    expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+  });
+
+  it('test 9', () => {
+    expect(4).to.equal(4);
+  });
+
+  it('test 10', () => {
+    expect(() => {}).to.be.a('function');
+  });
+});

--- a/packages/test-runner/demo/tsc/test/pass-3.test.ts
+++ b/packages/test-runner/demo/tsc/test/pass-3.test.ts
@@ -1,0 +1,45 @@
+import { expect } from './chai.js';
+import './shared-a.js';
+import './shared-b.js';
+
+it('test 1', () => {
+  expect(true).to.be.true;
+});
+
+it('test 2', () => {
+  expect('foo').to.be.a('string');
+});
+
+it('test 3', () => {
+  expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+});
+
+it('test 4', () => {
+  expect(4).to.equal(4);
+});
+
+it('test 5', () => {
+  expect(() => {}).to.be.a('function');
+});
+
+describe('scoped tests', () => {
+  it('test 6', () => {
+    expect(true).to.be.true;
+  });
+
+  it('test 7', () => {
+    expect('foo').to.be.a('string');
+  });
+
+  it('test 8', () => {
+    expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+  });
+
+  it('test 9', () => {
+    expect(4).to.equal(4);
+  });
+
+  it('test 10', () => {
+    expect(() => {}).to.be.a('function');
+  });
+});

--- a/packages/test-runner/demo/tsc/test/pass-4.test.ts
+++ b/packages/test-runner/demo/tsc/test/pass-4.test.ts
@@ -1,0 +1,45 @@
+import { expect } from './chai.js';
+import './shared-a.js';
+import './shared-b.js';
+
+it('test 1', () => {
+  expect(true).to.be.true;
+});
+
+it('test 2', () => {
+  expect('foo').to.be.a('string');
+});
+
+it('test 3', () => {
+  expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+});
+
+it('test 4', () => {
+  expect(4).to.equal(4);
+});
+
+it('test 5', () => {
+  expect(() => {}).to.be.a('function');
+});
+
+describe('scoped tests', () => {
+  it('test 6', () => {
+    expect(true).to.be.true;
+  });
+
+  it('test 7', () => {
+    expect('foo').to.be.a('string');
+  });
+
+  it('test 8', () => {
+    expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+  });
+
+  it('test 9', () => {
+    expect(4).to.equal(4);
+  });
+
+  it('test 10', () => {
+    expect(() => {}).to.be.a('function');
+  });
+});

--- a/packages/test-runner/demo/tsc/test/pass-5.test.ts
+++ b/packages/test-runner/demo/tsc/test/pass-5.test.ts
@@ -1,0 +1,45 @@
+import { expect } from './chai.js';
+import './shared-a.js';
+import './shared-b.js';
+
+it('test 1', () => {
+  expect(true).to.be.true;
+});
+
+it('test 2', () => {
+  expect('foo').to.be.a('string');
+});
+
+it('test 3', () => {
+  expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+});
+
+it('test 4', () => {
+  expect(4).to.equal(4);
+});
+
+it('test 5', () => {
+  expect(() => {}).to.be.a('function');
+});
+
+describe('scoped tests', () => {
+  it('test 6', () => {
+    expect(true).to.be.true;
+  });
+
+  it('test 7', () => {
+    expect('foo').to.be.a('string');
+  });
+
+  it('test 8', () => {
+    expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+  });
+
+  it('test 9', () => {
+    expect(4).to.equal(4);
+  });
+
+  it('test 10', () => {
+    expect(() => {}).to.be.a('function');
+  });
+});

--- a/packages/test-runner/demo/tsc/test/pass-6.test.ts
+++ b/packages/test-runner/demo/tsc/test/pass-6.test.ts
@@ -1,0 +1,45 @@
+import { expect } from './chai.js';
+import './shared-a.js';
+import './shared-b.js';
+
+it('test 1', () => {
+  expect(true).to.be.true;
+});
+
+it('test 2', () => {
+  expect('foo').to.be.a('string');
+});
+
+it('test 3', () => {
+  expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+});
+
+it('test 4', () => {
+  expect(4).to.equal(4);
+});
+
+it('test 5', () => {
+  expect(() => {}).to.be.a('function');
+});
+
+describe('scoped tests', () => {
+  it('test 6', () => {
+    expect(true).to.be.true;
+  });
+
+  it('test 7', () => {
+    expect('foo').to.be.a('string');
+  });
+
+  it('test 8', () => {
+    expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+  });
+
+  it('test 9', () => {
+    expect(4).to.equal(4);
+  });
+
+  it('test 10', () => {
+    expect(() => {}).to.be.a('function');
+  });
+});

--- a/packages/test-runner/demo/tsc/test/pass-7.test.ts
+++ b/packages/test-runner/demo/tsc/test/pass-7.test.ts
@@ -1,0 +1,45 @@
+import { expect } from './chai.js';
+import './shared-a.js';
+import './shared-b.js';
+
+it('test 1', () => {
+  expect(true).to.be.true;
+});
+
+it('test 2', () => {
+  expect('foo').to.be.a('string');
+});
+
+it('test 3', () => {
+  expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+});
+
+it('test 4', () => {
+  expect(4).to.equal(4);
+});
+
+it('test 5', () => {
+  expect(() => {}).to.be.a('function');
+});
+
+describe('scoped tests', () => {
+  it('test 6', () => {
+    expect(true).to.be.true;
+  });
+
+  it('test 7', () => {
+    expect('foo').to.be.a('string');
+  });
+
+  it('test 8', () => {
+    expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+  });
+
+  it('test 9', () => {
+    expect(4).to.equal(4);
+  });
+
+  it('test 10', () => {
+    expect(() => {}).to.be.a('function');
+  });
+});

--- a/packages/test-runner/demo/tsc/test/pass-8.test.ts
+++ b/packages/test-runner/demo/tsc/test/pass-8.test.ts
@@ -1,0 +1,45 @@
+import { expect } from './chai.js';
+import './shared-a.js';
+import './shared-b.js';
+
+it('test 1', () => {
+  expect(true).to.be.true;
+});
+
+it('test 2', () => {
+  expect('foo').to.be.a('string');
+});
+
+it('test 3', () => {
+  expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+});
+
+it('test 4', () => {
+  expect(4).to.equal(4);
+});
+
+it('test 5', () => {
+  expect(() => {}).to.be.a('function');
+});
+
+describe('scoped tests', () => {
+  it('test 6', () => {
+    expect(true).to.be.true;
+  });
+
+  it('test 7', () => {
+    expect('foo').to.be.a('string');
+  });
+
+  it('test 8', () => {
+    expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+  });
+
+  it('test 9', () => {
+    expect(4).to.equal(4);
+  });
+
+  it('test 10', () => {
+    expect(() => {}).to.be.a('function');
+  });
+});

--- a/packages/test-runner/demo/tsc/test/pass-9.test.ts
+++ b/packages/test-runner/demo/tsc/test/pass-9.test.ts
@@ -1,0 +1,45 @@
+import { expect } from './chai.js';
+import './shared-a.js';
+import './shared-b.js';
+
+it('test 1', () => {
+  expect(true).to.be.true;
+});
+
+it('test 2', () => {
+  expect('foo').to.be.a('string');
+});
+
+it('test 3', () => {
+  expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+});
+
+it('test 4', () => {
+  expect(4).to.equal(4);
+});
+
+it('test 5', () => {
+  expect(() => {}).to.be.a('function');
+});
+
+describe('scoped tests', () => {
+  it('test 6', () => {
+    expect(true).to.be.true;
+  });
+
+  it('test 7', () => {
+    expect('foo').to.be.a('string');
+  });
+
+  it('test 8', () => {
+    expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+  });
+
+  it('test 9', () => {
+    expect(4).to.equal(4);
+  });
+
+  it('test 10', () => {
+    expect(() => {}).to.be.a('function');
+  });
+});

--- a/packages/test-runner/demo/tsc/test/shared-a.ts
+++ b/packages/test-runner/demo/tsc/test/shared-a.ts
@@ -1,0 +1,9 @@
+// this file is shared by all tests
+
+export function sharedA() {
+  return 'hello world';
+}
+
+export function throwError() {
+  throw Error('Some error');
+}

--- a/packages/test-runner/demo/tsc/test/shared-b.ts
+++ b/packages/test-runner/demo/tsc/test/shared-b.ts
@@ -1,0 +1,5 @@
+// this file is shared by some tests
+
+export function sharedB1() {
+  return 'hello world';
+}

--- a/packages/test-runner/demo/tsc/tsconfig.json
+++ b/packages/test-runner/demo/tsc/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "lib": ["es2017", "dom"],
+    "strict": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "outDir": "dist",
+    "sourceMap": true,
+    "inlineSources": true,
+    "rootDir": "./",
+    "declaration": true,
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/packages/test-runner/package.json
+++ b/packages/test-runner/package.json
@@ -49,6 +49,7 @@
     "test:puppeteer-firefox": "node dist/bin.js \"demo/test/pass-*.test.{js,html}\" --puppeteer --browsers firefox",
     "test:saucelabs": "node dist/bin.js --config demo/saucelabs.config.mjs",
     "test:selenium": "node dist/bin.js --config demo/selenium.config.mjs",
+    "test:tsc": "tsc -p demo/tsc/tsconfig.json && concurrently -k -r \"tsc -p demo/tsc/tsconfig.json --watch --preserveWatchOutput\" \"wtr --config demo/tsc/config.mjs --watch\"",
     "test:virtual-files": "node dist/bin.js --config demo/virtual-files.config.mjs --coverage",
     "test:watch": "node dist/bin.js \"demo/test/pass-*.test.{js,html}\" --watch"
   },
@@ -89,6 +90,7 @@
   "devDependencies": {
     "@web/dev-server-legacy": "^0.1.7",
     "@web/test-runner-saucelabs": "^0.3.2",
-    "babel-plugin-istanbul": "^6.0.0"
+    "babel-plugin-istanbul": "^6.0.0",
+    "concurrently": "^5.3.0"
   }
 }


### PR DESCRIPTION
## What I did

1. Reduce delay when clearing the terminal between test runs. This prevents flickering of test logs
