### PR TITLE
fix(test-runner-visual-regression): allow mismatched screenshot sizes to be diffed

### DIFF
--- a/.changeset/few-sloths-grin.md
+++ b/.changeset/few-sloths-grin.md
@@ -1,0 +1,6 @@
+---
+"@web/test-runner-visual-regression": patch
+"@web/test-runner": patch
+---
+
+Capture visual regressions across changing screenshot sizes.

--- a/packages/test-runner-visual-regression/src/config.ts
+++ b/packages/test-runner-visual-regression/src/config.ts
@@ -28,6 +28,7 @@ export type OptionalImage = Buffer | undefined | Promise<Buffer | undefined>;
 export interface DiffResult {
   diffPercentage: number;
   diffImage: Buffer;
+  error: string;
 }
 
 export interface DiffArgs {


### PR DESCRIPTION
## What I did

1. Move mismatched size error up into diff command.
2. When images mismatch create two new images of the largest width/height from the initial screenshots.
3. Copy the original images into the new images.
4. Diff the synthetic screenshots.

In this was the following baseline, current, and diff screenshots will be created by the test pass:

<img src="https://user-images.githubusercontent.com/1156657/110954328-60b62100-8316-11eb-862d-de34d28a4d00.png" width="30%" alt="Baseline screenshot" align="left" /><img src="https://user-images.githubusercontent.com/1156657/110954339-63187b00-8316-11eb-9f6c-9dbc9902c4ac.png" width="30%" alt="Current screenshot" align="left" /><img src="https://user-images.githubusercontent.com/1156657/110954342-64e23e80-8316-11eb-9a57-58674241d8ce.png" width="30%" alt="Diff screenshot" align="left" />

