### PR TITLE
Do not override js loader with esbuild target

### DIFF
--- a/.changeset/strange-chefs-raise.md
+++ b/.changeset/strange-chefs-raise.md
@@ -1,0 +1,5 @@
+---
+"@web/dev-server-esbuild": patch
+---
+
+Do not override js loader with esbuild target

--- a/packages/dev-server-esbuild/src/esbuildPluginFactory.ts
+++ b/packages/dev-server-esbuild/src/esbuildPluginFactory.ts
@@ -36,7 +36,10 @@ export function esbuildPlugin(args: EsBuildPluginArgs = {}): Plugin {
   if (args.js) {
     loaders['.js'] = 'js';
   }
-  if (typeof args.target === 'string' || Array.isArray(args.target)) {
+  if (
+    !Object.prototype.hasOwnProperty.call(loaders, '.js') &&
+    (typeof args.target === 'string' || Array.isArray(args.target))
+  ) {
     loaders['.js'] = 'js';
   }
 


### PR DESCRIPTION
Esbuild plugin overrides the js loader passed by options if target has been passed as well.

## What I did

1. Added a check for js loader configuration
