### PR TITLE
Use unescaped import specifier

### DIFF
--- a/packages/dev-server-core/src/plugins/transformModuleImportsPlugin.ts
+++ b/packages/dev-server-core/src/plugins/transformModuleImportsPlugin.ts
@@ -25,6 +25,7 @@ interface ParsedImport {
   ss: number;
   se: number;
   d: number;
+  n?: string;
 }
 
 const CONCAT_NO_PACKAGE_ERROR =
@@ -131,11 +132,11 @@ export async function transformImports(
   let lastIndex = 0;
 
   for (const imp of imports) {
-    const { s: start, e: end, d: dynamicImportIndex } = imp;
+    const { s: start, e: end, d: dynamicImportIndex, n: unescaped } = imp;
 
     if (dynamicImportIndex === -1) {
       // static import
-      const importSpecifier = code.substring(start, end);
+      const importSpecifier = unescaped || code.substring(start, end);
       const lines = code.slice(0, end).split('\n');
       const line = lines.length;
       const column = lines[lines.length - 1].indexOf(importSpecifier);

--- a/packages/dev-server-esbuild/package.json
+++ b/packages/dev-server-esbuild/package.json
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@types/ua-parser-js": "^0.7.35",
+    "@web/dev-server-rollup": "^0.3.3",
     "lit-element": "^2.4.0",
     "node-fetch": "3.0.0-beta.9",
     "preact": "^10.5.9"


### PR DESCRIPTION
Since version 0.4.0, `es-module-lexer` exposes a `n` property for each import specifier with its unescaped source. This is useful (and more accurate) for virtual modules like `\0commonHelpers`.

## What I did

1. try to use the `n` property of the specifier, fallback to the previous version if missing.
