### PR TITLE
fix(rollup-plugin-polyfills-loader): calculate pathToRoot correctly

### DIFF
--- a/.changeset/nasty-actors-laugh.md
+++ b/.changeset/nasty-actors-laugh.md
@@ -1,0 +1,5 @@
+---
+'@web/rollup-plugin-polyfills-loader': patch
+---
+
+fix pathToRoot

--- a/packages/rollup-plugin-polyfills-loader/src/rollupPluginPolyfillsLoader.ts
+++ b/packages/rollup-plugin-polyfills-loader/src/rollupPluginPolyfillsLoader.ts
@@ -61,7 +61,7 @@ export function polyfillsLoader(pluginOptions: RollupPluginPolyfillsLoaderConfig
           preloaded.push(entrypoint.importPath);
 
           // js files (incl. chunks) will always be in the root directory
-          const pathToRoot = path.posix.relative('./', path.posix.dirname(entrypoint.importPath));
+          const pathToRoot = path.posix.dirname(entrypoint.importPath);
           for (const chunkPath of entrypoint.chunk.imports) {
             preloaded.push(path.posix.join(pathToRoot, chunkPath));
           }


### PR DESCRIPTION
## What I did

1. Remove relative path because importPath is already relative.

What was wrong?

- Trying to build a project in a folder close to system root (`/`) for example: `/app` when you try to calculate the `patToRoot` of `entrypoint.importPath = '../../../[hash].js' you always get `..` because it's relative to /app and there are no more directories. The correct way is to calculate direct the dirname of the entrypoint, because it's actually relative to index.html.
