### PR TITLE
Upgrade to esbuild ^0.11.0

### DIFF
--- a/.changeset/sixty-mugs-float.md
+++ b/.changeset/sixty-mugs-float.md
@@ -1,0 +1,6 @@
+---
+"@web/dev-server-esbuild": patch
+"@web/dev-server": patch
+---
+
+Upgrade to esbuild ^0.11.0

--- a/packages/dev-server-esbuild/package.json
+++ b/packages/dev-server-esbuild/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@mdn/browser-compat-data": "^3.0.1",
     "@web/dev-server-core": "^0.3.2",
-    "esbuild": "^0.8.28",
+    "esbuild": "^0.11.0",
     "parse5": "^6.0.1",
     "ua-parser-js": "^0.7.23"
   },

--- a/packages/dev-server-esbuild/test/target.test.ts
+++ b/packages/dev-server-esbuild/test/target.test.ts
@@ -50,7 +50,7 @@ const transformedSyntax = {
   ],
   optionalChaining: 'const optionalChaining = (_a = window.bar) == null ? void 0 : _a.foo;',
   optionalCatch: '} catch (e) {',
-  objectSpread: 'const spread = __assign(__assign({}, foo), bar);',
+  objectSpread: 'const spread = __objSpread(__objSpread({}, foo), bar);',
   asyncFunctions: [
     'var __async = (__this, __arguments, generator) => {',
     'return __async(this, null, function* () {',

--- a/packages/dev-server-esbuild/test/ts.test.ts
+++ b/packages/dev-server-esbuild/test/ts.test.ts
@@ -85,13 +85,13 @@ class Bar {
       expectIncludes(text, 'this.x = "y";');
       expectIncludes(
         text,
-        `__decorate([
+        `__decorateClass([
   prop
 ], Bar.prototype, "x", 2);`,
       );
       expectIncludes(
         text,
-        `Bar = __decorate([
+        `Bar = __decorateClass([
   foo
 ], Bar);`,
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4973,10 +4973,10 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-esbuild@^0.8.28:
-  version "0.8.34"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.8.34.tgz#16b4ac58f74c821d2c5a8c2f0585ca96a38ab4e6"
-  integrity sha512-tnr0V1ooakYr1aRLXQLzCn2GVG1kBTW3FWpRyC+NgrR3ntsouVpJOlTOV0BS4YLATx3/c+x3h/uBq9lWJlUAtQ==
+esbuild@^0.11.0:
+  version "0.11.12"
+  resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.11.12.tgz#8cbe15bcb44212624c3e77c896a835f74dc71c3c"
+  integrity sha512-c8cso/1RwVj+fbDvLtUgSG4ZJQ0y9Zdrl6Ot/GAjyy4pdMCHaFnDMts5gqFnWRPLajWtEnI+3hlET4R9fVoZng==
 
 escalade@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
Since version 0.9.0, esbuild removed the service api, that is no longer needed.

## What I did

1. Updated constraint and lock
2. Replaced service calls
3. Updated tests
