### PR TITLE
Fix undeclared dependencies

### DIFF
--- a/.changeset/quiet-mice-call.md
+++ b/.changeset/quiet-mice-call.md
@@ -1,0 +1,7 @@
+---
+"@web/test-runner-core": patch
+"@web/test-runner-coverage-v8": patch
+"@web/test-runner": patch
+---
+
+Add undeclared dependencies

--- a/packages/test-runner-core/package.json
+++ b/packages/test-runner-core/package.json
@@ -54,8 +54,10 @@
     "@web/browser-logs": "^0.2.0",
     "@web/dev-server-core": "^0.3.3",
     "chalk": "^4.1.0",
+    "chokidar": "^3.4.3",
     "cli-cursor": "^3.1.0",
     "co-body": "^6.1.0",
+    "convert-source-map": "^1.7.0",
     "debounce": "^1.2.0",
     "dependency-graph": "^0.10.0",
     "globby": "^11.0.1",
@@ -64,7 +66,9 @@
     "istanbul-lib-report": "^3.0.0",
     "istanbul-reports": "^3.0.2",
     "log-update": "^4.0.0",
+    "open": "^7.3.0",
     "picomatch": "^2.2.2",
+    "source-map": "^0.7.3",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/packages/test-runner-coverage-v8/package.json
+++ b/packages/test-runner-coverage-v8/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@web/test-runner-core": "^0.10.0",
     "istanbul-lib-coverage": "^3.0.0",
+    "picomatch": "^2.2.2",
     "v8-to-istanbul": "^7.1.0"
   },
   "devDependencies": {

--- a/packages/test-runner/package.json
+++ b/packages/test-runner/package.json
@@ -81,6 +81,7 @@
     "camelcase": "^6.2.0",
     "chalk": "^4.1.0",
     "command-line-args": "^5.1.1",
+    "command-line-usage": "^6.1.1",
     "convert-source-map": "^1.7.0",
     "deepmerge": "^4.2.2",
     "diff": "^5.0.0",


### PR DESCRIPTION
## What I did

When running web-test-runner with yarn v2, PnP module resolution warns about imports of packages not declared as dependencies in the module:

```
$ yarn web-test-runner --puppeteer
(node:47320) [MODULE_NOT_FOUND] Error: debug tried to access supports-color (a peer dependency) but it isn't provided by its ancestors; this makes the require call ambiguous and unsound.
(Use `node --trace-warnings ...` to show where the warning was created)
(node:47320) [MODULE_NOT_FOUND] Error: @web/test-runner-core tried to access chokidar, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
(node:47320) [MODULE_NOT_FOUND] Error: @web/test-runner-core tried to access convert-source-map, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
(node:47320) [MODULE_NOT_FOUND] Error: @web/test-runner-core tried to access source-map, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
(node:47320) [MODULE_NOT_FOUND] Error: @web/test-runner-core tried to access open, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
(node:47320) [MODULE_NOT_FOUND] Error: @web/test-runner-coverage-v8 tried to access picomatch, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
(node:47320) [MODULE_NOT_FOUND] Error: @web/test-runner tried to access command-line-usage, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
```

This PR adds dependencies to the respective package.json files. In the case of chokidar and open, which have newer versions than specified by other repo packages, I used the older version for consistency.