### PR TITLE
feat(test-runner): filter out internal stack traces

### DIFF
--- a/.changeset/long-ads-drum.md
+++ b/.changeset/long-ads-drum.md
@@ -1,0 +1,7 @@
+---
+'@web/browser-logs': patch
+'@web/test-runner-core': patch
+'@web/test-runner-mocha': patch
+---
+
+filter out internal stack traces

--- a/packages/test-runner-core/src/server/plugins/serveTestFrameworkPlugin.ts
+++ b/packages/test-runner-core/src/server/plugins/serveTestFrameworkPlugin.ts
@@ -5,7 +5,6 @@ import { Plugin } from '@web/dev-server-core';
 import { TestFramework } from '../../test-framework/TestFramework';
 
 const TEST_FRAMEWORK_IMPORT_ROOT = '/__web-test-runner__/test-framework/';
-const REGEXP_SOURCE_MAP = /\/\/# sourceMappingURL=.*/;
 
 async function readFile(codePath: string) {
   if (!fs.existsSync(codePath)) {
@@ -15,7 +14,7 @@ async function readFile(codePath: string) {
     );
   }
 
-  return (await promisify(fs.readFile)(codePath, 'utf-8')).replace(REGEXP_SOURCE_MAP, '');
+  return await promisify(fs.readFile)(codePath, 'utf-8');
 }
 
 /**
@@ -39,6 +38,7 @@ export function serveTestFrameworkPlugin(testFramework: TestFramework) {
         if (path.sep === '/') {
           filePath = `/${filePath}`;
         }
+
         const body = await readFile(filePath);
         return { body, type: 'js', headers: { 'cache-control': 'public, max-age=31536000' } };
       }

--- a/packages/test-runner-mocha/package.json
+++ b/packages/test-runner-mocha/package.json
@@ -39,7 +39,6 @@
     "@web/test-runner-core": "^0.10.0"
   },
   "devDependencies": {
-    "clean-css": "^5.0.1",
     "mocha": "^8.2.1"
   }
 }

--- a/rollup.browser.config.js
+++ b/rollup.browser.config.js
@@ -7,13 +7,14 @@ export default input => ({
   input,
   output: {
     dir: './dist',
-    sourcemap: true,
+    sourcemap: false,
     format: 'es',
   },
   plugins: [
     nodeResolve(),
     typescript({
       composite: false,
+      sourceMap: false,
     }),
     terser({
       output: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3584,13 +3584,6 @@ clean-css@^4.1.11, clean-css@^4.2.1, clean-css@^4.2.3:
   dependencies:
     source-map "~0.6.0"
 
-clean-css@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.0.1.tgz#f84c6ad82c5a8246a680206da8bceef483ccc0b6"
-  integrity sha512-F1zAGOowUCg8yxT0O4UR+nmbMauf3YwbiUS60CPxpzJU7ulpamGzQomFrJSK4w/HqHtMmQKSHJUNue+dQQYQdg==
-  dependencies:
-    source-map "~0.6.0"
-
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"


### PR DESCRIPTION
## What I did

This change filters out stack traces of internal packages, such as `@web/test-runner-mocha` and `@web/test-runner-core/browser/session.js`