### PR TITLE
attempt to fix reading configName when there is no CLI args

### DIFF
--- a/packages/config-loader/src/index.js
+++ b/packages/config-loader/src/index.js
@@ -11,6 +11,10 @@ const EXTENSIONS = ['.mjs', '.cjs', '.js'];
  * @param {string} [basedir]
  */
 async function readConfig(name, customPath, basedir = process.cwd()) {
+  if (fileExists(name)) {
+    return importOrRequireConfig(name);
+  }
+
   const resolvedCustomPath = customPath ? path.resolve(basedir, customPath) : undefined;
   if (resolvedCustomPath && !(await fileExists(resolvedCustomPath))) {
     throw new ConfigLoaderError(`Could not find a config file at ${resolvedCustomPath}`);

--- a/packages/dev-server/src/startDevServer.ts
+++ b/packages/dev-server/src/startDevServer.ts
@@ -7,7 +7,6 @@ import { readFileConfig } from './config/readFileConfig';
 import { DevServerStartError } from './DevServerStartError';
 import { createLogger } from './logger/createLogger';
 import { openBrowser } from './openBrowser';
-import { dirname } from 'path';
 
 export interface StartDevServerParams {
   /**
@@ -56,12 +55,7 @@ export async function startDevServer(options: StartDevServerParams = {}) {
 
   try {
     const cliArgs = readCliArgsFlag ? readCliArgs({ argv }) : {};
-    const rawConfig = readFileConfigFlag
-      ? await readFileConfig({
-          configName,
-          configPath: readCliArgsFlag ? cliArgs.config : dirname(configName),
-        })
-      : {};
+    const rawConfig = await readFileConfig({ configName, configPath: cliArgs.config });
     const mergedConfig = mergeConfigs(extraConfig, rawConfig);
     const config = await parseConfig(mergedConfig, cliArgs);
 

--- a/packages/dev-server/src/startDevServer.ts
+++ b/packages/dev-server/src/startDevServer.ts
@@ -7,6 +7,7 @@ import { readFileConfig } from './config/readFileConfig';
 import { DevServerStartError } from './DevServerStartError';
 import { createLogger } from './logger/createLogger';
 import { openBrowser } from './openBrowser';
+import { dirname } from 'path';
 
 export interface StartDevServerParams {
   /**
@@ -56,7 +57,10 @@ export async function startDevServer(options: StartDevServerParams = {}) {
   try {
     const cliArgs = readCliArgsFlag ? readCliArgs({ argv }) : {};
     const rawConfig = readFileConfigFlag
-      ? await readFileConfig({ configName, configPath: cliArgs.config })
+      ? await readFileConfig({
+          configName,
+          configPath: readCliArgsFlag ? cliArgs.config : dirname(configName),
+        })
       : {};
     const mergedConfig = mergeConfigs(extraConfig, rawConfig);
     const config = await parseConfig(mergedConfig, cliArgs);


### PR DESCRIPTION
## What I did

1. When calling `startDevServer()` programatically with readCliArgsFlag as false, the `startDevServer()` routine attempts to read the cli args anyway.  This patch will instead attempt to guess the directory from the configName option.  
