### PR TITLE
fix(dev-server-esbuild): pass `esbuildconfig.define` to esbuild transform function

### DIFF
--- a/.changeset/flat-eyes-join.md
+++ b/.changeset/flat-eyes-join.md
@@ -1,0 +1,5 @@
+---
+"@web/dev-server-esbuild": patch
+---
+
+pass `esbuildconfig.define` to esbuild transform function

--- a/packages/dev-server-esbuild/src/EsbuildPlugin.ts
+++ b/packages/dev-server-esbuild/src/EsbuildPlugin.ts
@@ -185,6 +185,7 @@ export class EsbuildPlugin implements Plugin {
         format: ['js', 'jsx', 'ts', 'tsx'].includes(loader) ? undefined : 'esm',
         jsxFactory: this.esbuildConfig.jsxFactory,
         jsxFragment: this.esbuildConfig.jsxFragment,
+        define: this.esbuildConfig.define,
       });
 
       if (warnings) {


### PR DESCRIPTION
Just found out that `define` option is not being used by dev-server-esbuild despite it's declared in the `EsBuildPluginArgs` and `EsbuildConfig` interface

## What I did

1. pass `esbuildconfig.define` to esbuild transform function
