### PR TITLE
chore: update mocha types to remove warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@rollup/plugin-node-resolve": "^11.0.1",
     "@rollup/plugin-typescript": "^8.1.0",
     "@types/chai": "^4.2.14",
-    "@types/mocha": "^8.0.01",
+    "@types/mocha": "^8.2.0",
     "@types/node": "^14.14.19",
     "@types/node-fetch": "^2.5.8",
     "@typescript-eslint/eslint-plugin": "^4.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2057,7 +2057,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/mocha@^8.0.01", "@types/mocha@^8.2.0":
+"@types/mocha@^8.2.0":
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-8.2.0.tgz#3eb56d13a1de1d347ecb1957c6860c911704bc44"
   integrity sha512-/Sge3BymXo4lKc31C8OINJgXLaw+7vL1/L1pGiBNpGrBiT8FQiaFpSYV0uhTaG4y78vcMBTMFsWaHDvuD+xGzQ==


### PR DESCRIPTION
## What I did

1. Updated `@types/mocha` to  get rid of the following warning:

```
warning Pattern ["@types/mocha@^8.0.01"] is trying to unpack in the same destination "/Users/sergey/Library/Caches/Yarn/v6/npm-@types-mocha-8.2.0-3eb56d13a1de1d347ecb1957c6860c911704bc44-integrity/node_modules/@types/mocha" as pattern ["@types/mocha@^8.2.0"]. This could result in non-deterministic behavior, skipping.
```