### PR TITLE
chore: Update Renovate config

### DIFF
--- a/.github/workflows/verify-browserstack.yml
+++ b/.github/workflows/verify-browserstack.yml
@@ -1,10 +1,6 @@
 name: Verify Browserstack
 
-on:
-  pull_request:
-  push:
-    branches:
-    - 'renovate/*'
+on: pull_request
 
 jobs:
   verify-browserstack:

--- a/.github/workflows/verify-node.yml
+++ b/.github/workflows/verify-node.yml
@@ -1,10 +1,6 @@
 name: Verify Node
 
-on:
-  pull_request:
-  push:
-    branches:
-    - 'renovate/*'
+on: pull_request
 
 jobs:
   verify-linux:

--- a/.github/workflows/verify-saucelabs.yml
+++ b/.github/workflows/verify-saucelabs.yml
@@ -1,10 +1,6 @@
 name: Verify Saucelabs
 
-on:
-  pull_request:
-  push:
-    branches:
-    - 'renovate/*'
+on: pull_request
 
 jobs:
   verify-saucelabs:

--- a/.github/workflows/verify-windows.yml
+++ b/.github/workflows/verify-windows.yml
@@ -1,10 +1,6 @@
 name: Verify Windows
 
-on:
-  pull_request:
-  push:
-    branches:
-    - 'renovate/*'
+on: pull_request
 
 jobs:
   verify-windows:

--- a/renovate.json
+++ b/renovate.json
@@ -1,29 +1,23 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":separateMultipleMajorReleases",
+    ":separatePatchReleases",
+    ":maintainLockFilesWeekly",
+    ":widenPeerDependencies"
   ],
-
-  "separateMinorPatch": true,
 
   "packageRules": [
     {
       "updateTypes": ["patch"],
-
-      "automerge": true,
-      "automergeType": "branch"
+      "enabled": false
     },
     {
       "updateTypes": ["minor"],
       "matchCurrentVersion": "!/^[~^]?0/",
-
-      "automerge": true,
-      "automergeType": "branch"
+      "enabled": false
     }
   ],
 
-  "rangeStrategy": "bump",
-
-  "lockFileMaintenance": {
-    "enabled": true
-  }
+  "rangeStrategy": "bump"
 }


### PR DESCRIPTION
## What I did

After discussion with @LarsDenBakker, we are trying to reduce noise by only opening PRs for major updates and catching minor updates with the weekly lock file maintenance. I also included a couple improvements to the configuration.

Specific changes:
1. Disabled minor (> 0.x) and patch updates
1. Disabled running CI on Renovate branches (since we aren't doing branch automerging anymore, we only need CI on PRs)
1. Replaced `separateMinorPatch` rule with equivalent `:separatePatchReleases` preset
1. Replaced `lockFileMaintenance` rule with equivalent `:maintainLockFilesWeekly` preset
1. Added `:separateMultipleMajorReleases` preset to separate each available major version of dependencies into individual PRs
1. Added `:widenPeerDependencies` preset to always widen `peerDependencies` semver ranges when updating, instead of replacing (see https://github.com/semver/semver/issues/502)
