### PR TITLE
feat(test-runner): skip non-http test coverage files

### DIFF
--- a/.changeset/breezy-ducks-give.md
+++ b/.changeset/breezy-ducks-give.md
@@ -1,0 +1,8 @@
+---
+'@web/test-runner-coverage-v8': patch
+'@web/test-runner': patch
+'@web/test-runner-chrome': patch
+'@web/test-runner-playwright': patch
+---
+
+skip non-http coverage files


### PR DESCRIPTION
## What I did

When converting coverage from v8 to istanbul, webpack bundled files are returned with a specific webpack protocol. This is because of the inline source maps. We can't fetch the source maps for these files back from the server, so we skip them entirely for now.
