### PR TITLE
fix(test-runner): fallback to fetch on IE11

### DIFF
--- a/.changeset/cold-flowers-laugh.md
+++ b/.changeset/cold-flowers-laugh.md
@@ -1,0 +1,7 @@
+---
+'@web/dev-server-core': patch
+'@web/test-runner-core': patch
+'@web/test-runner': patch
+---
+
+fallback to fetch on IE11

--- a/packages/dev-server-core/src/web-sockets/webSocketsPlugin.ts
+++ b/packages/dev-server-core/src/web-sockets/webSocketsPlugin.ts
@@ -21,97 +21,112 @@ export function webSocketsPlugin(): Plugin {
         return `
 export let webSocket;
 export let webSocketOpened;
+export let sendMessage;
+export let sendMessageWaitForResponse;
 let getNextMessageId;
 
-if (window.parent !== window && window.parent.__WDS_WEB_SOCKET__ !== undefined) {
-  // get the websocket instance from the parent element if present
-  const info = window.parent.__WDS_WEB_SOCKET__;
-  webSocket = info.webSocket;
-  webSocketOpened = info.webSocketOpened;
-  getNextMessageId = info.getNextMessageId;
-} else {
-  webSocket =
-    'WebSocket' in window
-      ? new WebSocket(\`ws\${location.protocol === 'https:' ? 's' : ''}://\${location.host}\`)
-      : null;
-  webSocketOpened = new Promise(resolve => {
-    if (!webSocket) {
-      resolve();
-    } else {
-      webSocket.addEventListener('open', () => {
+function setupFetch() {
+  sendMessage = (message) =>fetch('/__web-test-runner__/wtr-legacy-browser-api', { method: 'POST', body: JSON.stringify(message) });
+  sendMessageWaitForResponse = (message) => fetch('/__web-test-runner__/wtr-legacy-browser-api', { method: 'POST', body: JSON.stringify(message) });
+}
+
+function setupWebSocket() {
+  if (window.parent !== window && window.parent.__WDS_WEB_SOCKET__ !== undefined) {
+    // get the websocket instance from the parent element if present
+    const info = window.parent.__WDS_WEB_SOCKET__;
+    webSocket = info.webSocket;
+    webSocketOpened = info.webSocketOpened;
+    getNextMessageId = info.getNextMessageId;
+  } else {
+    webSocket =
+      'WebSocket' in window
+        ? new WebSocket(\`ws\${location.protocol === 'https:' ? 's' : ''}://\${location.host}\`)
+        : null;
+    webSocketOpened = new Promise(resolve => {
+      if (!webSocket) {
         resolve();
-      });
-    }
-  });
-  let messageId = 0;
-  getNextMessageId = function () {
-    if (messageId >= Number.MAX_SAFE_INTEGER) {
-      messageId = 0;
-    }
-    messageId += 1;
-    return messageId;
-  };
-  window.__WDS_WEB_SOCKET__ = { webSocket, webSocketOpened, getNextMessageId };
-}
-
-export async function sendMessage(message) {
-  if (!message.type) {
-    throw new Error('Missing message type');
+      } else {
+        webSocket.addEventListener('open', () => {
+          resolve();
+        });
+      }
+    });
+    let messageId = 0;
+    getNextMessageId = function () {
+      if (messageId >= Number.MAX_SAFE_INTEGER) {
+        messageId = 0;
+      }
+      messageId += 1;
+      return messageId;
+    };
+    window.__WDS_WEB_SOCKET__ = { webSocket, webSocketOpened, getNextMessageId };
   }
-  await webSocketOpened;
-  webSocket.send(JSON.stringify(message));
-}
-
-// sends a websocket message and expects a response from the server
-export function sendMessageWaitForResponse(message) {
-  return new Promise(async (resolve, reject) => {
-    const id = getNextMessageId();
-
-    function onResponse(e) {
-      const message = JSON.parse(e.data);
-      if (message.type === 'message-response' && message.id === id) {
+  
+  sendMessage = async (message) => {
+    if (!message.type) {
+      throw new Error('Missing message type');
+    }
+    await webSocketOpened;
+    webSocket.send(JSON.stringify(message));
+  }
+  
+  // sends a websocket message and expects a response from the server
+  sendMessageWaitForResponse = async (message) => {
+    return new Promise(async (resolve, reject) => {
+      const id = getNextMessageId();
+  
+      function onResponse(e) {
+        const message = JSON.parse(e.data);
+        if (message.type === 'message-response' && message.id === id) {
+          webSocket.removeEventListener('message', onResponse);
+          if (message.error) {
+            reject(new Error(message.error));
+          } else {
+            resolve(message.response);
+          }
+        }
+      }
+  
+      webSocket.addEventListener('message', onResponse);
+  
+      setTimeout(() => {
         webSocket.removeEventListener('message', onResponse);
-        if (message.error) {
-          reject(new Error(message.error));
-        } else {
-          resolve(message.response);
+        reject(
+          new Error(
+            \`Did not receive a server response for message with type \${message.type} within 20000ms\`,
+          ),
+        );
+      }, 20000);
+  
+      sendMessage({ ...message, id });
+    });
+  }
+  
+  if (webSocket) {
+    webSocket.addEventListener('message', async e => {
+      try {
+        const message = JSON.parse(e.data);
+        if (message.type === 'import') {
+          const module = await import(message.data.importPath);
+          if (typeof module.default === 'function') {
+            module.default(...(message.data.args || []));
+          }
+          return;
         }
+      } catch (error) {
+        console.error('[Web Dev Server] Error while handling websocket message.');
+        console.error(error);
       }
-    }
-
-    webSocket.addEventListener('message', onResponse);
-
-    setTimeout(() => {
-      webSocket.removeEventListener('message', onResponse);
-      reject(
-        new Error(
-          \`Did not receive a server response for message with type \${message.type} within 20000ms\`,
-        ),
-      );
-    }, 20000);
-
-    sendMessage({ ...message, id });
-  });
+    });
+  }
 }
 
-if (webSocket) {
-  webSocket.addEventListener('message', async e => {
-    try {
-      const message = JSON.parse(e.data);
-      if (message.type === 'import') {
-        const module = await import(message.data.importPath);
-        if (typeof module.default === 'function') {
-          module.default(...(message.data.args || []));
-        }
-        return;
-      }
-    } catch (error) {
-      console.error('[Web Dev Server] Error while handling websocket message.');
-      console.error(error);
-    }
-  });
+if (!!navigator.userAgent.match(/Trident/)) {
+  setupFetch();
+} else {
+  setupWebSocket();
 }
-        `;
+`;
       }
     },
 


### PR DESCRIPTION
## What I did

Falls back to fetch instead of using a websocket on IE11. Let's see if this improves stability.