### PR TITLE
feat(rollup-plugin-html): add absolutePathPrefix for subfolder deployment

### DIFF
--- a/.changeset/blue-laws-hide.md
+++ b/.changeset/blue-laws-hide.md
@@ -1,0 +1,5 @@
+---
+'@web/rollup-plugin-html': minor
+---
+
+Add option `absolutePathPrefix` to support subfolders deployments if absolute urls are used

--- a/docs/docs/building/rollup-plugin-html.md
+++ b/docs/docs/building/rollup-plugin-html.md
@@ -296,6 +296,8 @@ export interface RollupPluginHTMLOptions {
   injectServiceWorker?: boolean;
   /** File system path to the generated service worker file */
   serviceWorkerPath?: string;
+  /** If output is supposed to be deploy as a subdirectory you need to define the prefix path so assets can be found */
+  absolutePathPrefix?: string;
 }
 
 export interface GeneratedBundle {

--- a/docs/docs/building/rollup-plugin-html.md
+++ b/docs/docs/building/rollup-plugin-html.md
@@ -296,7 +296,7 @@ export interface RollupPluginHTMLOptions {
   injectServiceWorker?: boolean;
   /** File system path to the generated service worker file */
   serviceWorkerPath?: string;
-  /** If output is supposed to be deploy as a subdirectory you need to define the prefix path so assets can be found */
+  /** Prefix to strip from absolute paths when resolving assets and scripts, for example when using a base path that does not exist on disk. */
   absolutePathPrefix?: string;
 }
 

--- a/packages/rollup-plugin-html/src/RollupPluginHTMLOptions.ts
+++ b/packages/rollup-plugin-html/src/RollupPluginHTMLOptions.ts
@@ -32,7 +32,7 @@ export interface RollupPluginHTMLOptions {
   injectServiceWorker?: boolean;
   /** File system path to the generated service worker file */
   serviceWorkerPath?: string;
-  /** If output is supposed to be deploy as a subdirectory you need to define the prefix path so assets can be found */
+  /** Prefix to strip from absolute paths when resolving assets and scripts, for example when using a base path that does not exist on disk. */
   absolutePathPrefix?: string;
 }
 

--- a/packages/rollup-plugin-html/src/RollupPluginHTMLOptions.ts
+++ b/packages/rollup-plugin-html/src/RollupPluginHTMLOptions.ts
@@ -32,6 +32,8 @@ export interface RollupPluginHTMLOptions {
   injectServiceWorker?: boolean;
   /** File system path to the generated service worker file */
   serviceWorkerPath?: string;
+  /** If output is supposed to be deploy as a subdirectory you need to define the prefix path so assets can be found */
+  absolutePathPrefix?: string;
 }
 
 export interface GeneratedBundle {

--- a/packages/rollup-plugin-html/src/assets/utils.ts
+++ b/packages/rollup-plugin-html/src/assets/utils.ts
@@ -57,10 +57,19 @@ export function isHashedAsset(node: Node) {
   }
 }
 
-export function resolveAssetFilePath(browserPath: string, htmlDir: string, projectRootDir: string) {
+export function resolveAssetFilePath(
+  browserPath: string,
+  htmlDir: string,
+  projectRootDir: string,
+  absolutePathPrefix?: string,
+) {
+  const _browserPath =
+    absolutePathPrefix && browserPath[0] === '/'
+      ? '/' + path.relative(absolutePathPrefix, browserPath)
+      : browserPath;
   return path.join(
-    browserPath.startsWith('/') ? projectRootDir : htmlDir,
-    browserPath.split('/').join(path.sep),
+    _browserPath.startsWith('/') ? projectRootDir : htmlDir,
+    _browserPath.split('/').join(path.sep),
   );
 }
 

--- a/packages/rollup-plugin-html/src/assets/utils.ts
+++ b/packages/rollup-plugin-html/src/assets/utils.ts
@@ -65,7 +65,7 @@ export function resolveAssetFilePath(
 ) {
   const _browserPath =
     absolutePathPrefix && browserPath[0] === '/'
-      ? '/' + path.relative(absolutePathPrefix, browserPath)
+      ? '/' + path.posix.relative(absolutePathPrefix, browserPath)
       : browserPath;
   return path.join(
     _browserPath.startsWith('/') ? projectRootDir : htmlDir,

--- a/packages/rollup-plugin-html/src/input/extract/extractAssets.ts
+++ b/packages/rollup-plugin-html/src/input/extract/extractAssets.ts
@@ -9,6 +9,7 @@ export interface ExtractAssetsParams {
   htmlFilePath: string;
   htmlDir: string;
   rootDir: string;
+  absolutePathPrefix?: string;
 }
 
 export function extractAssets(params: ExtractAssetsParams): InputAsset[] {
@@ -17,7 +18,12 @@ export function extractAssets(params: ExtractAssetsParams): InputAsset[] {
 
   for (const node of assetNodes) {
     const sourcePath = getSourcePath(node);
-    const filePath = resolveAssetFilePath(sourcePath, params.htmlDir, params.rootDir);
+    const filePath = resolveAssetFilePath(
+      sourcePath,
+      params.htmlDir,
+      params.rootDir,
+      params.absolutePathPrefix,
+    );
     const hashed = isHashedAsset(node);
     const alreadyHandled = allAssets.find(a => a.filePath === filePath && a.hashed === hashed);
     if (!alreadyHandled) {

--- a/packages/rollup-plugin-html/src/input/extract/extractModules.ts
+++ b/packages/rollup-plugin-html/src/input/extract/extractModules.ts
@@ -8,6 +8,7 @@ export interface ExtractModulesParams {
   document: Document;
   htmlDir: string;
   rootDir: string;
+  absolutePathPrefix?: string;
 }
 
 function createContentHash(content: string) {
@@ -24,7 +25,7 @@ function isAbsolute(src: string) {
 }
 
 export function extractModules(params: ExtractModulesParams) {
-  const { document, htmlDir, rootDir } = params;
+  const { document, htmlDir, rootDir, absolutePathPrefix } = params;
   const scriptNodes = findElements(
     document,
     e => getTagName(e) === 'script' && getAttribute(e, 'type') === 'module',
@@ -47,7 +48,7 @@ export function extractModules(params: ExtractModulesParams) {
     } else {
       if (!isAbsolute(src)) {
         // external script <script type="module" src="./foo.js"></script>
-        const importPath = resolveAssetFilePath(src, htmlDir, rootDir);
+        const importPath = resolveAssetFilePath(src, htmlDir, rootDir, absolutePathPrefix);
         moduleImports.push(importPath);
         remove(scriptNode);
       }

--- a/packages/rollup-plugin-html/src/input/extract/extractModulesAndAssets.ts
+++ b/packages/rollup-plugin-html/src/input/extract/extractModulesAndAssets.ts
@@ -8,17 +8,23 @@ export interface ExtractParams {
   htmlFilePath: string;
   rootDir: string;
   extractAssets: boolean;
+  absolutePathPrefix?: string;
 }
 
 export function extractModulesAndAssets(params: ExtractParams) {
-  const { html, htmlFilePath, rootDir } = params;
+  const { html, htmlFilePath, rootDir, absolutePathPrefix } = params;
   const htmlDir = path.dirname(htmlFilePath);
   const document = parse(html);
 
   // extract functions mutate the AST
-  const { moduleImports, inlineModules } = extractModules({ document, htmlDir, rootDir });
+  const { moduleImports, inlineModules } = extractModules({
+    document,
+    htmlDir,
+    rootDir,
+    absolutePathPrefix,
+  });
   const assets = params.extractAssets
-    ? extractAssets({ document, htmlDir, htmlFilePath, rootDir })
+    ? extractAssets({ document, htmlDir, htmlFilePath, rootDir, absolutePathPrefix })
     : [];
 
   // turn mutated AST back to a string

--- a/packages/rollup-plugin-html/src/output/createHTMLOutput.ts
+++ b/packages/rollup-plugin-html/src/output/createHTMLOutput.ts
@@ -20,6 +20,7 @@ export interface CreateHTMLAssetParams {
   defaultInjectDisabled: boolean;
   serviceWorkerPath: string;
   injectServiceWorker: boolean;
+  absolutePathPrefix?: string;
 }
 
 export async function createHTMLAsset(params: CreateHTMLAssetParams): Promise<EmittedFile> {
@@ -33,6 +34,7 @@ export async function createHTMLAsset(params: CreateHTMLAssetParams): Promise<Em
     defaultInjectDisabled,
     serviceWorkerPath,
     injectServiceWorker,
+    absolutePathPrefix,
   } = params;
 
   if (generatedBundles.length === 0) {
@@ -57,6 +59,7 @@ export async function createHTMLAsset(params: CreateHTMLAssetParams): Promise<Em
     defaultInjectDisabled,
     serviceWorkerPath,
     injectServiceWorker,
+    absolutePathPrefix,
   });
 
   return { fileName: input.name, name: input.name, source: outputHtml, type: 'asset' };
@@ -72,6 +75,7 @@ export interface CreateHTMLAssetsParams {
   defaultInjectDisabled: boolean;
   serviceWorkerPath: string;
   injectServiceWorker: boolean;
+  absolutePathPrefix?: string;
 }
 
 export async function createHTMLOutput(params: CreateHTMLAssetsParams): Promise<EmittedFile[]> {

--- a/packages/rollup-plugin-html/src/output/getOutputHTML.ts
+++ b/packages/rollup-plugin-html/src/output/getOutputHTML.ts
@@ -21,6 +21,7 @@ export interface GetOutputHTMLParams {
   defaultInjectDisabled: boolean;
   serviceWorkerPath: string;
   injectServiceWorker: boolean;
+  absolutePathPrefix?: string;
 }
 
 export async function getOutputHTML(params: GetOutputHTMLParams) {
@@ -34,6 +35,7 @@ export async function getOutputHTML(params: GetOutputHTMLParams) {
     defaultInjectDisabled,
     serviceWorkerPath,
     injectServiceWorker,
+    absolutePathPrefix,
   } = params;
   const { default: defaultBundle, ...multiBundles } = entrypointBundles;
   const { absoluteSocialMediaUrls = true, rootDir = process.cwd() } = pluginOptions;
@@ -41,7 +43,14 @@ export async function getOutputHTML(params: GetOutputHTMLParams) {
   // inject rollup output into HTML
   const document = parse(input.html);
   if (pluginOptions.extractAssets !== false) {
-    injectedUpdatedAssetPaths({ document, input, outputDir, rootDir, emittedAssets });
+    injectedUpdatedAssetPaths({
+      document,
+      input,
+      outputDir,
+      rootDir,
+      emittedAssets,
+      absolutePathPrefix,
+    });
   }
   if (!defaultInjectDisabled) {
     injectBundles(document, entrypointBundles);

--- a/packages/rollup-plugin-html/src/output/injectedUpdatedAssetPaths.ts
+++ b/packages/rollup-plugin-html/src/output/injectedUpdatedAssetPaths.ts
@@ -21,17 +21,26 @@ export interface InjectUpdatedAssetPathsArgs {
   rootDir: string;
   emittedAssets: EmittedAssets;
   publicPath?: string;
+  absolutePathPrefix?: string;
 }
 
 export function injectedUpdatedAssetPaths(args: InjectUpdatedAssetPathsArgs) {
-  const { document, input, outputDir, rootDir, emittedAssets, publicPath = './' } = args;
+  const {
+    document,
+    input,
+    outputDir,
+    rootDir,
+    emittedAssets,
+    publicPath = './',
+    absolutePathPrefix,
+  } = args;
   const assetNodes = findAssets(document);
 
   for (const node of assetNodes) {
     const sourcePath = getSourcePath(node);
     const htmlFilePath = input.filePath ? input.filePath : path.join(rootDir, input.name);
     const htmlDir = path.dirname(htmlFilePath);
-    const filePath = resolveAssetFilePath(sourcePath, htmlDir, rootDir);
+    const filePath = resolveAssetFilePath(sourcePath, htmlDir, rootDir, absolutePathPrefix);
     const assetPaths = isHashedAsset(node) ? emittedAssets.hashed : emittedAssets.static;
     const relativeOutputPath = assetPaths.get(filePath);
 

--- a/packages/rollup-plugin-html/src/rollupPluginHTML.ts
+++ b/packages/rollup-plugin-html/src/rollupPluginHTML.ts
@@ -31,6 +31,7 @@ export function rollupPluginHTML(pluginOptions: RollupPluginHTMLOptions = {}): R
   let defaultInjectDisabled = false;
   let serviceWorkerPath = '';
   let injectServiceWorker = false;
+  let absolutePathPrefix: string;
 
   function reset() {
     inputs = [];
@@ -62,6 +63,9 @@ export function rollupPluginHTML(pluginOptions: RollupPluginHTMLOptions = {}): R
       }
       if (pluginOptions.injectServiceWorker) {
         injectServiceWorker = pluginOptions.injectServiceWorker;
+      }
+      if (pluginOptions.absolutePathPrefix) {
+        absolutePathPrefix = pluginOptions.absolutePathPrefix;
       }
 
       if (pluginOptions.input == null) {
@@ -140,6 +144,7 @@ export function rollupPluginHTML(pluginOptions: RollupPluginHTMLOptions = {}): R
         defaultInjectDisabled,
         serviceWorkerPath,
         injectServiceWorker,
+        absolutePathPrefix,
       });
 
       for (const output of outputs) {
@@ -197,6 +202,7 @@ export function rollupPluginHTML(pluginOptions: RollupPluginHTMLOptions = {}): R
                 defaultInjectDisabled,
                 serviceWorkerPath,
                 injectServiceWorker,
+                absolutePathPrefix,
               });
 
               for (const output of outputs) {

--- a/packages/rollup-plugin-html/test/rollup-plugin-html.test.ts
+++ b/packages/rollup-plugin-html/test/rollup-plugin-html.test.ts
@@ -884,4 +884,38 @@ describe('rollup-plugin-html', () => {
       extractServiceWorkerPath(getAsset(output, path.join('sub-pure-html', 'index.html')).source),
     ).to.equal(`../service-worker.js`);
   });
+
+  it('does support a absolutePathPrefix to allow for sub folder deployments', async () => {
+    const config = {
+      plugins: [
+        rollupPluginHTML({
+          input: {
+            html: `<html>
+<body>
+<img src="/my-prefix/x/foo.svg" />
+<link rel="stylesheet" href="../styles.css" />
+<img src="../image-b.svg" />
+</body>
+</html>`,
+            name: 'x/index.html',
+          },
+          rootDir: path.join(__dirname, 'fixtures', 'assets'),
+          absolutePathPrefix: '/my-prefix/',
+        }),
+      ],
+    };
+
+    const bundle = await rollup(config);
+    const { output } = await bundle.generate(outputConfig);
+
+    expect(stripNewlines(getAsset(output, 'x/index.html').source)).to.equal(
+      [
+        '<html><head></head><body>',
+        '<img src="../assets/foo-c9db7cc0.svg">',
+        '<link rel="stylesheet" href="../assets/styles-ed723e17.css">',
+        '<img src="../assets/image-b-ee32b49e.svg">',
+        '</body></html>',
+      ].join(''),
+    );
+  });
 });


### PR DESCRIPTION
## What I did

If you are using absolute URLs for your assets and want to deploy to a sub directory then all your absolute links/urls will need to start with `/my-sub-directory/`. To still be able to find the actual assets you need to provide this `absolutePathPrefix`.

PS: the only relevant codechange is this
```js
  const _browserPath =
    absolutePathPrefix && browserPath[0] === '/'
      ? '/' + path.relative(absolutePathPrefix, browserPath)
      : browserPath;
```

the rest is only to pass around `absolutePathPrefix`