### PR TITLE
docs: restore launch options link for Playwright

### DIFF
--- a/docs/docs/test-runner/browser-launchers/playwright.md
+++ b/docs/docs/test-runner/browser-launchers/playwright.md
@@ -44,9 +44,10 @@ export default {
 
 ## Customizing launch options
 
-If you want to customize the puppeteer launcher options, you can add the browser launcher in the config.
+If you want to customize the playwright launcher options, you can add the browser launcher in the config.
 
-You can find all possible launch options in the [official documentation](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#puppeteerlaunchoptions)
+You can find all possible launch options in the [official documentation](https://github.com/microsoft/playwright/blob/master/docs/api.md#browsertypelaunchoptions).
+
 
 ```js
 import { playwrightLauncher } from '@web/test-runner-playwright';


### PR DESCRIPTION
## What I did

1. Updated the lines changed by #1151 which added some Puppeteer mentions to the Playwright page.
