### PR TITLE
Updated browser-targets.ts wording

### DIFF
--- a/packages/dev-server-esbuild/src/browser-targets.ts
+++ b/packages/dev-server-esbuild/src/browser-targets.ts
@@ -13,13 +13,13 @@ function createModernTarget() {
     if (!latestChrome) throw new Error('Could not find latest Chrome major version');
 
     const latestEdge = getLatestStableMajor(browsers.edge.releases);
-    if (!latestEdge) throw new Error('Could not find latest Chrome major version');
+    if (!latestEdge) throw new Error('Could not find latest Edge major version');
 
     const latestSafari = getLatestStableMajor(browsers.safari.releases);
     if (!latestSafari) throw new Error('Could not find latest Safari major version');
 
     const latestFirefox = getLatestStableMajor(browsers.firefox.releases);
-    if (!latestFirefox) throw new Error('Could not find latest Chrome major version');
+    if (!latestFirefox) throw new Error('Could not find latest Firefox major version');
 
     return [
       `chrome${latestChrome - 1}`,


### PR DESCRIPTION
The purpose of this PR is to update the wording when certain browsers are not found, so the end user knows which specific browser was not found.

## What I did

1. Updated wording to reflect the browser names of what wasn't found.
