### PR TITLE
fix(test-runner-webdriver) Wait until the page unloads before reusing frame

### DIFF
--- a/.changeset/mighty-clocks-relax.md
+++ b/.changeset/mighty-clocks-relax.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-webdriver': patch
+---
+
+Fix intermittent testsStartTimeout on Safari on Sauce


### PR DESCRIPTION
## What I did

1. Use `executeAsync` when setting the iframe src to an empty page, and wait until the load (or error) event fires before returning the frame to `inactiveFrames`

This appears to resolve the intermittent `testsStartTimeout` timeouts we've seen on Safari when running on Sauce, reported in #1216.

Fixes #1216