### PR TITLE
chore: update Playwright dependency

### DIFF
--- a/packages/test-runner-playwright/package.json
+++ b/packages/test-runner-playwright/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@web/test-runner-core": "^0.10.8",
     "@web/test-runner-coverage-v8": "^0.4.5",
-    "playwright": "^1.7.1"
+    "playwright": "^1.8.1"
   },
   "devDependencies": {
     "@web/test-runner-mocha": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8975,10 +8975,10 @@ pkg-dir@^5.0.0:
   dependencies:
     find-up "^5.0.0"
 
-playwright@^1.7.1:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.8.0.tgz#8eca2250967ee892b9fdfec44e2358455ab0f8e3"
-  integrity sha512-urMJDLX92KawbkWKrt3chVVBPQsuuNwlS5St7I5YQENXAEItoyUqX7FjiYaoPgXifKqe1+BKC+7pBAq1QUkgSw==
+playwright@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.8.1.tgz#0a26035d1b5f2c31d9a4da09d649b4992f989d1e"
+  integrity sha512-nmuiDEDwB/SdAxiZQS5pLqPS3XXN8OJ1LKvTSiAbJvu+AUf7f0RD7nuq9xB0C08Emd6stx9yBMhANvD12k/+GQ==
   dependencies:
     commander "^6.1.0"
     debug "^4.1.1"


### PR DESCRIPTION
## What I did

1. Re-floor the playwright dependency to force consumers onto a version that supports macOS11

## What I'll do

1. Confirm Monday whether any further changes here are needed to ensure stability in this OS