### PR TITLE
#1443 up to 13 so web-test-runner happy in mjs configs

### DIFF
--- a/packages/dev-server-storybook/package.json
+++ b/packages/dev-server-storybook/package.json
@@ -59,7 +59,7 @@
     "@babel/preset-env": "^7.12.11",
     "@mdx-js/mdx": "^1.6.22",
     "@rollup/plugin-babel": "^5.2.2",
-    "@rollup/plugin-node-resolve": "^11.0.1",
+    "@rollup/plugin-node-resolve": "^13.0.0",
     "@web/dev-server-core": "^0.3.0",
     "@web/rollup-plugin-html": "^1.3.2",
     "@web/rollup-plugin-polyfills-loader": "^1.0.3",


### PR DESCRIPTION
> copied from the issue in question for the full explanation

running node 14 and using rollup.config.mjs I was getting the following error: plugin_node_resolve_1.nodeResolve

In searching I was able to find that versions of https://www.npmjs.com/package/@rollup/plugin-node-resolve newer versions should resolve this config loading issue. In adding 13.0.0 to my package.json and running again it now correctly accepts the command. This seems an interrelated issues potentially as

https://github.com/modernweb-dev/web/blob/master/packages/dev-server-storybook/package.json#L62
dev-server-storybook is pointed to 11.x.x.

Making this 13 (assuming that still works) should resolve this issue for those of us starting to use .mjs based configuration routines.