### PR TITLE
Don't use red text color when there are 0 failures

### DIFF
--- a/.changeset/heavy-rabbits-sin.md
+++ b/.changeset/heavy-rabbits-sin.md
@@ -1,0 +1,5 @@
+---
+"@web/test-runner": patch
+---
+
+Don't use red text color when there are 0 failures

--- a/packages/test-runner/src/reporter/getTestProgress.ts
+++ b/packages/test-runner/src/reporter/getTestProgress.ts
@@ -36,9 +36,10 @@ function getProgressReport(
   skippedTests: number,
   failedTests: number,
 ) {
+  const failedText = `${failedTests} failed`;
   const testResults =
     `${chalk.green(`${passedTests} passed`)}` +
-    `, ${chalk.red(`${failedTests} failed`)}` +
+    `, ${failedTests !== 0 ? chalk.red(failedText) : failedText}` +
     (skippedTests !== 0 ? `, ${chalk.gray(`${skippedTests} skipped`)}` : '');
   const progressBar = `${renderProgressBar(
     finishedFiles,


### PR DESCRIPTION
As discussed in #1234. Some notes:

- The contributing documentation didn't include any specific notes on how to run tests for the repository, but I think I got them to work via `yarn build && yarn test`. At least one test complained about Selenium not being able to start up; maybe it would be nice to have some documentation on how to get things up and running (or provide an install script that installs required system dependencies.)
- It didn't look like there was a specific test for this functionality, and considering the simplicity of the change, I did not bother adding one.
