### PR TITLE
fix(rollup-plugin-html): use publicPath for emitting assets

### DIFF
--- a/.changeset/tall-jokes-wave.md
+++ b/.changeset/tall-jokes-wave.md
@@ -1,0 +1,5 @@
+---
+'@web/rollup-plugin-html': patch
+---
+
+fix(rollup-plugin-html): fix linked assets not being prefixed with configured publicPath. See https://github.com/modernweb-dev/web/issues/1302

--- a/packages/rollup-plugin-html/src/output/getOutputHTML.ts
+++ b/packages/rollup-plugin-html/src/output/getOutputHTML.ts
@@ -53,6 +53,7 @@ export async function getOutputHTML(params: GetOutputHTMLParams) {
       rootDir,
       emittedAssets,
       absolutePathPrefix,
+      publicPath: pluginOptions.publicPath,
     });
   }
   if (!defaultInjectDisabled) {


### PR DESCRIPTION
Adds the missing publicPath argument to the _injectedUpdatedAssetPaths_ call, so linked assets also get the prefix applied. Previously the default of './' was always used.

Fixes #1302