### PR TITLE
chore: add backwards compatibility for "middlewares" property

### DIFF
--- a/.changeset/perfect-onions-roll.md
+++ b/.changeset/perfect-onions-roll.md
@@ -1,0 +1,6 @@
+---
+'@web/dev-server': patch
+'@web/test-runner': patch
+---
+
+add backwards compatibility for "middlewares" config property

--- a/packages/dev-server/src/config/parseConfig.ts
+++ b/packages/dev-server/src/config/parseConfig.ts
@@ -59,6 +59,13 @@ export async function parseConfig(
   cliArgs?: DevServerCliArgs,
 ): Promise<DevServerConfig> {
   const mergedConfigs = mergeConfigs(defaultConfig, config, cliArgs);
+
+  // backwards compatibility for configs written for es-dev-server, where middleware was
+  // spelled incorrectly as middlewares
+  if (Array.isArray((mergedConfigs as any).middlewares)) {
+    mergedConfigs.middleware!.push(...(mergedConfigs as any).middlewares);
+  }
+
   const finalConfig = validateConfig(mergedConfigs);
   // filter out non-objects from plugin list
   finalConfig.plugins = (finalConfig.plugins ?? []).filter(pl => typeof pl === 'object');

--- a/packages/test-runner/src/config/parseConfig.ts
+++ b/packages/test-runner/src/config/parseConfig.ts
@@ -134,6 +134,13 @@ export async function parseConfig(
   delete cliArgsConfig.browsers;
 
   const mergedConfigs = mergeConfigs(defaultConfig, config, cliArgsConfig);
+
+  // backwards compatibility for configs written for es-dev-server, where middleware was
+  // spelled incorrectly as middlewares
+  if (Array.isArray((mergedConfigs as any).middlewares)) {
+    mergedConfigs.middleware!.push(...(mergedConfigs as any).middlewares);
+  }
+
   const finalConfig = validateConfig(mergedConfigs);
   // filter out non-objects from plugin list
   finalConfig.plugins = (finalConfig.plugins ?? []).filter(pl => typeof pl === 'object');


### PR DESCRIPTION
## What I did

Adds backwards compatibility for "middlewares" property, this helps migrating configs written for es-dev-server where the config option was misspelled a `middlewares`.
