### PR TITLE
fix(rollup-plugin-import-meta-assets): skip unnecessary sourcemap generation

### DIFF
--- a/.changeset/lovely-cats-draw.md
+++ b/.changeset/lovely-cats-draw.md
@@ -1,0 +1,5 @@
+---
+'@web/rollup-plugin-import-meta-assets': patch
+---
+
+fix(rollup-plugin-import-meta-assets): skip unnecessary sourcemap generation

--- a/packages/rollup-plugin-import-meta-assets/src/rollup-plugin-import-meta-assets.js
+++ b/packages/rollup-plugin-import-meta-assets/src/rollup-plugin-import-meta-assets.js
@@ -64,6 +64,7 @@ function importMetaAssets({ include, exclude, warnOnError, transform } = {}) {
 
       const ast = this.parse(code);
       const magicString = new MagicString(code);
+      let modifiedCode = false;
 
       await asyncWalk(ast, {
         enter: async node => {
@@ -89,6 +90,7 @@ function importMetaAssets({ include, exclude, warnOnError, transform } = {}) {
                 node.arguments[0].end,
                 `import.meta.ROLLUP_FILE_URL_${ref}`,
               );
+              modifiedCode = true;
             } catch (error) {
               if (warnOnError) {
                 this.warn(error, node.arguments[0].start);
@@ -102,7 +104,7 @@ function importMetaAssets({ include, exclude, warnOnError, transform } = {}) {
 
       return {
         code: magicString.toString(),
-        map: magicString.generateMap({ hires: true }),
+        map: modifiedCode ? magicString.generateMap({ hires: true }) : null,
       };
     },
   };


### PR DESCRIPTION
Fixes https://github.com/modernweb-dev/web/issues/1379 by skipping sourcemap generation when the plugin has not modified the code (per recommendation at https://rollupjs.org/guide/en/#source-code-transformations).