### PR TITLE
fix(dev-server): fix handling of paths outside root dir

### DIFF
--- a/.changeset/good-cycles-tickle.md
+++ b/.changeset/good-cycles-tickle.md
@@ -1,0 +1,7 @@
+---
+'@web/dev-server': patch
+'@web/dev-server-core': patch
+'@web/dev-server-rollup': patch
+---
+
+fix handling of paths resolved outside the root dir. we now correctly use the resolved path when resolving relative imports and when populating the transform cache

--- a/packages/dev-server-core/src/middleware/pluginTransformMiddleware.ts
+++ b/packages/dev-server-core/src/middleware/pluginTransformMiddleware.ts
@@ -76,10 +76,7 @@ export function pluginTransformMiddleware(
 
       if (transformedCode && !disableCache) {
         logger.debug(`Added cache key "${cacheKey}" to plugin transform cache`);
-        let filePath = getRequestFilePath(context, config.rootDir);
-        if (filePath.endsWith('/') && context.response.is('html')) {
-          filePath = `${filePath}index.html`;
-        }
+        const filePath = getRequestFilePath(context, config.rootDir);
         cache.set(filePath, context.body, context.response.headers, cacheKey);
       }
     } catch (error) {

--- a/packages/dev-server-core/src/middleware/serveFilesMiddleware.ts
+++ b/packages/dev-server-core/src/middleware/serveFilesMiddleware.ts
@@ -1,9 +1,7 @@
 import { Middleware } from 'koa';
-import path from 'path';
 import send from 'koa-send';
 import koaStatic, { Options as KoaStaticOptions } from 'koa-static';
-
-const OUTSIDE_ROOT_KEY = '/__wds-outside-root__/';
+import { isOutsideRootDir, resolvePathOutsideRootDir } from '../utils';
 
 /**
  * Creates multiple middleware used for serving files.
@@ -22,16 +20,9 @@ export function serveFilesMiddleware(rootDir: string): Middleware[] {
   // the wds-root-dir parameter indicates using a different root directory as a path relative
   // from the regular root dir or as an absolute path
   const serveCustomRootDirMiddleware: Middleware = async (ctx, next) => {
-    if (ctx.path.startsWith(OUTSIDE_ROOT_KEY)) {
-      const [, , depthString] = ctx.path.split('/');
-      const depth = Number(depthString);
-      if (depth == null || Number.isNaN(depth)) {
-        throw new Error(`Invalid wds-root-dir path: ${ctx.path}`);
-      }
-
-      ctx.path = ctx.path.replace(`${OUTSIDE_ROOT_KEY}${depth}`, '');
-      const localRootDir = path.resolve(rootDir, `..${path.sep}`.repeat(depth));
-      await send(ctx, ctx.path, { ...koaStaticOptions, root: localRootDir });
+    if (isOutsideRootDir(ctx.path)) {
+      const { normalizedPath, newRootDir } = resolvePathOutsideRootDir(ctx.path, rootDir);
+      await send(ctx, normalizedPath, { ...koaStaticOptions, root: newRootDir });
       return;
     }
     return next();

--- a/packages/dev-server-rollup/src/rollupAdapter.ts
+++ b/packages/dev-server-rollup/src/rollupAdapter.ts
@@ -110,8 +110,7 @@ export function rollupAdapter(
         return source;
       }
 
-      const requestedFile = context.path.endsWith('/') ? `${context.path}index.html` : context.path;
-      const filePath = path.join(rootDir, requestedFile);
+      const filePath = getRequestFilePath(context, rootDir);
 
       try {
         const rollupPluginContext = createRollupPluginContextAdapter(


### PR DESCRIPTION
## What I did

fix handling of paths resolved outside the root dir. we now correctly use the resolved path when resolving relative imports and when populating the transform cache