### PR TITLE
fix(parse5-utils): ignore comments in isHtmlFragment

### DIFF
--- a/.changeset/nine-pears-invent.md
+++ b/.changeset/nine-pears-invent.md
@@ -1,0 +1,5 @@
+---
+'@web/parse5-utils': minor
+---
+
+Ignore comments when checking isHtmlFragment

--- a/packages/parse5-utils/src/index.js
+++ b/packages/parse5-utils/src/index.js
@@ -47,7 +47,8 @@ function createScript(attrs = {}, code = undefined) {
  * @param {string} html
  */
 function isHtmlFragment(html) {
-  return !REGEXP_IS_HTML_DOCUMENT.test(html);
+  let htmlWithoutComments = html.replace(/<!--.*?-->/g, '');
+  return !REGEXP_IS_HTML_DOCUMENT.test(htmlWithoutComments);
 }
 
 /**

--- a/packages/parse5-utils/test/index.test.js
+++ b/packages/parse5-utils/test/index.test.js
@@ -57,6 +57,9 @@ describe('parse5-utils', () => {
       expect(utils.isHtmlFragment('')).to.equal(true);
       expect(utils.isHtmlFragment('foo')).to.equal(true);
       expect(utils.isHtmlFragment('<div></div>')).to.equal(true);
+      expect(utils.isHtmlFragment('<!-- COMMENT --><!DOCTYPE><my-element></my-element>')).to.equal(
+        false,
+      );
       expect(utils.isHtmlFragment('<!DOCTYPE><my-element></my-element>')).to.equal(false);
       expect(utils.isHtmlFragment('  <!DOCTYPE><my-element></my-element>')).to.equal(false);
       expect(utils.isHtmlFragment('  <html><my-element></my-element></html>')).to.equal(false);


### PR DESCRIPTION
## What I did

1. Replaced comments passed to `isHtmlFragment` with empty string.
```
function isHtmlFragment(html) {
  let htmlWithoutComments = html.replace(/<!--.*?-->/g, '');
  return !REGEXP_IS_HTML_DOCUMENT.test(htmlWithoutComments);
}
```
2. Add test which checks `isHtmlFragment('<!-- COMMENT --><!DOCTYPE><my-element></my-element>')` is false.
