### PR TITLE
Detect websocket url from server

### DIFF
--- a/.changeset/friendly-eels-fetch.md
+++ b/.changeset/friendly-eels-fetch.md
@@ -1,0 +1,6 @@
+---
+"@web/dev-server-core": patch
+"@web/dev-server": patch
+---
+
+Detect websocket url from server

--- a/packages/dev-server-core/src/web-sockets/webSocketsPlugin.ts
+++ b/packages/dev-server-core/src/web-sockets/webSocketsPlugin.ts
@@ -6,8 +6,13 @@ export const webSocketScript = `<!-- injected by web-dev-server -->
 <script type="module" src="${NAME_WEB_SOCKET_IMPORT}"></script>`;
 
 export function webSocketsPlugin(): Plugin {
+  let origin: string;
   return {
     name: 'web-sockets',
+
+    serverStart({ config }) {
+      origin = `ws${config.http2 ? 's' : ''}://${config.hostname ?? 'localhost'}:${config.port}`;
+    },
 
     resolveImport({ source }) {
       if (source === NAME_WEB_SOCKET_IMPORT) {
@@ -40,7 +45,7 @@ function setupWebSocket() {
   } else {
     webSocket =
       'WebSocket' in window
-      ? new WebSocket(\`ws\${location.protocol === 'https:' ? 's' : ''}://\${location.host}/${NAME_WEB_SOCKET_API}\`)
+      ? new WebSocket('${origin}/${NAME_WEB_SOCKET_API}')
         : null;
     webSocketOpened = new Promise(resolve => {
       if (!webSocket) {

--- a/packages/dev-server-core/src/web-sockets/webSocketsPlugin.ts
+++ b/packages/dev-server-core/src/web-sockets/webSocketsPlugin.ts
@@ -11,7 +11,7 @@ export function webSocketsPlugin(): Plugin {
     name: 'web-sockets',
 
     serverStart({ config }) {
-      origin = `ws${config.http2 ? 's' : ''}://${config.hostname ?? 'localhost'}:${config.port}`;
+      origin = `ws${config.sslCert ? 's' : ''}://${config.hostname ?? 'localhost'}:${config.port}`;
     },
 
     resolveImport({ source }) {


### PR DESCRIPTION
WebSocket should be created using the server url instead of the runtime location (script may be imported from a differente origin).

## What I did

1. Stored the server url using the `serverStart` hook
2. Replaced the url argument of the `WebSocket` constructor
