### PR TITLE
feat(rollup-plugin-html): add minify option

### DIFF
--- a/.changeset/young-wolves-worry.md
+++ b/.changeset/young-wolves-worry.md
@@ -1,0 +1,5 @@
+---
+'@web/rollup-plugin-html': minor
+---
+
+add minify option

--- a/docs/docs/building/rollup-plugin-html.md
+++ b/docs/docs/building/rollup-plugin-html.md
@@ -179,7 +179,7 @@ You can add transform functions to modify the HTML page and assets in the build,
 import html from '@web/rollup-plugin-html';
 
 export default {
-  input: 'pages/**/*.html',
+  input: 'index.html',
   output: { dir: 'dist' },
   plugins: [
     // add HTML plugin
@@ -203,7 +203,22 @@ export default {
 
 ### Minification
 
-The HTML plugin does not do any minification by default. You can use a transform function to use a minifier for your HTML or assets.
+Set the minify option to do default HTML minificiation. If you need custom options, you can implement your own minifier using the `transformHtml` option.
+
+```js
+import html from '@web/rollup-plugin-html';
+
+export default {
+  input: 'index.html',
+  output: { dir: 'dist' },
+  plugins: [
+    // add HTML plugin
+    html({
+      minify: true,
+    }),
+  ],
+};
+```
 
 ### Social Media Tags
 
@@ -292,6 +307,8 @@ export interface InputHTMLOptions {
 export interface RollupPluginHTMLOptions {
   /** HTML file(s) to use as input. If not set, uses rollup input option. */
   input?: string | InputHTMLOptions | (string | InputHTMLOptions)[];
+  /** Whether to minify the output HTML. */
+  minify?: boolean;
   /** Whether to preserve or flatten the directory structure of the HTML file. */
   flattenOutput?: boolean;
   /** Directory to resolve absolute paths relative to, and to use as base for non-flatted filename output. */

--- a/packages/rollup-plugin-html/package.json
+++ b/packages/rollup-plugin-html/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@web/parse5-utils": "^1.2.2",
     "glob": "^7.1.6",
+    "html-minifier-terser": "^5.1.1",
     "parse5": "^6.0.1"
   },
   "devDependencies": {

--- a/packages/rollup-plugin-html/src/RollupPluginHTMLOptions.ts
+++ b/packages/rollup-plugin-html/src/RollupPluginHTMLOptions.ts
@@ -13,6 +13,8 @@ export interface InputHTMLOptions {
 export interface RollupPluginHTMLOptions {
   /** HTML file(s) to use as input. If not set, uses rollup input option. */
   input?: string | InputHTMLOptions | (string | InputHTMLOptions)[];
+  /** Whether to minify the output HTML. */
+  minify?: boolean;
   /** Whether to preserve or flatten the directory structure of the HTML file. */
   flattenOutput?: boolean;
   /** Directory to resolve absolute paths relative to, and to use as base for non-flatted filename output. */

--- a/packages/rollup-plugin-html/src/output/getOutputHTML.ts
+++ b/packages/rollup-plugin-html/src/output/getOutputHTML.ts
@@ -6,6 +6,7 @@ import {
   TransformHtmlFunction,
 } from '../RollupPluginHTMLOptions';
 import { parse, serialize } from 'parse5';
+import { minify as minifyHTMLFunc } from 'html-minifier-terser';
 import { injectedUpdatedAssetPaths } from './injectedUpdatedAssetPaths';
 import { EmittedAssets } from './emitAssets';
 import { injectAbsoluteBaseUrl } from './injectAbsoluteBaseUrl';
@@ -87,6 +88,19 @@ export async function getOutputHTML(params: GetOutputHTMLParams) {
       bundle: defaultBundle,
       bundles: multiBundles,
       htmlFileName: input.name,
+    });
+  }
+
+  if (pluginOptions.minify) {
+    outputHtml = minifyHTMLFunc(outputHtml, {
+      collapseWhitespace: true,
+      removeComments: true,
+      removeRedundantAttributes: true,
+      removeScriptTypeAttributes: true,
+      removeStyleLinkTypeAttributes: true,
+      useShortDoctype: true,
+      minifyCSS: true,
+      minifyJS: true,
     });
   }
 

--- a/packages/rollup-plugin-html/test/src/output/getOutputHTML.test.ts
+++ b/packages/rollup-plugin-html/test/src/output/getOutputHTML.test.ts
@@ -172,4 +172,39 @@ describe('getOutputHTML()', () => {
       ].join('\n'),
     );
   });
+
+  it('can minify HTML', async () => {
+    const htmlInput = `
+    
+    <html>
+
+      <head></head>
+      <body>
+        <script>
+          (() => {
+            const foo = 'x';
+            console.log(foo);
+          })();
+
+        </script>
+      </body>
+
+    </html>
+    `;
+    const output = await getOutputHTML({
+      ...defaultOptions,
+      pluginOptions: {
+        ...defaultOptions.pluginOptions,
+        minify: true,
+      },
+      input: {
+        ...defaultOptions.input,
+        html: htmlInput,
+      },
+    });
+
+    expect(output).to.equal(
+      '<html><head></head><body><script>console.log("x")</script><script type="module" src="/app.js"></script><script type="module" src="/module.js"></script></body></html>',
+    );
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4624,11 +4624,6 @@ devtools-protocol@0.0.847576:
   resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.847576.tgz#2f201bfb68aa9ef4497199fbd7f5d5dfde3b200b"
   integrity sha512-0M8kobnSQE0Jmly7Mhbeq0W/PpZfnuK+WjN2ZRVPbGqYwCHCioAVp84H0TcLimgECcN5H976y5QiXMGBC9JKmg==
 
-devtools-protocol@0.0.854822:
-  version "0.0.854822"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.854822.tgz#eac3a5260a6b3b4e729a09fdc0c77b0d322e777b"
-  integrity sha512-xd4D8kHQtB0KtWW0c9xBZD5LVtm9chkMOfs/3Yn01RhT/sFIsVtzTtypfKoFfWBaL+7xCYLxjOLkhwPXaX/Kcg==
-
 devtools-protocol@0.0.869402:
   version "0.0.869402"
   resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.869402.tgz#03ade701761742e43ae4de5dc188bcd80f156d8d"


### PR DESCRIPTION
## What I did

Adds a default minify option to the HTML plugin. We didn't want to do this initially, but I see a good use case for it now. We don't allow customizing the options, so we're not coupled to a specific implementation. If users need customization, they can still implement their own minifier.
