### PR TITLE
feat(test-runner): add coverageConfig.reporters configuration option

### DIFF
--- a/.changeset/rude-countries-pretend.md
+++ b/.changeset/rude-countries-pretend.md
@@ -1,0 +1,6 @@
+---
+'@web/test-runner': minor
+'@web/test-runner-core': minor
+---
+
+add configuration option reporters in coverageConfig to use various istanbul reporters

--- a/.changeset/rude-countries-pretend.md
+++ b/.changeset/rude-countries-pretend.md
@@ -1,6 +1,6 @@
 ---
-'@web/test-runner': minor
-'@web/test-runner-core': minor
+'@web/test-runner': patch
+'@web/test-runner-core': patch
 ---
 
 add configuration option reporters in coverageConfig to use various istanbul reporters

--- a/docs/docs/test-runner/cli-and-configuration.md
+++ b/docs/docs/test-runner/cli-and-configuration.md
@@ -80,6 +80,7 @@ A configuration file accepts most of the command line args camel-cased, with som
 
 ```ts
 import { Plugin, Middleware } from '@web/dev-server';
+import { ReportType } from 'istanbul-reports';
 
 interface TestFramework {
   path: string;
@@ -99,6 +100,7 @@ interface CoverageConfig {
   threshold?: CoverageThresholdConfig;
   report: boolean;
   reportDir: string;
+  reporters?: ReportType[];
 }
 
 type MimeTypeMappings = Record<string, string>;

--- a/packages/test-runner-core/src/cli/writeCoverageReport.ts
+++ b/packages/test-runner-core/src/cli/writeCoverageReport.ts
@@ -17,7 +17,9 @@ export function writeCoverageReport(testCoverage: TestCoverage, config: Coverage
     coverageMap: testCoverage.coverageMap,
   });
 
-  for (const reporter of config.reporters) {
+  const reporters = config.reporters || [];
+
+  for (const reporter of reporters) {
     const report = reports.create(reporter);
     (report as any).execute(context);
   }

--- a/packages/test-runner-core/src/cli/writeCoverageReport.ts
+++ b/packages/test-runner-core/src/cli/writeCoverageReport.ts
@@ -17,6 +17,8 @@ export function writeCoverageReport(testCoverage: TestCoverage, config: Coverage
     coverageMap: testCoverage.coverageMap,
   });
 
-  const report = reports.create('lcov');
-  (report as any).execute(context);
+  for (const reporter of config.reporters) {
+    const report = reports.create(reporter);
+    (report as any).execute(context);
+  }
 }

--- a/packages/test-runner-core/src/cli/writeCoverageReport.ts
+++ b/packages/test-runner-core/src/cli/writeCoverageReport.ts
@@ -20,7 +20,13 @@ export function writeCoverageReport(testCoverage: TestCoverage, config: Coverage
   const reporters = config.reporters || [];
 
   for (const reporter of reporters) {
-    const report = reports.create(reporter);
+    const report = reports.create(
+      reporter,
+      {
+        projectRoot: process.cwd(),
+        maxCols: process.stdout.columns || 100
+      }
+    );
     (report as any).execute(context);
   }
 }

--- a/packages/test-runner-core/src/cli/writeCoverageReport.ts
+++ b/packages/test-runner-core/src/cli/writeCoverageReport.ts
@@ -20,13 +20,10 @@ export function writeCoverageReport(testCoverage: TestCoverage, config: Coverage
   const reporters = config.reporters || [];
 
   for (const reporter of reporters) {
-    const report = reports.create(
-      reporter,
-      {
-        projectRoot: process.cwd(),
-        maxCols: process.stdout.columns || 100
-      }
-    );
+    const report = reports.create(reporter, {
+      projectRoot: process.cwd(),
+      maxCols: process.stdout.columns || 100,
+    });
     (report as any).execute(context);
   }
 }

--- a/packages/test-runner-core/src/config/TestRunnerCoreConfig.ts
+++ b/packages/test-runner-core/src/config/TestRunnerCoreConfig.ts
@@ -20,7 +20,7 @@ export interface CoverageConfig {
   threshold?: CoverageThresholdConfig;
   report: boolean;
   reportDir: string;
-  reporters: ReportType[];
+  reporters?: ReportType[];
 }
 
 export interface TestRunnerCoreConfig {

--- a/packages/test-runner-core/src/config/TestRunnerCoreConfig.ts
+++ b/packages/test-runner-core/src/config/TestRunnerCoreConfig.ts
@@ -4,6 +4,7 @@ import { TestFramework } from '../test-framework/TestFramework.js';
 import { Reporter } from '../reporter/Reporter.js';
 import { Logger } from '../logger/Logger.js';
 import { TestRunnerPlugin } from '../server/TestRunnerPlugin.js';
+import { ReportType } from 'istanbul-reports';
 
 export interface CoverageThresholdConfig {
   statements: number;
@@ -19,6 +20,7 @@ export interface CoverageConfig {
   threshold?: CoverageThresholdConfig;
   report: boolean;
   reportDir: string;
+  reporters: ReportType[];
 }
 
 export interface TestRunnerCoreConfig {

--- a/packages/test-runner/src/config/parseConfig.ts
+++ b/packages/test-runner/src/config/parseConfig.ts
@@ -43,6 +43,7 @@ const defaultCoverageConfig: CoverageConfig = {
   threshold: { statements: 0, functions: 0, branches: 0, lines: 0 },
   report: true,
   reportDir: 'coverage',
+  reporters: ['lcov'],
 };
 
 function validate(config: Record<string, unknown>, key: string, type: string) {

--- a/packages/test-runner/src/reporter/getCodeCoverage.ts
+++ b/packages/test-runner/src/reporter/getCodeCoverage.ts
@@ -39,7 +39,7 @@ export function getCodeCoverage(
     });
   }
 
-  if (!watch && coverageConfig.report && coverageConfig.reporters.includes('lcov')) {
+  if (!watch && coverageConfig.report && coverageConfig.reporters?.includes('lcov')) {
     entries.push(
       `View full coverage report at ${chalk.underline(
         path.join(coverageConfig.reportDir, 'lcov-report', 'index.html'),

--- a/packages/test-runner/src/reporter/getCodeCoverage.ts
+++ b/packages/test-runner/src/reporter/getCodeCoverage.ts
@@ -39,7 +39,7 @@ export function getCodeCoverage(
     });
   }
 
-  if (!watch && coverageConfig.report) {
+  if (!watch && coverageConfig.report && coverageConfig.reporters.includes('lcov')) {
     entries.push(
       `View full coverage report at ${chalk.underline(
         path.join(coverageConfig.reportDir, 'lcov-report', 'index.html'),


### PR DESCRIPTION
## What I did

1. add a reporters option for coverageConfig allowing to use [alternative istanbul reporters](https://istanbul.js.org/docs/advanced/alternative-reporters/) for code coverage
