### PR TITLE
fix(test-runner): fixes coverageConfig merge with default by switching to object spread

### DIFF
--- a/.changeset/happy-balloons-speak.md
+++ b/.changeset/happy-balloons-speak.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner': patch
+---
+
+coverageConfig now uses object spread to merge with defaults

--- a/packages/polyfills-loader/package.json
+++ b/packages/polyfills-loader/package.json
@@ -50,7 +50,6 @@
     "@webcomponents/webcomponentsjs": "^2.5.0",
     "abortcontroller-polyfill": "^1.5.0",
     "core-js-bundle": "^3.8.1",
-    "deepmerge": "^4.2.2",
     "dynamic-import-polyfill": "^0.1.1",
     "intersection-observer": "^0.12.0",
     "parse5": "^6.0.1",

--- a/packages/test-runner-mocha/package.json
+++ b/packages/test-runner-mocha/package.json
@@ -39,6 +39,7 @@
     "@web/test-runner-core": "^0.10.8"
   },
   "devDependencies": {
+    "deepmerge": "^4.2.2",
     "mocha": "^8.2.1"
   }
 }

--- a/packages/test-runner/package.json
+++ b/packages/test-runner/package.json
@@ -84,7 +84,6 @@
     "command-line-args": "^5.1.1",
     "command-line-usage": "^6.1.1",
     "convert-source-map": "^1.7.0",
-    "deepmerge": "^4.2.2",
     "diff": "^5.0.0",
     "globby": "^11.0.1",
     "portfinder": "^1.0.28",

--- a/packages/test-runner/src/config/parseConfig.ts
+++ b/packages/test-runner/src/config/parseConfig.ts
@@ -7,7 +7,6 @@ import {
 } from '@web/test-runner-commands/plugins';
 import { getPortPromise } from 'portfinder';
 import path from 'path';
-import deepmerge from 'deepmerge';
 import { cpus } from 'os';
 
 import { TestRunnerCliArgs } from './readCliArgs';
@@ -158,11 +157,10 @@ export async function parseConfig(
     finalConfig.port = await getPortPromise({ port: 8000 });
   }
 
-  if (finalConfig.coverageConfig) {
-    finalConfig.coverageConfig = deepmerge(defaultCoverageConfig, finalConfig.coverageConfig!);
-  } else {
-    finalConfig.coverageConfig = defaultCoverageConfig;
-  }
+  finalConfig.coverageConfig = {
+    ...defaultCoverageConfig,
+    ...finalConfig.coverageConfig,
+  };
 
   let groupConfigs = await parseConfigGroups(finalConfig, cliArgs);
   if (groupConfigs.find(g => g.name === 'default')) {


### PR DESCRIPTION
This PR addresses #1374 by modifying the config merge for `coverageConfig` to use object spread assignment.