### PR TITLE
fix(dev-server-rollup): support private imports

### DIFF
--- a/.changeset/tidy-ads-help.md
+++ b/.changeset/tidy-ads-help.md
@@ -1,0 +1,32 @@
+---
+'@web/dev-server-rollup': patch
+---
+
+Support for subpath imports
+
+👉 `my-pkg/package.json`
+
+```json
+{
+  "name": "my-pkg",
+  "imports": {
+    "#internal-a": "./path/to/internal-a.js"
+  }
+}
+```
+
+👉 `my-pkg/src/file.js`
+
+```js
+import { private } from '#internal-a';
+```
+
+Subpath imports are not available to users of your package
+
+👉 `other-pkg/src/file.js`
+
+```js
+// both will fail
+import { private } from 'my-pkg#internal-a';
+import { private } from 'my-pkg/path/to/internal-a.js';
+```

--- a/packages/dev-server-rollup/src/rollupAdapter.ts
+++ b/packages/dev-server-rollup/src/rollupAdapter.ts
@@ -134,10 +134,15 @@ export function rollupAdapter(
         // we have to special case node-resolve because it doesn't support resolving
         // with hash/params at the moment
         if (rollupPlugin.name === 'node-resolve') {
-          const [withoutHash, hash] = source.split('#');
-          const [importPath, params] = withoutHash.split('?');
-          importSuffix = `${params ? `?${params}` : ''}${hash ? `#${hash}` : ''}`;
-          resolvableImport = importPath;
+          if (source[0] === '#') {
+            // private import
+            resolvableImport = source;
+          } else {
+            const [withoutHash, hash] = source.split('#');
+            const [importPath, params] = withoutHash.split('?');
+            importSuffix = `${params ? `?${params}` : ''}${hash ? `#${hash}` : ''}`;
+            resolvableImport = importPath;
+          }
         }
 
         let result = await rollupPlugin.resolveId?.call(

--- a/packages/dev-server-rollup/test/node/fixtures/private-imports/import-private-directly.html
+++ b/packages/dev-server-rollup/test/node/fixtures/private-imports/import-private-directly.html
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <script type="module">
+      import 'my-app/internal-a.js';
+    </script>
+  </body>
+</html>

--- a/packages/dev-server-rollup/test/node/fixtures/private-imports/index.html
+++ b/packages/dev-server-rollup/test/node/fixtures/private-imports/index.html
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <script type="module">
+      import '#internal-a';
+    </script>
+  </body>
+</html>

--- a/packages/dev-server-rollup/test/node/fixtures/private-imports/internal-a.js
+++ b/packages/dev-server-rollup/test/node/fixtures/private-imports/internal-a.js
@@ -1,0 +1,1 @@
+export const internalA = 'internal a value';

--- a/packages/dev-server-rollup/test/node/fixtures/private-imports/package.json
+++ b/packages/dev-server-rollup/test/node/fixtures/private-imports/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-app",
+  "imports": {
+    "#internal-a": "./internal-a.js"
+  }
+}

--- a/packages/dev-server-rollup/test/node/plugins/node-resolve.test.ts
+++ b/packages/dev-server-rollup/test/node/plugins/node-resolve.test.ts
@@ -37,6 +37,35 @@ describe('@rollup/plugin-node-resolve', () => {
     }
   });
 
+  it('can resolve private imports in inline scripts', async () => {
+    const { server, host } = await createTestServer({
+      rootDir: path.resolve(__dirname, '..', 'fixtures', 'private-imports'),
+      plugins: [nodeResolve()],
+    });
+
+    try {
+      const text = await fetchText(`${host}/index.html`);
+      console.log(text);
+      expectIncludes(text, "import './internal-a.js';");
+    } finally {
+      server.stop();
+    }
+  });
+
+  it('throws when trying to access files from the package directly if they are not exposed in the export map', async () => {
+    const { server, host } = await createTestServer({
+      rootDir: path.resolve(__dirname, '..', 'fixtures', 'private-imports'),
+      plugins: [nodeResolve()],
+    });
+
+    try {
+      const response = await fetch(`${host}/import-private-directly.html`);
+      expect(response.status).to.equal(500);
+    } finally {
+      server.stop();
+    }
+  });
+
   it('throws on unresolved bare imports', async () => {
     const { server, host } = await createTestServer({
       plugins: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4624,11 +4624,6 @@ devtools-protocol@0.0.847576:
   resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.847576.tgz#2f201bfb68aa9ef4497199fbd7f5d5dfde3b200b"
   integrity sha512-0M8kobnSQE0Jmly7Mhbeq0W/PpZfnuK+WjN2ZRVPbGqYwCHCioAVp84H0TcLimgECcN5H976y5QiXMGBC9JKmg==
 
-devtools-protocol@0.0.854822:
-  version "0.0.854822"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.854822.tgz#eac3a5260a6b3b4e729a09fdc0c77b0d322e777b"
-  integrity sha512-xd4D8kHQtB0KtWW0c9xBZD5LVtm9chkMOfs/3Yn01RhT/sFIsVtzTtypfKoFfWBaL+7xCYLxjOLkhwPXaX/Kcg==
-
 devtools-protocol@0.0.869402:
   version "0.0.869402"
   resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.869402.tgz#03ade701761742e43ae4de5dc188bcd80f156d8d"


### PR DESCRIPTION
## What I did

1. Support for subpath imports

👉 `my-pkg/package.json`

```json
{
  "name": "my-pkg",
  "imports": {
    "#internal-a": "./path/to/internal-a.js"
  }
}
```

👉 `my-pkg/src/file.js`

```js
import { private } from '#internal-a';
```

Subpath imports are not available to users of your package

👉 `other-pkg/src/file.js`

```js
// both will fail
import { private } from 'my-pkg#internal-a';
import { private } from 'my-pkg/path/to/internal-a.js';
```

closes https://github.com/modernweb-dev/web/issues/1321
