### PR TITLE
fix(test-runner-junit-reporter): strip invalid XML characters in stdout

### DIFF
--- a/.changeset/two-mangos-allow.md
+++ b/.changeset/two-mangos-allow.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-junit-reporter': patch
+---
+
+fix logging non UTF-8 characters (e.g. ANSI escape seq) produces malformed junit xml report

--- a/packages/test-runner-junit-reporter/src/junitReporter.ts
+++ b/packages/test-runner-junit-reporter/src/junitReporter.ts
@@ -98,7 +98,7 @@ const toResultsWithMetadataByBrowserTestFileName = (
 };
 
 const escapeLogs = (test: TestResultWithMetadata) =>
-  test.logs.flatMap(x => x.map(_cdata => ({ _cdata })));
+  test.logs.flatMap(x => x.map(_cdata => ({ _cdata: stripXMLInvalidChars(_cdata) })));
 
 const isFailedTest = (test: TestResult): boolean =>
   // NB: shouldn't have to check for `error`,


### PR DESCRIPTION
Fixes #1463