### PR TITLE
Do not resolve multiple times outside root files

### DIFF
--- a/.changeset/healthy-lizards-attack.md
+++ b/.changeset/healthy-lizards-attack.md
@@ -1,0 +1,6 @@
+---
+"@web/dev-server-rollup": patch
+"@web/dev-server": patch
+---
+
+do not resolve multiple times outside root files

--- a/packages/dev-server-rollup/src/rollupAdapter.ts
+++ b/packages/dev-server-rollup/src/rollupAdapter.ts
@@ -21,7 +21,7 @@ import { CustomPluginOptions, Plugin as RollupPlugin, TransformPluginContext } f
 import { InputOptions } from 'rollup';
 import { red, cyanBright } from 'chalk';
 
-import { toBrowserPath, isAbsoluteFilePath } from './utils';
+import { toBrowserPath, isAbsoluteFilePath, isOutsideRootDir } from './utils';
 import { createRollupPluginContextAdapter } from './createRollupPluginContextAdapter';
 import { createRollupPluginContexts, RollupPluginContexts } from './createRollupPluginContexts';
 
@@ -193,6 +193,11 @@ export function rollupAdapter(
 
         // some plugins don't return a file path, so we just return it as is
         if (!isAbsoluteFilePath(resolvedImportPath)) {
+          return `${resolvedImportPath}`;
+        }
+
+        // file already resolved outsided root dir
+        if (isOutsideRootDir(resolvedImportPath)) {
           return `${resolvedImportPath}`;
         }
 

--- a/packages/dev-server-rollup/src/utils.ts
+++ b/packages/dev-server-rollup/src/utils.ts
@@ -14,3 +14,7 @@ export function toBrowserPath(filePath: string) {
 export function isAbsoluteFilePath(path: string) {
   return REGEXP_ABSOLUTE.test(path);
 }
+
+export function isOutsideRootDir(path: string) {
+  return path.startsWith('/__wds-outside-root__/');
+}

--- a/packages/dev-server-rollup/test/node/fixtures/resolve-outside-dir/node_modules/module-a/index.js
+++ b/packages/dev-server-rollup/test/node/fixtures/resolve-outside-dir/node_modules/module-a/index.js
@@ -1,0 +1,1 @@
+export default 'moduleA';

--- a/packages/dev-server-rollup/test/node/fixtures/resolve-outside-dir/node_modules/module-a/package.json
+++ b/packages/dev-server-rollup/test/node/fixtures/resolve-outside-dir/node_modules/module-a/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "module-a"
+}

--- a/packages/dev-server-rollup/test/node/fixtures/resolve-outside-dir/src/app.js
+++ b/packages/dev-server-rollup/test/node/fixtures/resolve-outside-dir/src/app.js
@@ -1,0 +1,3 @@
+import moduleA from 'module-a';
+
+console.log(moduleA);

--- a/packages/dev-server-rollup/test/node/plugins/node-resolve.test.ts
+++ b/packages/dev-server-rollup/test/node/plugins/node-resolve.test.ts
@@ -86,14 +86,15 @@ describe('@rollup/plugin-node-resolve', () => {
   it('node modules resolved outside root directory are rewritten', async () => {
     const { server, host } = await createTestServer({
       rootDir: path.resolve(__dirname, '..', 'fixtures', 'resolve-outside-dir', 'src'),
-      plugins: [
-        nodeResolve(),
-      ],
+      plugins: [nodeResolve()],
     });
 
     try {
       const responseText = await fetchText(`${host}/app.js`);
-      expectIncludes(responseText, "import moduleA from '/__wds-outside-root__/1/node_modules/module-a/index.js'");
+      expectIncludes(
+        responseText,
+        "import moduleA from '/__wds-outside-root__/1/node_modules/module-a/index.js'",
+      );
     } finally {
       server.stop();
     }
@@ -102,15 +103,15 @@ describe('@rollup/plugin-node-resolve', () => {
   it('node modules resolved outside root directory are rewritten with commonjs', async () => {
     const { server, host } = await createTestServer({
       rootDir: path.resolve(__dirname, '..', 'fixtures', 'resolve-outside-dir', 'src'),
-      plugins: [
-        commonjs(),
-        nodeResolve(),
-      ],
+      plugins: [commonjs(), nodeResolve()],
     });
 
     try {
       const responseText = await fetchText(`${host}/app.js`);
-      expectIncludes(responseText, "import moduleA from '/__wds-outside-root__/1/node_modules/module-a/index.js'");
+      expectIncludes(
+        responseText,
+        "import moduleA from '/__wds-outside-root__/1/node_modules/module-a/index.js'",
+      );
     } finally {
       server.stop();
     }


### PR DESCRIPTION
Right now, files outside the root dir are not correctly served when using a rollup plugin in combination with the node resolve option. Multiple `resolveImport` passes result in `/__wds-outside-root__/<n>/__wds-outside-root__/<n>/<module>/<file>`.

## What I did

1. Added a check for already resolved files outside the `rootDir`
