### PR TITLE
Fix JS syntax in readme examples

### DIFF
--- a/packages/rollup-plugin-workbox/README.md
+++ b/packages/rollup-plugin-workbox/README.md
@@ -19,7 +19,7 @@ You can find a detailed list of supported properties for the workbox config obje
 ```js
 const { generateSW } = require('rollup-plugin-workbox');
 
-module.exports {
+module.exports = {
   input: 'main.js',
   output: {
     file: 'dist/bundle.js',
@@ -41,7 +41,7 @@ const { generateSW } = require('rollup-plugin-workbox');
 
 const workboxConfig = require('./workbox-config.js')
 
-module.exports {
+module.exports = {
   // ...
   plugins: [
     generateSW(workboxConfig)
@@ -56,7 +56,7 @@ const { generateSW } = require('rollup-plugin-workbox');
 
 const workboxConfig = require('./workbox-config.js')
 
-module.exports {
+module.exports = {
   // ...
   plugins: [
     generateSW(
@@ -82,7 +82,7 @@ You can find a detailed list of supported properties for the workbox config obje
 ```js
 const { injectManifest } = require('rollup-plugin-workbox');
 
-module.exports {
+module.exports = {
   input: 'main.js',
   output: {
     file: 'dist/bundle.js',
@@ -105,7 +105,7 @@ const { injectManifest } = require('rollup-plugin-workbox');
 
 const workboxConfig = require('./workbox-config.js')
 
-module.exports {
+module.exports = {
   // ...
   plugins: [
     injectManifest(workboxConfig)
@@ -120,7 +120,7 @@ const { injectManifest } = require('rollup-plugin-workbox');
 
 const workboxConfig = require('./workbox-config.js')
 
-module.exports {
+module.exports = {
   // ...
   plugins: [
     injectManifest(
@@ -148,7 +148,7 @@ Until this gets fixed in `workbox-build`, `rollup-plugin-workbox` **does** suppo
 ```diff
 const { injectManifest } = require('rollup-plugin-workbox');
 
-module.exports {
+module.exports = {
   input: 'main.js',
   output: {
     file: 'dist/bundle.js',

--- a/packages/rollup-plugin-workbox/README.md
+++ b/packages/rollup-plugin-workbox/README.md
@@ -29,7 +29,7 @@ module.exports = {
     generateSW({
       swDest: '/dist/sw.js',
       globDirectory: 'demo/dist/',
-    })
+    }),
   ],
 };
 ```
@@ -39,13 +39,11 @@ You can also `require` your `workbox-config.js` file and pass it to the plugin.
 ```js
 const { generateSW } = require('rollup-plugin-workbox');
 
-const workboxConfig = require('./workbox-config.js')
+const workboxConfig = require('./workbox-config.js');
 
 module.exports = {
   // ...
-  plugins: [
-    generateSW(workboxConfig)
-  ],
+  plugins: [generateSW(workboxConfig)],
 };
 ```
 
@@ -93,7 +91,7 @@ module.exports = {
       swSrc: 'sw.js',
       swDest: '/dist/sw.js',
       globDirectory: 'demo/dist/',
-    })
+    }),
   ],
 };
 ```
@@ -103,13 +101,11 @@ You can also `require` your `workbox-config.js` file and pass it to the plugin.
 ```js
 const { injectManifest } = require('rollup-plugin-workbox');
 
-const workboxConfig = require('./workbox-config.js')
+const workboxConfig = require('./workbox-config.js');
 
 module.exports = {
   // ...
-  plugins: [
-    injectManifest(workboxConfig)
-  ],
+  plugins: [injectManifest(workboxConfig)],
 };
 ```
 


### PR DESCRIPTION
This brings the missing `=` in the README examples.
