### PR TITLE
fix(rollup-plugin-polyfills-loader): allow changing filetype of only modern output

### DIFF
--- a/.changeset/sharp-birds-build.md
+++ b/.changeset/sharp-birds-build.md
@@ -1,0 +1,5 @@
+---
+'@web/rollup-plugin-polyfills-loader': patch
+---
+
+allow changing filetype for only modern output

--- a/packages/rollup-plugin-polyfills-loader/src/createPolyfillsLoaderConfig.ts
+++ b/packages/rollup-plugin-polyfills-loader/src/createPolyfillsLoaderConfig.ts
@@ -47,14 +47,14 @@ export function createPolyfillsLoaderConfig(
   // @web/rollup-plugin-html outputs `bundle` when there is a single output,
   // otherwise it outputs `bundles`
   if (bundle) {
-    if (modernOutput || legacyOutput) {
+    if (modernOutput && legacyOutput) {
       throw createError(
-        'Options modernOutput or legacyOutput was set, but @web/rollup-plugin-html' +
+        'Options modernOutput and legacyOutput was set, but @web/rollup-plugin-html' +
           ` did not output multiple builds. Make sure you use html.api.addOutput('my-output') for each rollup output.`,
       );
     }
 
-    modern = createEntrypoints(bundle);
+    modern = createEntrypoints(bundle, modernOutput?.type);
   } else {
     if (!bundles || Object.keys(bundles).length === 0) {
       throw createError('@web/rollup-plugin-html did not output any bundles to be injected');

--- a/packages/rollup-plugin-polyfills-loader/src/rollupPluginPolyfillsLoader.ts
+++ b/packages/rollup-plugin-polyfills-loader/src/rollupPluginPolyfillsLoader.ts
@@ -52,9 +52,10 @@ export function polyfillsLoader(pluginOptions: RollupPluginPolyfillsLoaderConfig
         }
 
         // preload all entrypoints as well as their direct dependencies
-        const { entrypoints } = pluginOptions.modernOutput
-          ? bundles[pluginOptions.modernOutput.name]
-          : bundle;
+        const { entrypoints } =
+          pluginOptions.legacyOutput && pluginOptions.modernOutput
+            ? bundles[pluginOptions.modernOutput.name]
+            : bundle;
 
         let preloaded = [];
         for (const entrypoint of entrypoints) {

--- a/packages/rollup-plugin-polyfills-loader/test/snapshots/customize-filetype-multi-output.html
+++ b/packages/rollup-plugin-polyfills-loader/test/snapshots/customize-filetype-multi-output.html
@@ -1,8 +1,5 @@
 <html><head>
-
-<link rel="preload" href="../entrypoint-a.js" as="script" crossorigin="anonymous">
-<link rel="preload" href="../shared-ed942ddb.js" as="script" crossorigin="anonymous">
-<link rel="preload" href="../entrypoint-b.js" as="script" crossorigin="anonymous">
+<link rel="preload" href="./entrypoint-a.js" as="script">
 </head><body><script>(function () {
   function loadScript(src, type) {
     return new Promise(function (resolve) {
@@ -32,17 +29,23 @@
   var polyfills = [];
 
   if (!('fetch' in window)) {
-    polyfills.push(loadScript('./../polyfills/fetch.js'));
+    polyfills.push(loadScript('./polyfills/fetch.js'));
+  }
+
+  if (!('attachShadow' in Element.prototype) || !('getRootNode' in Element.prototype) || window.ShadyDOM && window.ShadyDOM.force) {
+    polyfills.push(loadScript('./polyfills/webcomponents.js'));
+  }
+
+  if (!('noModule' in HTMLScriptElement.prototype) && 'getRootNode' in Element.prototype) {
+    polyfills.push(loadScript('./polyfills/custom-elements-es5-adapter.js'));
   }
 
   function loadFiles() {
-    [function () {
-      return loadScript('../entrypoint-a.js', 'module');
-    }, function () {
-      return loadScript('../entrypoint-b.js', 'module');
-    }].reduce(function (a, c) {
-      return a.then(c);
-    }, Promise.resolve());
+    if (!('noModule' in HTMLScriptElement.prototype)) {
+      loadScript('./entrypoint-a.js');
+    } else {
+      loadScript('./entrypoint-a.js');
+    }
   }
 
   if (polyfills.length) {

--- a/packages/rollup-plugin-polyfills-loader/test/snapshots/customize-filetype.html
+++ b/packages/rollup-plugin-polyfills-loader/test/snapshots/customize-filetype.html
@@ -32,6 +32,8 @@
     polyfills.push(loadScript('./polyfills/fetch.js'));
   }
 
+  polyfills.push(loadScript('./polyfills/systemjs.js'));
+
   if (!('attachShadow' in Element.prototype) || !('getRootNode' in Element.prototype) || window.ShadyDOM && window.ShadyDOM.force) {
     polyfills.push(loadScript('./polyfills/webcomponents.js'));
   }
@@ -41,11 +43,7 @@
   }
 
   function loadFiles() {
-    if (!('noModule' in HTMLScriptElement.prototype)) {
-      loadScript('./entrypoint-a.js');
-    } else {
-      loadScript('./entrypoint-a.js');
-    }
+    System.import('./entrypoint-a.js');
   }
 
   if (polyfills.length) {

--- a/packages/rollup-plugin-polyfills-loader/test/snapshots/flattened.html
+++ b/packages/rollup-plugin-polyfills-loader/test/snapshots/flattened.html
@@ -1,5 +1,5 @@
 <html><head>
-            
+
 <link rel="preload" href="./entrypoint-a.js" as="script" crossorigin="anonymous">
 <link rel="preload" href="shared-ed942ddb.js" as="script" crossorigin="anonymous">
 <link rel="preload" href="./entrypoint-b.js" as="script" crossorigin="anonymous">

--- a/packages/rollup-plugin-polyfills-loader/test/src/createPolyfillsLoaderConfig.test.ts
+++ b/packages/rollup-plugin-polyfills-loader/test/src/createPolyfillsLoaderConfig.test.ts
@@ -191,6 +191,7 @@ describe('createPolyfillsLoaderConfig()', () => {
   it('throws when a single build is output while multiple builds are configured', () => {
     const pluginConfig = {
       modernOutput: 'modern',
+      legacyOutput: 'legacy',
     };
     const bundle = {
       options: { format: 'es' },

--- a/packages/rollup-plugin-polyfills-loader/test/src/rollupPluginPolyfillsLoader.test.ts
+++ b/packages/rollup-plugin-polyfills-loader/test/src/rollupPluginPolyfillsLoader.test.ts
@@ -252,6 +252,37 @@ describe('rollup-plugin-polyfills-loader', function describe() {
       plugins: [
         htmlPlugin,
         polyfillsLoader({
+          modernOutput: { name: 'modern', type: 'systemjs' },
+          polyfills: { hash: false, webcomponents: true, fetch: true },
+        }),
+      ],
+    };
+
+    const outputOptions: OutputOptions[] = [
+      {
+        format: 'es',
+        dir: 'dist',
+      },
+    ];
+
+    await testSnapshot({
+      name: 'customize-filetype',
+      fileName: 'index.html',
+      inputOptions,
+      outputOptions,
+    });
+  });
+
+  it('can customize the file type for multiple outputs', async () => {
+    const htmlPlugin = html({
+      input: {
+        html: `<script type="module" src="${relativeUrl}/fixtures/entrypoint-a.js"></script>`,
+      },
+    });
+    const inputOptions = {
+      plugins: [
+        htmlPlugin,
+        polyfillsLoader({
           modernOutput: { name: 'modern', type: 'script' },
           legacyOutput: [
             {
@@ -279,7 +310,7 @@ describe('rollup-plugin-polyfills-loader', function describe() {
     ];
 
     await testSnapshot({
-      name: 'customize-filetype',
+      name: 'customize-filetype-multi-output',
       fileName: 'index.html',
       inputOptions,
       outputOptions,


### PR DESCRIPTION
## What I did

1. Allows changing the output filetype when using only a modern build

```js
        polyfillsLoader({
          modernOutput: { name: 'modern', type: 'systemjs' },
          polyfills: { webcomponents: true, fetch: true },
        }),
```
