### PR TITLE
Deserialize bound function from browser logs

### DIFF
--- a/.changeset/good-dolphins-attend.md
+++ b/.changeset/good-dolphins-attend.md
@@ -1,0 +1,5 @@
+---
+"@web/browser-logs": patch
+---
+
+Deserialize bound function from browser logs

--- a/packages/browser-logs/src/deserialize.ts
+++ b/packages/browser-logs/src/deserialize.ts
@@ -41,7 +41,12 @@ function createReviver(promises: Promise<unknown>[], options?: DeserializeOption
           return;
         case 'Function':
           // Create a fake function with the same name. We don't log the function implementation.
-          return new Function(`return function ${value.name.replace(/^bound\s+/, '')}() { /* implementation hidden */ }`)();
+          return new Function(
+            `return function ${value.name.replace(
+              /^bound\s+/,
+              '',
+            )}() { /* implementation hidden */ }`,
+          )();
         case 'RegExp':
           // Create a new RegExp using the same parameters
           return new RegExp(value.source, value.flags);

--- a/packages/browser-logs/src/deserialize.ts
+++ b/packages/browser-logs/src/deserialize.ts
@@ -41,7 +41,7 @@ function createReviver(promises: Promise<unknown>[], options?: DeserializeOption
           return;
         case 'Function':
           // Create a fake function with the same name. We don't log the function implementation.
-          return new Function(`return function ${value.name}() { /* implementation hidden */ }`)();
+          return new Function(`return function ${value.name.replace(/^bound\s+/, '')}() { /* implementation hidden */ }`)();
         case 'RegExp':
           // Create a new RegExp using the same parameters
           return new RegExp(value.source, value.flags);

--- a/packages/browser-logs/src/deserialize.ts
+++ b/packages/browser-logs/src/deserialize.ts
@@ -5,6 +5,8 @@ const KEY_CONSTRUCTOR_NAME = '__WTR_CONSTRUCTOR_NAME__';
 
 const ASYNC_DESERIALIZE_WRAPPER = Symbol('ASYNC_DESERIALIZE_WRAPPER');
 
+const BOUND_NAME_FUNCTION_REGEX = /^bound\s+/;
+
 function createReviver(promises: Promise<unknown>[], options?: DeserializeOptions) {
   const undefinedPropsPerObject = new Map();
 
@@ -43,7 +45,7 @@ function createReviver(promises: Promise<unknown>[], options?: DeserializeOption
           // Create a fake function with the same name. We don't log the function implementation.
           return new Function(
             `return function ${value.name.replace(
-              /^bound\s+/,
+              BOUND_NAME_FUNCTION_REGEX,
               '',
             )}() { /* implementation hidden */ }`,
           )();

--- a/packages/browser-logs/test/serialize-deserialize.test.ts
+++ b/packages/browser-logs/test/serialize-deserialize.test.ts
@@ -58,6 +58,18 @@ describe('serialize deserialize', () => {
     expect(deserialized.name).to.equal('foo');
   });
 
+  it('handles bound Function', async () => {
+    const serialized = await page.evaluate(() => {
+      function foo(x: number, y: number) {
+        return x * y;
+      }
+      return (window as any)._serialize(foo.bind(null));
+    });
+    const deserialized = await deserialize(serialized);
+    expect(typeof deserialized).to.equal('function');
+    expect(deserialized.name).to.equal('foo');
+  });
+
   it('handles Symbol', async () => {
     const serialized = await page.evaluate(() => (window as any)._serialize(Symbol('foo')));
     const deserialized = await deserialize(serialized);


### PR DESCRIPTION
Bound function were not correctly handled by the browser logs module.

## What I did

1. Convert `bound fn` to `fn` in order to avoid syntax errors 
