### PR TITLE
Fix/rollup csp

### DIFF
--- a/.changeset/large-glasses-attack.md
+++ b/.changeset/large-glasses-attack.md
@@ -1,0 +1,5 @@
+---
+'@web/parse5-utils': patch
+---
+
+Add missing export for prepend utility.

--- a/.changeset/swift-poems-look.md
+++ b/.changeset/swift-poems-look.md
@@ -1,0 +1,5 @@
+---
+'@web/rollup-plugin-html': minor
+---
+
+Add option to scan for inline scripts in HTML assets, and insert a CSP meta tag to allow them executing with strict CSP rules.

--- a/docs/docs/building/rollup-plugin-html.md
+++ b/docs/docs/building/rollup-plugin-html.md
@@ -259,6 +259,20 @@ export default {
 };
 ```
 
+### Strict CSP for inline scripts
+
+To prevent XSS, there is a rule in Content-Security-Policy guidelines called [script-src](https://content-security-policy.com/script-src/).
+
+Some servers will (rightfully so) set this value to 'self', sometimes adding a whitelist of other origins e.g. for Google Analytics.
+This makes it impossible for inline scripts to execute. There's an ugly way around that, by setting CSP rule `unsafe-inline`.
+
+There's also a proper workaround, which is by either using hashes or a nonce to allow inline scripts to run.
+Quite often, rollup plugins will insert inline scripts, e.g. to load polyfills, SystemJS or other common use cases.
+
+In this plugin, you can pass the option `strictCSPInlineScripts` and set it to true.
+The plugin will then scan HTML assets for inline scripts, turn its contents into a sha256 hash.
+These hashes are then inserted in a CSP `meta` tag in the HTML asset, enabling these inline scripts to run even under strict CSP rules.
+
 ## Type definitions
 
 ```ts
@@ -298,6 +312,8 @@ export interface RollupPluginHTMLOptions {
   serviceWorkerPath?: string;
   /** Prefix to strip from absolute paths when resolving assets and scripts, for example when using a base path that does not exist on disk. */
   absolutePathPrefix?: string;
+  /** When set to true, will insert meta tags for CSP and add script-src values for inline scripts by sha256-hashing the contents */
+  strictCSPInlineScripts?: boolean;
 }
 
 export interface GeneratedBundle {

--- a/docs/docs/building/rollup-plugin-polyfills-loader.md
+++ b/docs/docs/building/rollup-plugin-polyfills-loader.md
@@ -60,7 +60,7 @@ export default {
   plugins: [
     htmlPlugin,
     polyfillsLoader({
-      modernOutput: 'modern',
+      modernOutput: { name: 'modern' },
       legacyOutput: { name: 'legacy', test: "!('noModule' in HTMLScriptElement.prototype)" },
       polyfills: {
         coreJs: true,

--- a/packages/parse5-utils/src/index.js
+++ b/packages/parse5-utils/src/index.js
@@ -376,5 +376,6 @@ module.exports.findNode = findNode;
 module.exports.findNodes = findNodes;
 module.exports.findElement = findElement;
 module.exports.findElements = findElements;
+module.exports.prepend = prepend;
 module.exports.prependToDocument = prependToDocument;
 module.exports.appendToDocument = appendToDocument;

--- a/packages/rollup-plugin-html/src/RollupPluginHTMLOptions.ts
+++ b/packages/rollup-plugin-html/src/RollupPluginHTMLOptions.ts
@@ -34,6 +34,8 @@ export interface RollupPluginHTMLOptions {
   serviceWorkerPath?: string;
   /** Prefix to strip from absolute paths when resolving assets and scripts, for example when using a base path that does not exist on disk. */
   absolutePathPrefix?: string;
+  /** When set to true, will insert meta tags for CSP and add script-src values for inline scripts by sha256-hashing the contents */
+  strictCSPInlineScripts?: boolean;
 }
 
 export interface GeneratedBundle {

--- a/packages/rollup-plugin-html/src/output/createHTMLOutput.ts
+++ b/packages/rollup-plugin-html/src/output/createHTMLOutput.ts
@@ -21,6 +21,7 @@ export interface CreateHTMLAssetParams {
   serviceWorkerPath: string;
   injectServiceWorker: boolean;
   absolutePathPrefix?: string;
+  strictCSPInlineScripts: boolean;
 }
 
 export async function createHTMLAsset(params: CreateHTMLAssetParams): Promise<EmittedFile> {
@@ -35,6 +36,7 @@ export async function createHTMLAsset(params: CreateHTMLAssetParams): Promise<Em
     serviceWorkerPath,
     injectServiceWorker,
     absolutePathPrefix,
+    strictCSPInlineScripts,
   } = params;
 
   if (generatedBundles.length === 0) {
@@ -60,6 +62,7 @@ export async function createHTMLAsset(params: CreateHTMLAssetParams): Promise<Em
     serviceWorkerPath,
     injectServiceWorker,
     absolutePathPrefix,
+    strictCSPInlineScripts,
   });
 
   return { fileName: input.name, name: input.name, source: outputHtml, type: 'asset' };
@@ -76,6 +79,7 @@ export interface CreateHTMLAssetsParams {
   serviceWorkerPath: string;
   injectServiceWorker: boolean;
   absolutePathPrefix?: string;
+  strictCSPInlineScripts: boolean;
 }
 
 export async function createHTMLOutput(params: CreateHTMLAssetsParams): Promise<EmittedFile[]> {

--- a/packages/rollup-plugin-html/src/output/getOutputHTML.ts
+++ b/packages/rollup-plugin-html/src/output/getOutputHTML.ts
@@ -9,6 +9,7 @@ import { parse, serialize } from 'parse5';
 import { injectedUpdatedAssetPaths } from './injectedUpdatedAssetPaths';
 import { EmittedAssets } from './emitAssets';
 import { injectAbsoluteBaseUrl } from './injectAbsoluteBaseUrl';
+import { hashInlineScripts } from './hashInlineScripts';
 import { injectServiceWorkerRegistration } from './injectServiceWorkerRegistration';
 
 export interface GetOutputHTMLParams {
@@ -22,6 +23,7 @@ export interface GetOutputHTMLParams {
   serviceWorkerPath: string;
   injectServiceWorker: boolean;
   absolutePathPrefix?: string;
+  strictCSPInlineScripts: boolean;
 }
 
 export async function getOutputHTML(params: GetOutputHTMLParams) {
@@ -36,6 +38,7 @@ export async function getOutputHTML(params: GetOutputHTMLParams) {
     serviceWorkerPath,
     injectServiceWorker,
     absolutePathPrefix,
+    strictCSPInlineScripts,
   } = params;
   const { default: defaultBundle, ...multiBundles } = entrypointBundles;
   const { absoluteSocialMediaUrls = true, rootDir = process.cwd() } = pluginOptions;
@@ -65,6 +68,10 @@ export async function getOutputHTML(params: GetOutputHTMLParams) {
       serviceWorkerPath,
       htmlFileName: input.name,
     });
+  }
+
+  if (strictCSPInlineScripts) {
+    hashInlineScripts(document);
   }
 
   let outputHtml = serialize(document);

--- a/packages/rollup-plugin-html/src/output/getOutputHTML.ts
+++ b/packages/rollup-plugin-html/src/output/getOutputHTML.ts
@@ -44,7 +44,7 @@ export async function getOutputHTML(params: GetOutputHTMLParams) {
   const { absoluteSocialMediaUrls = true, rootDir = process.cwd() } = pluginOptions;
 
   // inject rollup output into HTML
-  const document = parse(input.html);
+  let document = parse(input.html);
   if (pluginOptions.extractAssets !== false) {
     injectedUpdatedAssetPaths({
       document,
@@ -70,10 +70,6 @@ export async function getOutputHTML(params: GetOutputHTMLParams) {
     });
   }
 
-  if (strictCSPInlineScripts) {
-    hashInlineScripts(document);
-  }
-
   let outputHtml = serialize(document);
 
   const transforms = [...(externalTransformHtmlFns ?? [])];
@@ -92,6 +88,12 @@ export async function getOutputHTML(params: GetOutputHTMLParams) {
       bundles: multiBundles,
       htmlFileName: input.name,
     });
+  }
+
+  if (strictCSPInlineScripts) {
+    document = parse(outputHtml);
+    hashInlineScripts(document);
+    outputHtml = serialize(document);
   }
 
   return outputHtml;

--- a/packages/rollup-plugin-html/src/output/hashInlineScripts.ts
+++ b/packages/rollup-plugin-html/src/output/hashInlineScripts.ts
@@ -1,14 +1,27 @@
-import { Node, Document } from 'parse5';
+import { Node, Document, DefaultTreeElement } from 'parse5';
 import {
+  findElement,
   findElements,
   getTagName,
   hasAttribute,
+  getAttribute,
   getTextContent,
   createElement,
   findNode,
   prepend,
+  setAttribute,
 } from '@web/parse5-utils';
 import crypto from 'crypto';
+
+function isMetaCSPTag(node: Node) {
+  if (
+    getTagName(node) === 'meta' &&
+    getAttribute(node, 'http-equiv') === 'Content-Security-Policy'
+  ) {
+    return true;
+  }
+  return false;
+}
 
 function isInlineScript(node: Node) {
   if (getTagName(node) === 'script' && !hasAttribute(node, 'src')) {
@@ -17,10 +30,101 @@ function isInlineScript(node: Node) {
   return false;
 }
 
+/**
+ * Parses Meta CSP Content string as an object so we can easily mutate it in JS
+ * E.g.:
+ *
+ * "default-src 'self'; prefetch-src 'self'; upgrade-insecure-requests; style-src 'self' 'unsafe-inline';"
+ *
+ * becomes
+ *
+ * {
+ *   'default-src': ["'self'"],
+ *   'prefetch-src': ["'self'"],
+ *   'upgrade-insecure-requests': [],
+ *   'style-src': ["'self'", "'unsafe-inline'"]
+ * }
+ *
+ */
+function parseMetaCSPContent(content: string): { [key: string]: string[] } {
+  return content.split(';').reduce((acc, curr) => {
+    const trimmed = curr.trim();
+    if (!trimmed) {
+      return acc;
+    }
+    const splitItem = trimmed.split(' ');
+    const [, ...values] = splitItem;
+    return {
+      ...acc,
+      [splitItem[0]]: values,
+    };
+  }, {});
+}
+
+/**
+ * Serializes
+ *
+ * {
+ *   'default-src': ["'self'"],
+ *   'prefetch-src': ["'self'"],
+ *   'upgrade-insecure-requests': [],
+ *   'style-src': ["'self'", "'unsafe-inline'"]
+ * }
+ *
+ * back to
+ *
+ * "default-src 'self'; prefetch-src 'self'; upgrade-insecure-requests; style-src 'self' 'unsafe-inline';"
+ */
+function serializeMetaCSPContent(data: { [key: string]: string[] }): string {
+  const dataEntries = Object.entries(data);
+  return dataEntries.reduce((accOuter, currOuter, indexOuter) => {
+    let suffixOuter = ' ';
+    let sep = ' ';
+
+    // If there are no items for this key
+    if (currOuter[1].length === 0) {
+      suffixOuter = '; ';
+      sep = '';
+    }
+
+    // Don't insert space suffix when it is the last item
+    if (indexOuter === dataEntries.length - 1) {
+      suffixOuter = '';
+    }
+
+    return `${accOuter}${currOuter[0]}${sep}${currOuter[1].reduce(
+      (accInner, currInner, indexInner) => {
+        let suffixInner = ' ';
+        if (indexInner === currOuter[1].length - 1) {
+          suffixInner = ';';
+        }
+        return `${accInner}${currInner}${suffixInner}`;
+      },
+      '',
+    )}${suffixOuter}`;
+  }, '');
+}
+
+function injectCSPScriptRules(metaCSPEl: DefaultTreeElement, hashes: string[]) {
+  const content = getAttribute(metaCSPEl, 'content');
+  if (content) {
+    const data = parseMetaCSPContent(content);
+
+    if (Array.isArray(data['script-src'])) {
+      data['script-src'].push(...hashes);
+    } else {
+      data['script-src'] = ["'self'", ...hashes];
+    }
+
+    const newContent = serializeMetaCSPContent(data);
+    setAttribute(metaCSPEl, 'content', newContent);
+  }
+}
+
 function injectCSPMetaTag(document: Document, hashes: string[]) {
   const metaTag = createElement('meta', {
     'http-equiv': 'Content-Security-Policy',
-    content: `script-src 'self' ${hashes.join(' ')}`,
+    content: `script-src 'self' ${hashes.join(' ')};`,
   });
   const head = findNode(document, node => node.nodeName === 'head');
   if (head) {
@@ -29,9 +133,10 @@ function injectCSPMetaTag(document: Document, hashes: string[]) {
 }
 
 export function hashInlineScripts(document: Document) {
-  const nodes = findElements(document, isInlineScript);
+  const metaCSPEl = findElement(document, isMetaCSPTag);
+  const inlineScripts = findElements(document, isInlineScript);
   const hashes: string[] = [];
-  nodes.forEach(node => {
+  inlineScripts.forEach(node => {
     if (node.childNodes[0]) {
       const scriptContent = getTextContent(node.childNodes[0]);
       const hash = crypto.createHash('sha256').update(scriptContent).digest('base64');
@@ -39,6 +144,10 @@ export function hashInlineScripts(document: Document) {
     }
   });
   if (hashes.length > 0) {
-    injectCSPMetaTag(document, hashes);
+    if (metaCSPEl) {
+      injectCSPScriptRules(metaCSPEl, hashes);
+    } else {
+      injectCSPMetaTag(document, hashes);
+    }
   }
 }

--- a/packages/rollup-plugin-html/src/output/hashInlineScripts.ts
+++ b/packages/rollup-plugin-html/src/output/hashInlineScripts.ts
@@ -1,0 +1,44 @@
+import { Node, Document } from 'parse5';
+import {
+  findElements,
+  getTagName,
+  hasAttribute,
+  getTextContent,
+  createElement,
+  findNode,
+  prepend,
+} from '@web/parse5-utils';
+import crypto from 'crypto';
+
+function isInlineScript(node: Node) {
+  if (getTagName(node) === 'script' && !hasAttribute(node, 'src')) {
+    return true;
+  }
+  return false;
+}
+
+function injectCSPMetaTag(document: Document, hashes: string[]) {
+  const metaTag = createElement('meta', {
+    'http-equiv': 'Content-Security-Policy',
+    content: `script-src 'self' ${hashes.join(' ')}`,
+  });
+  const head = findNode(document, node => node.nodeName === 'head');
+  if (head) {
+    prepend(head, metaTag);
+  }
+}
+
+export function hashInlineScripts(document: Document) {
+  const nodes = findElements(document, isInlineScript);
+  const hashes: string[] = [];
+  nodes.forEach(node => {
+    if (node.childNodes[0]) {
+      const scriptContent = getTextContent(node.childNodes[0]);
+      const hash = crypto.createHash('sha256').update(scriptContent).digest('base64');
+      hashes.push(`'sha256-${hash}'`);
+    }
+  });
+  if (hashes.length > 0) {
+    injectCSPMetaTag(document, hashes);
+  }
+}

--- a/packages/rollup-plugin-html/src/rollupPluginHTML.ts
+++ b/packages/rollup-plugin-html/src/rollupPluginHTML.ts
@@ -32,6 +32,7 @@ export function rollupPluginHTML(pluginOptions: RollupPluginHTMLOptions = {}): R
   let serviceWorkerPath = '';
   let injectServiceWorker = false;
   let absolutePathPrefix: string;
+  let strictCSPInlineScripts = false;
 
   function reset() {
     inputs = [];
@@ -66,6 +67,9 @@ export function rollupPluginHTML(pluginOptions: RollupPluginHTMLOptions = {}): R
       }
       if (pluginOptions.absolutePathPrefix) {
         absolutePathPrefix = pluginOptions.absolutePathPrefix;
+      }
+      if (pluginOptions.strictCSPInlineScripts) {
+        strictCSPInlineScripts = pluginOptions.strictCSPInlineScripts;
       }
 
       if (pluginOptions.input == null) {
@@ -145,6 +149,7 @@ export function rollupPluginHTML(pluginOptions: RollupPluginHTMLOptions = {}): R
         serviceWorkerPath,
         injectServiceWorker,
         absolutePathPrefix,
+        strictCSPInlineScripts,
       });
 
       for (const output of outputs) {
@@ -203,6 +208,7 @@ export function rollupPluginHTML(pluginOptions: RollupPluginHTMLOptions = {}): R
                 serviceWorkerPath,
                 injectServiceWorker,
                 absolutePathPrefix,
+                strictCSPInlineScripts,
               });
 
               for (const output of outputs) {

--- a/packages/rollup-plugin-html/test/fixtures/rollup-plugin-html/csp-page-a.html
+++ b/packages/rollup-plugin-html/test/fixtures/rollup-plugin-html/csp-page-a.html
@@ -1,4 +1,15 @@
+<html>
+<head>
+</head>
+<body>
 <h1>hello world</h1>
 <script type="module" src="./entrypoint-a.js"></script>
 <script type="module" src="./entrypoint-b.js"></script>
-<script>console.log('foo')</script>
+<script>
+console.log('foo');
+</script>
+<script>
+console.log('bar');
+</script>
+</body>
+</html>

--- a/packages/rollup-plugin-html/test/fixtures/rollup-plugin-html/csp-page-b.html
+++ b/packages/rollup-plugin-html/test/fixtures/rollup-plugin-html/csp-page-b.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+<meta
+  http-equiv="Content-Security-Policy"
+  content="default-src 'self'; prefetch-src 'self'; upgrade-insecure-requests; style-src 'self' 'unsafe-inline';"
+/>
+</head>
+<body>
+<h1>hello world</h1>
+<script type="module" src="./entrypoint-a.js"></script>
+<script type="module" src="./entrypoint-b.js"></script>
+<script>
+console.log('foo');
+</script>
+<script>
+console.log('bar');
+</script>
+</body>
+</html>

--- a/packages/rollup-plugin-html/test/fixtures/rollup-plugin-html/csp-page-c.html
+++ b/packages/rollup-plugin-html/test/fixtures/rollup-plugin-html/csp-page-c.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+<meta
+  http-equiv="Content-Security-Policy"
+  content="default-src 'self'; prefetch-src 'self'; upgrade-insecure-requests; style-src 'self' 'unsafe-inline'; script-src 'self';"
+/>
+</head>
+<body>
+<h1>hello world</h1>
+<script type="module" src="./entrypoint-a.js"></script>
+<script type="module" src="./entrypoint-b.js"></script>
+<script>
+console.log('foo');
+</script>
+<script>
+console.log('bar');
+</script>
+</body>
+</html>

--- a/packages/rollup-plugin-html/test/fixtures/rollup-plugin-html/csp-page.html
+++ b/packages/rollup-plugin-html/test/fixtures/rollup-plugin-html/csp-page.html
@@ -1,0 +1,4 @@
+<h1>hello world</h1>
+<script type="module" src="./entrypoint-a.js"></script>
+<script type="module" src="./entrypoint-b.js"></script>
+<script>console.log('foo')</script>

--- a/packages/rollup-plugin-html/test/src/output/getOutputHTML.test.ts
+++ b/packages/rollup-plugin-html/test/src/output/getOutputHTML.test.ts
@@ -28,6 +28,7 @@ describe('getOutputHTML()', () => {
     defaultInjectDisabled: false,
     injectServiceWorker: false,
     serviceWorkerPath: '',
+    strictCSPInlineScripts: false,
   };
 
   it('injects output into the input HTML', async () => {


### PR DESCRIPTION
## What I did

1. Fix multi-output docs error
2. Add missing prepend util export
3. Add strictCSPInlineScripts option


Works in my app now, but if other plugins insert scripts (e.g. polyfills-loader), these inline scripts are not caught by rollup-plugin-html where I am scanning for inline scripts and injecting the meta tag, because I am doing it too early.

The above is fixed, should add some more logic though to scan for existing meta CSP tags, and instead of overriding or adding a new meta CSP tag, reuse the existing one and add to it.

Above is fixed too now, ready for review