### PR TITLE
feat(webdriver): update webdriverio to v7

### DIFF
--- a/.changeset/friendly-forks-pull.md
+++ b/.changeset/friendly-forks-pull.md
@@ -1,0 +1,5 @@
+---
+"@web/test-runner-browserstack": patch
+---
+
+feat(webdriver): update webdriverio to v7

--- a/.changeset/warm-bears-check.md
+++ b/.changeset/warm-bears-check.md
@@ -1,0 +1,6 @@
+---
+'@web/test-runner-saucelabs': minor
+'@web/test-runner-webdriver': minor
+---
+
+Update webdriverio dependency to v7

--- a/packages/test-runner-saucelabs/package.json
+++ b/packages/test-runner-saucelabs/package.json
@@ -50,8 +50,8 @@
     "ip": "^1.1.5",
     "saucelabs": "^4.6.2",
     "uuid": "^8.3.2",
-    "webdriver": "^6.10.11",
-    "webdriverio": "^6.10.11"
+    "webdriver": "^7.0.3",
+    "webdriverio": "^7.0.3"
   },
   "devDependencies": {
     "@types/ip": "^1.1.0",

--- a/packages/test-runner-webdriver/package.json
+++ b/packages/test-runner-webdriver/package.json
@@ -48,7 +48,7 @@
   ],
   "dependencies": {
     "@web/test-runner-core": "^0.10.8",
-    "webdriverio": "^6.10.11"
+    "webdriverio": "^7.0.3"
   },
   "devDependencies": {
     "@types/selenium-standalone": "^6.15.2",

--- a/packages/test-runner-webdriver/src/IFrameManager.ts
+++ b/packages/test-runner-webdriver/src/IFrameManager.ts
@@ -1,5 +1,5 @@
 import { TestRunnerCoreConfig } from '@web/test-runner-core';
-import { BrowserObject, Element } from 'webdriverio';
+import { Browser, Element } from 'webdriverio';
 import { validateBrowserResult } from './coverage';
 
 /**
@@ -7,7 +7,7 @@ import { validateBrowserResult } from './coverage';
  */
 export class IFrameManager {
   private config: TestRunnerCoreConfig;
-  private driver: BrowserObject;
+  private driver: Browser<'async'>;
   private framePerSession = new Map<string, string>();
   private inactiveFrames: string[] = [];
   private frameCount = 0;
@@ -16,7 +16,7 @@ export class IFrameManager {
   private locked?: Promise<unknown>;
   private isIE: boolean;
 
-  constructor(config: TestRunnerCoreConfig, driver: BrowserObject, isIE: boolean) {
+  constructor(config: TestRunnerCoreConfig, driver: Browser<'async'>, isIE: boolean) {
     this.config = config;
     this.driver = driver;
     this.isIE = isIE;
@@ -155,7 +155,7 @@ export class IFrameManager {
 
     await this.driver.switchToFrame(frame);
 
-    const elementData = (await this.driver.execute(locator, [])) as Element;
+    const elementData = (await this.driver.execute(locator, [])) as Element<'async'>;
 
     const element = await this.driver.$(elementData);
 

--- a/packages/test-runner-webdriver/src/SessionManager.ts
+++ b/packages/test-runner-webdriver/src/SessionManager.ts
@@ -1,5 +1,5 @@
 import { TestRunnerCoreConfig } from '@web/test-runner-core';
-import { BrowserObject, Element } from 'webdriverio';
+import { Browser, Element } from 'webdriverio';
 import { validateBrowserResult } from './coverage';
 
 /**
@@ -7,12 +7,12 @@ import { validateBrowserResult } from './coverage';
  */
 export class SessionManager {
   private config: TestRunnerCoreConfig;
-  private driver: BrowserObject;
+  private driver: Browser<'async'>;
   private locked?: Promise<unknown>;
   private isIE: boolean;
   private urlMap = new Map<string, string>();
 
-  constructor(config: TestRunnerCoreConfig, driver: BrowserObject, isIE: boolean) {
+  constructor(config: TestRunnerCoreConfig, driver: Browser<'async'>, isIE: boolean) {
     this.config = config;
     this.driver = driver;
     this.isIE = isIE;
@@ -81,7 +81,7 @@ export class SessionManager {
   }
 
   async takeScreenshot(_: string, locator: string): Promise<Buffer> {
-    const elementData = (await this.driver.execute(locator, [])) as Element;
+    const elementData = (await this.driver.execute(locator, [])) as Element<'async'>;
 
     const element = await this.driver.$(elementData);
 

--- a/packages/test-runner-webdriver/src/webdriverLauncher.ts
+++ b/packages/test-runner-webdriver/src/webdriverLauncher.ts
@@ -1,5 +1,5 @@
 import { BrowserLauncher, TestRunnerCoreConfig } from '@web/test-runner-core';
-import { remote, BrowserObject, RemoteOptions } from 'webdriverio';
+import { Browser, remote, RemoteOptions } from 'webdriverio';
 import { IFrameManager } from './IFrameManager';
 import { SessionManager } from './SessionManager';
 import { getBrowserLabel } from './utils';
@@ -8,8 +8,8 @@ export class WebdriverLauncher implements BrowserLauncher {
   public name = 'Initializing...';
   public type = 'webdriver';
   private config?: TestRunnerCoreConfig;
-  private driver?: BrowserObject;
-  private debugDriver: undefined | BrowserObject = undefined;
+  private driver?: Browser<'async'>;
+  private debugDriver: undefined | Browser<'async'> = undefined;
   private driverManager?: IFrameManager | SessionManager;
   private __managerPromise?: Promise<IFrameManager | SessionManager>;
   private isIE = false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2341,43 +2341,52 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@wdio/config@6.12.1":
-  version "6.12.1"
-  resolved "https://registry.yarnpkg.com/@wdio/config/-/config-6.12.1.tgz#86d987b505d8ca85ec11471830d2ba296dab3bcf"
-  integrity sha512-V5hTIW5FNlZ1W33smHF4Rd5BKjGW2KeYhyXDQfXHjqLCeRiirZ9fABCo9plaVQDnwWSUMWYaAaIAifV82/oJCQ==
+"@wdio/config@7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@wdio/config/-/config-7.0.3.tgz#05d14dec34b9e026acc876d29fb1ed914069fcce"
+  integrity sha512-EQMRF957LnDLdlG638+RGTQYcedJ2nATC11NuTniUB4BggeJrknSxpao4jzOdsdkoImd+kc6mlgM0n5kgLLj1w==
   dependencies:
-    "@wdio/logger" "6.10.10"
+    "@wdio/logger" "7.0.0"
+    "@wdio/types" "7.0.3"
     deepmerge "^4.0.0"
     glob "^7.1.2"
 
-"@wdio/logger@6.10.10":
-  version "6.10.10"
-  resolved "https://registry.yarnpkg.com/@wdio/logger/-/logger-6.10.10.tgz#1e07cf32a69606ddb94fa9fd4b0171cb839a5980"
-  integrity sha512-2nh0hJz9HeZE0VIEMI+oPgjr/Q37ohrR9iqsl7f7GW5ik+PnKYCT9Eab5mR1GNMG60askwbskgGC1S9ygtvrSw==
+"@wdio/logger@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@wdio/logger/-/logger-7.0.0.tgz#d2e7a595b3daf1285da29571cc0fd7cfcc3c1a68"
+  integrity sha512-P3inCmtc0ms1vnx3v25+U6ccD2dkiuBhaJwmIWPwSbQn8cNQ5AcQIbRWMbnzFHbJ/jSrVBnlwmUArW7L02Zpeg==
   dependencies:
     chalk "^4.0.0"
     loglevel "^1.6.0"
     loglevel-plugin-prefix "^0.8.4"
     strip-ansi "^6.0.0"
 
-"@wdio/protocols@6.12.0":
-  version "6.12.0"
-  resolved "https://registry.yarnpkg.com/@wdio/protocols/-/protocols-6.12.0.tgz#e40850be62c42c82dd2c486655d6419cd9ec1e3e"
-  integrity sha512-UhTBZxClCsM3VjaiDp4DoSCnsa7D1QNmI2kqEBfIpyNkT3GcZhJb7L+nL0fTkzCwi7+/uLastb3/aOwH99gt0A==
+"@wdio/protocols@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@wdio/protocols/-/protocols-7.0.0.tgz#3def6e49187061ed231c5c5edd1c59e44b3b3894"
+  integrity sha512-njOD5dy8GqK1vIW5KfRrMPoWXN7CX3ucc1WZiiyGcqROOCNh/Lrb+ULwV9UHxh0n9a0uy+g1QyQ8//h2npBaXA==
 
-"@wdio/repl@6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@wdio/repl/-/repl-6.11.0.tgz#5b1eab574b6b89f7f7c383e7295c06af23c3818e"
-  integrity sha512-FxrFKiTkFyELNGGVEH1uijyvNY7lUpmff6x+FGskFGZB4uSRs0rxkOMaEjxnxw7QP1zgQKr2xC7GyO03gIGRGg==
+"@wdio/repl@7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@wdio/repl/-/repl-7.0.3.tgz#01795a6e6b492cf9485ad39a0b5890f2d0925f19"
+  integrity sha512-H/VWdoRaSUhCkFyVrUvRZ4kc3utH2ElS1PX1CzIzQs1YY40czxCz/sQ4klFdZUAyKnYGYGm/clRwmXVA7rLvLg==
   dependencies:
-    "@wdio/utils" "6.11.0"
+    "@wdio/utils" "7.0.3"
 
-"@wdio/utils@6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@wdio/utils/-/utils-6.11.0.tgz#878c2500efb1a325bf5a66d2ff3d08162f976e8c"
-  integrity sha512-vf0sOQzd28WbI26d6/ORrQ4XKWTzSlWLm9W/K/eJO0NASKPEzR+E+Q2kaa+MJ4FKXUpjbt+Lxfo+C26TzBk7tg==
+"@wdio/types@7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@wdio/types/-/types-7.0.3.tgz#b5758c31abf20cf4f3efe843287aafa5594cce4e"
+  integrity sha512-FUcxZorU0RrG9OkzBdoF8DYWvznYI5ttJIbrWU87GMkBJCmdqyoVHUaLOj2NoyaqaB3wHaIpruK9/2n5hfUFtA==
   dependencies:
-    "@wdio/logger" "6.10.10"
+    got "^11.8.1"
+
+"@wdio/utils@7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@wdio/utils/-/utils-7.0.3.tgz#db3f350db889ff03654b63619f643d11ec6702ae"
+  integrity sha512-vmYodgQeqVCzOF1fSRA1R3ohE8ui1g2HrRixMR5oukFc+88o4opdnjFhV6n9FLtHDkIKqaJ+WTBTj0RHGzb22A==
+  dependencies:
+    "@wdio/logger" "7.0.0"
+    "@wdio/types" "7.0.3"
 
 "@web/storybook-prebuilt@^0.1.20":
   version "0.1.20"
@@ -4576,15 +4585,21 @@ devtools-protocol@0.0.818844:
   resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.818844.tgz#d1947278ec85b53e4c8ca598f607a28fa785ba9e"
   integrity sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==
 
-devtools@6.12.1:
-  version "6.12.1"
-  resolved "https://registry.yarnpkg.com/devtools/-/devtools-6.12.1.tgz#f0298c6d6f46d8d3b751dd8fa4a0c7bc76e1268f"
-  integrity sha512-JyG46suEiZmld7/UVeogkCWM0zYGt+2ML/TI+SkEp+bTv9cs46cDb0pKF3glYZJA7wVVL2gC07Ic0iCxyJEnCQ==
+devtools-protocol@^0.0.849057:
+  version "0.0.849057"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.849057.tgz#5fa64e2c5ad4499a30aa9e8da82613afc4b1aa77"
+  integrity sha512-gelr0GCBy0fztR4iKbX3LN5jRjhLtmXVI+L87HARqxshVD9uvipbaadpkas1wvgybqIa1ZBgqm+zkd8qVGvupg==
+
+devtools@7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/devtools/-/devtools-7.0.3.tgz#3d2c99e6183acac3842ce101d7abcf6a19a1dd34"
+  integrity sha512-VG8Lej1zzBYGPPrQd+/e7y5We8h1cDAexRDniX+suZbiCEgf+cF2p/s+XofAXOXtKOEi7ypdHaNLJCQ7Mf+MDQ==
   dependencies:
-    "@wdio/config" "6.12.1"
-    "@wdio/logger" "6.10.10"
-    "@wdio/protocols" "6.12.0"
-    "@wdio/utils" "6.11.0"
+    "@wdio/config" "7.0.3"
+    "@wdio/logger" "7.0.0"
+    "@wdio/protocols" "7.0.0"
+    "@wdio/types" "7.0.3"
+    "@wdio/utils" "7.0.3"
     chrome-launcher "^0.13.1"
     edge-paths "^2.1.0"
     puppeteer-core "^5.1.0"
@@ -5807,7 +5822,7 @@ got@9.6.0, got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-got@^11.0.2, got@^11.7.0, got@^11.8.0:
+got@^11.0.2, got@^11.7.0, got@^11.8.0, got@^11.8.1:
   version "11.8.1"
   resolved "https://registry.yarnpkg.com/got/-/got-11.8.1.tgz#df04adfaf2e782babb3daabc79139feec2f7e85d"
   integrity sha512-9aYdZL+6nHmvJwHALLwKSUZ0hMwGaJGYv3hoPLPgnT8BoBXm1SjnZeky+91tfwJaDzun2s4RsBRy48IEYv2q2Q==
@@ -12508,33 +12523,37 @@ web-namespaces@^1.0.0, web-namespaces@^1.1.2:
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
 
-webdriver@6.12.1, webdriver@^6.10.11:
-  version "6.12.1"
-  resolved "https://registry.yarnpkg.com/webdriver/-/webdriver-6.12.1.tgz#30eee65340ea5124aa564f99a4dbc7d2f965b308"
-  integrity sha512-3rZgAj9o2XHp16FDTzvUYaHelPMSPbO1TpLIMUT06DfdZjNYIzZiItpIb/NbQDTPmNhzd9cuGmdI56WFBGY2BA==
+webdriver@7.0.3, webdriver@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/webdriver/-/webdriver-7.0.3.tgz#0427b50267030a4de8518d2cf30c2d389f59c9eb"
+  integrity sha512-t+7xqRrW8RtgoqovXmYWQkqbQJmpZkj1Wp4Wq14tYgJQvUyN6SPcK/2v4vzA6yUKaODUPNfisurf+woHd5ptIg==
   dependencies:
-    "@wdio/config" "6.12.1"
-    "@wdio/logger" "6.10.10"
-    "@wdio/protocols" "6.12.0"
-    "@wdio/utils" "6.11.0"
+    "@wdio/config" "7.0.3"
+    "@wdio/logger" "7.0.0"
+    "@wdio/protocols" "7.0.0"
+    "@wdio/types" "7.0.3"
+    "@wdio/utils" "7.0.3"
     got "^11.0.2"
     lodash.merge "^4.6.1"
 
-webdriverio@^6.10.11:
-  version "6.12.1"
-  resolved "https://registry.yarnpkg.com/webdriverio/-/webdriverio-6.12.1.tgz#5b6f1167373bd7a154419d8a930ef1ffda9d0537"
-  integrity sha512-Nx7ge0vTWHVIRUbZCT+IuMwB5Q0Q5nLlYdgnmmJviUKLuc3XtaEBkYPTbhHWHgSBXsPZMIc023vZKNkn+6iyeQ==
+webdriverio@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/webdriverio/-/webdriverio-7.0.3.tgz#639a8609d6eee98c91be86b6deac2c7980280ca8"
+  integrity sha512-04ko+5c0HuyCL9qbn/OW6F6G3VlDWsSlut3SLaWYuGQFIx4qL+LTUdE5txv1XkiNySJ8tcnDeVK+FOhu0zpSyA==
   dependencies:
     "@types/puppeteer-core" "^5.4.0"
-    "@wdio/config" "6.12.1"
-    "@wdio/logger" "6.10.10"
-    "@wdio/repl" "6.11.0"
-    "@wdio/utils" "6.11.0"
+    "@wdio/config" "7.0.3"
+    "@wdio/logger" "7.0.0"
+    "@wdio/protocols" "7.0.0"
+    "@wdio/repl" "7.0.3"
+    "@wdio/types" "7.0.3"
+    "@wdio/utils" "7.0.3"
     archiver "^5.0.0"
     atob "^2.1.2"
     css-shorthand-properties "^1.1.1"
     css-value "^0.0.1"
-    devtools "6.12.1"
+    devtools "7.0.3"
+    devtools-protocol "^0.0.849057"
     fs-extra "^9.0.1"
     get-port "^5.1.1"
     grapheme-splitter "^1.0.2"
@@ -12547,7 +12566,7 @@ webdriverio@^6.10.11:
     resq "^1.9.1"
     rgb2hex "0.2.3"
     serialize-error "^8.0.0"
-    webdriver "6.12.1"
+    webdriver "7.0.3"
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
## What I did

1. Updated `webdriverio` too v7 and fixed TypeScript compilation errors

@LarsDenBakker please note, the tests for the package are still skipped.

Closes #1285 