### PR TITLE
fix(rollup-plugin-import-meta-assets): fix outputted sourcemaps

### DIFF
--- a/.changeset/famous-snakes-beg.md
+++ b/.changeset/famous-snakes-beg.md
@@ -1,0 +1,5 @@
+---
+'@web/rollup-plugin-import-meta-assets': patch
+---
+
+fix(rollup-plugin-import-meta-assets): fix outputted sourcemaps

--- a/packages/rollup-plugin-import-meta-assets/src/rollup-plugin-import-meta-assets.js
+++ b/packages/rollup-plugin-import-meta-assets/src/rollup-plugin-import-meta-assets.js
@@ -102,7 +102,7 @@ function importMetaAssets({ include, exclude, warnOnError, transform } = {}) {
 
       return {
         code: magicString.toString(),
-        map: magicString.generateMap(),
+        map: magicString.generateMap({ hires: true }),
       };
     },
   };


### PR DESCRIPTION
Fixes #1366 by outputting [hi-res sourcemaps](https://github.com/Rich-Harris/magic-string#sgeneratemap-options-). 