### PR TITLE
fix(rollup-plugin-polyfills-loader): fix relative paths to polyfills with flattenOutput: false

### DIFF
--- a/.changeset/mighty-pandas-brake.md
+++ b/.changeset/mighty-pandas-brake.md
@@ -1,0 +1,6 @@
+---
+'@web/polyfills-loader': patch
+'@web/rollup-plugin-polyfills-loader': patch
+---
+
+fix(rollup-plugin-polyfills-loader): fix relative paths to polyfills with `flattenOutput: false`

--- a/packages/polyfills-loader/src/createPolyfillsLoader.ts
+++ b/packages/polyfills-loader/src/createPolyfillsLoader.ts
@@ -135,8 +135,8 @@ function createLoadFilesCode(cfg: PolyfillsLoaderConfig, polyfills: PolyfillFile
 }
 
 /**
- * Returns the relative path to a polyfill in posix path format suitable for
- * a relative URL, given the plugin configuation
+ * Returns the relative path to a polyfill (in posix path format suitable for
+ * a relative URL) given the plugin configuation
  */
 function relativePolyfillPath(polyfillPath: string, cfg: PolyfillsLoaderConfig) {
   const relativePath = path.join(cfg.relativePathToPolyfills || './', polyfillPath);

--- a/packages/polyfills-loader/src/createPolyfillsLoader.ts
+++ b/packages/polyfills-loader/src/createPolyfillsLoader.ts
@@ -135,10 +135,12 @@ function createLoadFilesCode(cfg: PolyfillsLoaderConfig, polyfills: PolyfillFile
 }
 
 /**
- * Returns the relative path to a polyfill, given the plugin configuation
+ * Returns the relative path to a polyfill in posix path format suitable for
+ * a relative URL, given the plugin configuation
  */
 function relativePolyfillPath(polyfillPath: string, cfg: PolyfillsLoaderConfig) {
-  return path.posix.join(cfg.relativePathToPolyfills || './', polyfillPath);
+  const relativePath = path.join(cfg.relativePathToPolyfills || './', polyfillPath);
+  return relativePath.split(path.sep).join(path.posix.sep);
 }
 
 /**

--- a/packages/polyfills-loader/src/types.ts
+++ b/packages/polyfills-loader/src/types.ts
@@ -12,6 +12,9 @@ export interface PolyfillsLoaderConfig {
   polyfills?: PolyfillsConfig;
   // directory to output polyfills into
   polyfillsDir?: string;
+  // relative path from the html file the loader is being injected into to the
+  // polyfills directory
+  relativePathToPolyfills?: string;
   // whether to minify the loader output
   minify?: boolean;
   // whether to preload the modern entrypoint, best for performance

--- a/packages/polyfills-loader/test/createPolyfillsLoader.test.ts
+++ b/packages/polyfills-loader/test/createPolyfillsLoader.test.ts
@@ -222,6 +222,28 @@ describe('createPolyfillsLoader', function describe() {
     });
   });
 
+  it('generates a loader script with a relative path to polyfills directory', async () => {
+    await testSnapshot({
+      name: 'relative-polyfills-dir',
+      config: {
+        modern: { files: [{ type: fileTypes.MODULE, path: 'app.js' }] },
+        relativePathToPolyfills: '../..',
+        polyfills: {
+          hash: false,
+          coreJs: true,
+          webcomponents: true,
+          fetch: true,
+        },
+      },
+      expectedFiles: [
+        'polyfills/fetch.js',
+        'polyfills/webcomponents.js',
+        'polyfills/custom-elements-es5-adapter.js',
+        'polyfills/core-js.js',
+      ],
+    });
+  });
+
   it('generates a loader script with a polyfill with an initializer', async () => {
     await testSnapshot({
       name: 'polyfills-initializer',

--- a/packages/polyfills-loader/test/snapshots/createPolyfillsLoader/custom-polyfills-dir.js
+++ b/packages/polyfills-loader/test/snapshots/createPolyfillsLoader/custom-polyfills-dir.js
@@ -58,7 +58,7 @@
       polyfillsLoader();
     }
 
-    s.src = "foo/bar/core-js.js";
+    s.src = "./foo/bar/core-js.js";
     s.onload = onLoaded;
 
     s.onerror = function () {

--- a/packages/polyfills-loader/test/snapshots/createPolyfillsLoader/polyfills-initializer.js
+++ b/packages/polyfills-loader/test/snapshots/createPolyfillsLoader/polyfills-initializer.js
@@ -61,7 +61,7 @@
       polyfillsLoader();
     }
 
-    s.src = "polyfills/core-js.js";
+    s.src = "./polyfills/core-js.js";
     s.onload = onLoaded;
 
     s.onerror = function () {

--- a/packages/polyfills-loader/test/snapshots/createPolyfillsLoader/polyfills-module.js
+++ b/packages/polyfills-loader/test/snapshots/createPolyfillsLoader/polyfills-module.js
@@ -36,7 +36,7 @@
       polyfillsLoader();
     }
 
-    s.src = "polyfills/core-js.js";
+    s.src = "./polyfills/core-js.js";
     s.onload = onLoaded;
 
     s.onerror = function () {

--- a/packages/polyfills-loader/test/snapshots/createPolyfillsLoader/relative-polyfills-dir.js
+++ b/packages/polyfills-loader/test/snapshots/createPolyfillsLoader/relative-polyfills-dir.js
@@ -28,15 +28,15 @@
     var polyfills = [];
 
     if (!('fetch' in window)) {
-      polyfills.push(loadScript('./polyfills/fetch.js'));
+      polyfills.push(loadScript('./../../polyfills/fetch.js'));
     }
 
     if (!('attachShadow' in Element.prototype) || !('getRootNode' in Element.prototype) || window.ShadyDOM && window.ShadyDOM.force) {
-      polyfills.push(loadScript('./polyfills/webcomponents.js'));
+      polyfills.push(loadScript('./../../polyfills/webcomponents.js'));
     }
 
     if (!('noModule' in HTMLScriptElement.prototype) && 'getRootNode' in Element.prototype) {
-      polyfills.push(loadScript('./polyfills/custom-elements-es5-adapter.js'));
+      polyfills.push(loadScript('./../../polyfills/custom-elements-es5-adapter.js'));
     }
 
     function loadFiles() {
@@ -58,7 +58,7 @@
       polyfillsLoader();
     }
 
-    s.src = "./polyfills/core-js.js";
+    s.src = "./../../polyfills/core-js.js";
     s.onload = onLoaded;
 
     s.onerror = function () {

--- a/packages/rollup-plugin-polyfills-loader/src/rollupPluginPolyfillsLoader.ts
+++ b/packages/rollup-plugin-polyfills-loader/src/rollupPluginPolyfillsLoader.ts
@@ -31,12 +31,16 @@ export function polyfillsLoader(pluginOptions: RollupPluginPolyfillsLoaderConfig
       }
 
       htmlPlugin.api.disableDefaultInject();
-      htmlPlugin.api.addHtmlTransformer(async (html, { bundle, bundles }) => {
+      htmlPlugin.api.addHtmlTransformer(async (html, { bundle, bundles, htmlFileName }) => {
         const config = createPolyfillsLoaderConfig(pluginOptions, bundle, bundles);
+        const relativePathToPolyfills = path.posix.relative(
+          path.posix.dirname(htmlFileName),
+          path.posix.dirname(pluginOptions.polyfillsDir || './polyfills'),
+        );
         let htmlString = html;
 
         if (shouldInjectLoader(config)) {
-          const result = await injectPolyfillsLoader(html, config);
+          const result = await injectPolyfillsLoader(html, { ...config, relativePathToPolyfills });
           htmlString = result.htmlString;
           generatedFiles = result.polyfillFiles;
         } else {

--- a/packages/rollup-plugin-polyfills-loader/src/rollupPluginPolyfillsLoader.ts
+++ b/packages/rollup-plugin-polyfills-loader/src/rollupPluginPolyfillsLoader.ts
@@ -33,9 +33,9 @@ export function polyfillsLoader(pluginOptions: RollupPluginPolyfillsLoaderConfig
       htmlPlugin.api.disableDefaultInject();
       htmlPlugin.api.addHtmlTransformer(async (html, { bundle, bundles, htmlFileName }) => {
         const config = createPolyfillsLoaderConfig(pluginOptions, bundle, bundles);
-        const relativePathToPolyfills = path.posix.relative(
-          path.posix.dirname(htmlFileName),
-          path.posix.dirname(pluginOptions.polyfillsDir || './polyfills'),
+        const relativePathToPolyfills = path.relative(
+          path.dirname(htmlFileName),
+          path.dirname(pluginOptions.polyfillsDir || './polyfills'),
         );
         let htmlString = html;
 

--- a/packages/rollup-plugin-polyfills-loader/src/types.d.ts
+++ b/packages/rollup-plugin-polyfills-loader/src/types.d.ts
@@ -13,4 +13,5 @@ export interface RollupPluginPolyfillsLoaderConfig {
   modernOutput?: OutputConfig;
   legacyOutput?: LegacyOutputConfig | LegacyOutputConfig[];
   polyfills?: PolyfillsConfig;
+  polyfillsDir?: string;
 }

--- a/packages/rollup-plugin-polyfills-loader/test/fixtures/non-flat/index.html
+++ b/packages/rollup-plugin-polyfills-loader/test/fixtures/non-flat/index.html
@@ -1,0 +1,2 @@
+<script type="module" src="../entrypoint-a.js"></script>
+<script type="module" src="../entrypoint-b.js"></script>

--- a/packages/rollup-plugin-polyfills-loader/test/snapshots/flattened.html
+++ b/packages/rollup-plugin-polyfills-loader/test/snapshots/flattened.html
@@ -1,0 +1,53 @@
+<html><head>
+            
+<link rel="preload" href="./entrypoint-a.js" as="script" crossorigin="anonymous">
+<link rel="preload" href="shared-ed942ddb.js" as="script" crossorigin="anonymous">
+<link rel="preload" href="./entrypoint-b.js" as="script" crossorigin="anonymous">
+</head><body><script>(function () {
+  function loadScript(src, type) {
+    return new Promise(function (resolve) {
+      var script = document.createElement('script');
+
+      function onLoaded() {
+        if (script.parentElement) {
+          script.parentElement.removeChild(script);
+        }
+
+        resolve();
+      }
+
+      script.src = src;
+      script.onload = onLoaded;
+
+      script.onerror = function () {
+        console.error('[polyfills-loader] failed to load: ' + src + ' check the network tab for HTTP status.');
+        onLoaded();
+      };
+
+      if (type) script.type = type;
+      document.head.appendChild(script);
+    });
+  }
+
+  var polyfills = [];
+
+  if (!('fetch' in window)) {
+    polyfills.push(loadScript('./polyfills/fetch.js'));
+  }
+
+  function loadFiles() {
+    [function () {
+      return loadScript('./entrypoint-a.js', 'module');
+    }, function () {
+      return loadScript('./entrypoint-b.js', 'module');
+    }].reduce(function (a, c) {
+      return a.then(c);
+    }, Promise.resolve());
+  }
+
+  if (polyfills.length) {
+    Promise.all(polyfills).then(loadFiles);
+  } else {
+    loadFiles();
+  }
+})();</script></body></html>

--- a/packages/rollup-plugin-polyfills-loader/test/snapshots/non-flattened.html
+++ b/packages/rollup-plugin-polyfills-loader/test/snapshots/non-flattened.html
@@ -1,0 +1,53 @@
+<html><head>
+            
+<link rel="preload" href="../entrypoint-a.js" as="script" crossorigin="anonymous">
+<link rel="preload" href="../shared-ed942ddb.js" as="script" crossorigin="anonymous">
+<link rel="preload" href="../entrypoint-b.js" as="script" crossorigin="anonymous">
+</head><body><script>(function () {
+  function loadScript(src, type) {
+    return new Promise(function (resolve) {
+      var script = document.createElement('script');
+
+      function onLoaded() {
+        if (script.parentElement) {
+          script.parentElement.removeChild(script);
+        }
+
+        resolve();
+      }
+
+      script.src = src;
+      script.onload = onLoaded;
+
+      script.onerror = function () {
+        console.error('[polyfills-loader] failed to load: ' + src + ' check the network tab for HTTP status.');
+        onLoaded();
+      };
+
+      if (type) script.type = type;
+      document.head.appendChild(script);
+    });
+  }
+
+  var polyfills = [];
+
+  if (!('fetch' in window)) {
+    polyfills.push(loadScript('./../polyfills/fetch.js'));
+  }
+
+  function loadFiles() {
+    [function () {
+      return loadScript('../entrypoint-a.js', 'module');
+    }, function () {
+      return loadScript('../entrypoint-b.js', 'module');
+    }].reduce(function (a, c) {
+      return a.then(c);
+    }, Promise.resolve());
+  }
+
+  if (polyfills.length) {
+    Promise.all(polyfills).then(loadFiles);
+  } else {
+    loadFiles();
+  }
+})();</script></body></html>

--- a/packages/rollup-plugin-polyfills-loader/test/src/rollupPluginPolyfillsLoader.test.ts
+++ b/packages/rollup-plugin-polyfills-loader/test/src/rollupPluginPolyfillsLoader.test.ts
@@ -142,7 +142,7 @@ describe('rollup-plugin-polyfills-loader', function describe() {
 
     await testSnapshot({
       name: 'non-flattened',
-      fileName: `non-flat/index.html`,
+      fileName: path.normalize(`non-flat/index.html`),
       inputOptions,
       outputOptions: defaultOutputOptions,
     });

--- a/packages/rollup-plugin-polyfills-loader/test/src/rollupPluginPolyfillsLoader.test.ts
+++ b/packages/rollup-plugin-polyfills-loader/test/src/rollupPluginPolyfillsLoader.test.ts
@@ -104,6 +104,50 @@ describe('rollup-plugin-polyfills-loader', function describe() {
     });
   });
 
+  it('can inject a polyfills loader with non-flat inputs, flattenOutput: true', async () => {
+    const inputOptions: RollupOptions = {
+      plugins: [
+        html({ 
+          rootDir: `${relativeUrl}/fixtures/`,
+          input: `non-flat/index.html`,
+          flattenOutput: true
+        }),
+        polyfillsLoader({
+          polyfills: { hash: false, fetch: true },
+        }),
+      ],
+    };
+
+    await testSnapshot({
+      name: 'flattened',
+      fileName: `index.html`,
+      inputOptions,
+      outputOptions: defaultOutputOptions,
+    });
+  });
+
+  it('can inject a polyfills loader with non-flat inputs, flattenOutput: false', async () => {
+    const inputOptions: RollupOptions = {
+      plugins: [
+        html({ 
+          rootDir: `${relativeUrl}/fixtures/`,
+          input: `non-flat/index.html`,
+          flattenOutput: false
+        }),
+        polyfillsLoader({
+          polyfills: { hash: false, fetch: true },
+        }),
+      ],
+    };
+
+    await testSnapshot({
+      name: 'non-flattened',
+      fileName: `non-flat/index.html`,
+      inputOptions,
+      outputOptions: defaultOutputOptions,
+    });
+  });
+
   it('injects the correct preload for systemjs output', async () => {
     const inputOptions: RollupOptions = {
       plugins: [

--- a/packages/rollup-plugin-polyfills-loader/test/src/rollupPluginPolyfillsLoader.test.ts
+++ b/packages/rollup-plugin-polyfills-loader/test/src/rollupPluginPolyfillsLoader.test.ts
@@ -107,10 +107,10 @@ describe('rollup-plugin-polyfills-loader', function describe() {
   it('can inject a polyfills loader with non-flat inputs, flattenOutput: true', async () => {
     const inputOptions: RollupOptions = {
       plugins: [
-        html({ 
+        html({
           rootDir: `${relativeUrl}/fixtures/`,
           input: `non-flat/index.html`,
-          flattenOutput: true
+          flattenOutput: true,
         }),
         polyfillsLoader({
           polyfills: { hash: false, fetch: true },
@@ -129,10 +129,10 @@ describe('rollup-plugin-polyfills-loader', function describe() {
   it('can inject a polyfills loader with non-flat inputs, flattenOutput: false', async () => {
     const inputOptions: RollupOptions = {
       plugins: [
-        html({ 
+        html({
           rootDir: `${relativeUrl}/fixtures/`,
           input: `non-flat/index.html`,
-          flattenOutput: false
+          flattenOutput: false,
         }),
         polyfillsLoader({
           polyfills: { hash: false, fetch: true },


### PR DESCRIPTION
## What I did

1. Added optional `relativePathToPolyfills` config option to `@web/polyfills-loader`
2. Changed `@web/rollup-plugin-polyfills-loader` to set `relativePathToPolyfills` based on the relative path between `polyfillsDir` and the input html file.

Fixes #1290