### PR TITLE
feat(rollup-plugin-html): inject service worker if defined by other plugin

### DIFF
--- a/packages/rollup-plugin-html/src/output/createHTMLOutput.ts
+++ b/packages/rollup-plugin-html/src/output/createHTMLOutput.ts
@@ -18,6 +18,7 @@ export interface CreateHTMLAssetParams {
   externalTransformHtmlFns: TransformHtmlFunction[];
   pluginOptions: RollupPluginHTMLOptions;
   defaultInjectDisabled: boolean;
+  serviceWorkerDestination: string;
 }
 
 export async function createHTMLAsset(params: CreateHTMLAssetParams): Promise<EmittedFile> {
@@ -29,6 +30,7 @@ export async function createHTMLAsset(params: CreateHTMLAssetParams): Promise<Em
     externalTransformHtmlFns,
     pluginOptions,
     defaultInjectDisabled,
+    serviceWorkerDestination,
   } = params;
 
   if (generatedBundles.length === 0) {
@@ -51,6 +53,7 @@ export async function createHTMLAsset(params: CreateHTMLAssetParams): Promise<Em
     emittedAssets,
     externalTransformHtmlFns,
     defaultInjectDisabled,
+    serviceWorkerDestination,
   });
 
   return { fileName: input.name, name: input.name, source: outputHtml, type: 'asset' };
@@ -64,6 +67,7 @@ export interface CreateHTMLAssetsParams {
   externalTransformHtmlFns: TransformHtmlFunction[];
   pluginOptions: RollupPluginHTMLOptions;
   defaultInjectDisabled: boolean;
+  serviceWorkerDestination: string;
 }
 
 export async function createHTMLOutput(params: CreateHTMLAssetsParams): Promise<EmittedFile[]> {

--- a/packages/rollup-plugin-html/src/output/getOutputHTML.ts
+++ b/packages/rollup-plugin-html/src/output/getOutputHTML.ts
@@ -9,6 +9,7 @@ import { parse, serialize } from 'parse5';
 import { injectedUpdatedAssetPaths } from './injectedUpdatedAssetPaths';
 import { EmittedAssets } from './emitAssets';
 import { injectAbsoluteBaseUrl } from './injectAbsoluteBaseUrl';
+import { injectServiceWorker } from './injectServiceWorker';
 
 export interface GetOutputHTMLParams {
   input: InputData;
@@ -18,6 +19,7 @@ export interface GetOutputHTMLParams {
   entrypointBundles: Record<string, EntrypointBundle>;
   externalTransformHtmlFns?: TransformHtmlFunction[];
   defaultInjectDisabled: boolean;
+  serviceWorkerDestination: string;
 }
 
 export async function getOutputHTML(params: GetOutputHTMLParams) {
@@ -29,6 +31,7 @@ export async function getOutputHTML(params: GetOutputHTMLParams) {
     outputDir,
     emittedAssets,
     defaultInjectDisabled,
+    serviceWorkerDestination,
   } = params;
   const { default: defaultBundle, ...multiBundles } = entrypointBundles;
   const { absoluteSocialMediaUrls = true, rootDir = process.cwd() } = pluginOptions;
@@ -43,6 +46,9 @@ export async function getOutputHTML(params: GetOutputHTMLParams) {
   }
   if (absoluteSocialMediaUrls && pluginOptions.absoluteBaseUrl) {
     injectAbsoluteBaseUrl(document, pluginOptions.absoluteBaseUrl);
+  }
+  if (serviceWorkerDestination) {
+    injectServiceWorker({ document, outputDir, swDest: serviceWorkerDestination, htmlFileName: input.name })
   }
 
   let outputHtml = serialize(document);

--- a/packages/rollup-plugin-html/src/output/injectServiceWorker.ts
+++ b/packages/rollup-plugin-html/src/output/injectServiceWorker.ts
@@ -1,0 +1,47 @@
+import path from 'path';
+import { Document } from 'parse5';
+import {
+  findElement,
+  getTagName,
+  appendChild,
+  createScript,
+  setAttribute,
+} from '@web/parse5-utils';
+
+export interface injectServiceWorkerArgs {
+  document: Document;
+  swDest: string;
+  outputDir: string;
+  htmlFileName: string;
+}
+
+export function injectServiceWorker(args: injectServiceWorkerArgs) {
+  const { document, swDest, outputDir, htmlFileName } = args;
+  const body = findElement(document, e => getTagName(e) === 'body');
+  if (!body) {
+    throw new Error('Missing body in HTML document.');
+  }
+
+  let swPath = swDest.replace(`${outputDir}/`, '');
+  swPath = path.relative(path.dirname(htmlFileName), swPath);
+
+  const code  = `
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', function() {
+        navigator.serviceWorker
+          .register('${swPath}')
+          .then(function() {
+            console.log('ServiceWorker registered from "${swPath}".');
+          })
+          .catch(function(err) {
+            console.log('ServiceWorker registration failed: ', err);
+          });
+      });
+    }
+  `;
+
+  const script = createScript({}, code);
+  setAttribute(script, 'inject-service-worker', '');
+
+  appendChild(body, script);
+}

--- a/packages/rollup-plugin-html/src/rollupPluginHTML.ts
+++ b/packages/rollup-plugin-html/src/rollupPluginHTML.ts
@@ -29,6 +29,7 @@ export function rollupPluginHTML(pluginOptions: RollupPluginHTMLOptions = {}): R
   let generatedBundles: GeneratedBundle[] = [];
   let externalTransformHtmlFns: TransformHtmlFunction[] = [];
   let defaultInjectDisabled = false;
+  let serviceWorkerDestination = '';
 
   function reset() {
     inputs = [];
@@ -79,7 +80,11 @@ export function rollupPluginHTML(pluginOptions: RollupPluginHTMLOptions = {}): R
     },
 
     /** Notifies rollup that we will be handling these modules */
-    resolveId(id) {
+    resolveId(id, importer, { custom }) {
+      // we only need to set this once
+      if (!serviceWorkerDestination && custom?.serviceWorkerDestination) {
+        serviceWorkerDestination = custom.serviceWorkerDestination;
+      }
       if (id === NOOP_IMPORT) {
         return NOOP_IMPORT;
       }
@@ -110,6 +115,8 @@ export function rollupPluginHTML(pluginOptions: RollupPluginHTMLOptions = {}): R
      * @param {OutputBundle} bundle
      */
     async generateBundle(options, bundle) {
+      // @ts-ignore
+      // console.log({ serviceWorkerDestination });
       if (multiOutputNames.length !== 0) {
         // we are generating multiple build outputs, which is handled by child plugins
         return;
@@ -129,6 +136,7 @@ export function rollupPluginHTML(pluginOptions: RollupPluginHTMLOptions = {}): R
         externalTransformHtmlFns,
         pluginOptions,
         defaultInjectDisabled,
+        serviceWorkerDestination,
       });
 
       for (const output of outputs) {
@@ -184,6 +192,7 @@ export function rollupPluginHTML(pluginOptions: RollupPluginHTMLOptions = {}): R
                 externalTransformHtmlFns,
                 pluginOptions,
                 defaultInjectDisabled,
+                serviceWorkerDestination,
               });
 
               for (const output of outputs) {

--- a/packages/rollup-plugin-html/test/fixtures/inject-service-worker/index.html
+++ b/packages/rollup-plugin-html/test/fixtures/inject-service-worker/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <p>inject a service worker into /index.html</p>
+  </body>
+</html>

--- a/packages/rollup-plugin-html/test/fixtures/inject-service-worker/sub-pure-html/index.html
+++ b/packages/rollup-plugin-html/test/fixtures/inject-service-worker/sub-pure-html/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <p>inject a service worker into /sub-page/index.html</p>
+  </body>
+</html>

--- a/packages/rollup-plugin-html/test/fixtures/inject-service-worker/sub-with-js/index.html
+++ b/packages/rollup-plugin-html/test/fixtures/inject-service-worker/sub-with-js/index.html
@@ -1,0 +1,6 @@
+<html>
+  <body>
+    <p>inject a service worker into /sub-page/index.html</p>
+    <script type="module" src="./sub-js.js"></script>
+  </body>
+</html>

--- a/packages/rollup-plugin-html/test/fixtures/inject-service-worker/sub-with-js/sub-js.js
+++ b/packages/rollup-plugin-html/test/fixtures/inject-service-worker/sub-with-js/sub-js.js
@@ -1,0 +1,1 @@
+console.log('sub-with-js');

--- a/packages/rollup-plugin-html/test/src/output/getOutputHTML.test.ts
+++ b/packages/rollup-plugin-html/test/src/output/getOutputHTML.test.ts
@@ -26,6 +26,7 @@ describe('getOutputHTML()', () => {
       inlineModules: new Map(),
     },
     defaultInjectDisabled: false,
+    serviceWorkerDestination: '',
   };
 
   it('injects output into the input HTML', async () => {


### PR DESCRIPTION
## What I did

1. check if another plugin created a service worker and define it as `serviceWorkerDestination` if so we inject a service worker registration code


I'm not sure if I'm currently using the best hooks for it... 🤔

If overall this sounds good I will make sure that `rollup-plugin-workbox` sets the custom shared option `serviceWorkerDestination`

what do you think?