### PR TITLE
fix(parse5-utils): allow break lines when checking isHtmlFragment

### DIFF
--- a/.changeset/smart-humans-remember.md
+++ b/.changeset/smart-humans-remember.md
@@ -1,0 +1,5 @@
+---
+'@web/parse5-utils': patch
+---
+
+Allow break lines in comments when checking isHtmlFragment

--- a/packages/parse5-utils/src/index.js
+++ b/packages/parse5-utils/src/index.js
@@ -47,7 +47,7 @@ function createScript(attrs = {}, code = undefined) {
  * @param {string} html
  */
 function isHtmlFragment(html) {
-  let htmlWithoutComments = html.replace(/<!--.*?-->/g, '');
+  let htmlWithoutComments = html.replace(/<!--.*?-->/gs, '');
   return !REGEXP_IS_HTML_DOCUMENT.test(htmlWithoutComments);
 }
 

--- a/packages/parse5-utils/test/index.test.js
+++ b/packages/parse5-utils/test/index.test.js
@@ -60,6 +60,11 @@ describe('parse5-utils', () => {
       expect(utils.isHtmlFragment('<!-- COMMENT --><!DOCTYPE><my-element></my-element>')).to.equal(
         false,
       );
+      expect(
+        utils.isHtmlFragment(`<!--
+      COMMENT
+      --><!DOCTYPE><my-element></my-element>`),
+      ).to.equal(false);
       expect(utils.isHtmlFragment('<!DOCTYPE><my-element></my-element>')).to.equal(false);
       expect(utils.isHtmlFragment('  <!DOCTYPE><my-element></my-element>')).to.equal(false);
       expect(utils.isHtmlFragment('  <html><my-element></my-element></html>')).to.equal(false);


### PR DESCRIPTION
## What I did

1. Allow break lines when checking isHtmlFragment

Reference: https://github.com/modernweb-dev/web/pull/1284#issuecomment-777316386