### PR TITLE
Add support for holding and releasing keys to the sendKeys command

### DIFF
--- a/.changeset/mighty-chicken-invite.md
+++ b/.changeset/mighty-chicken-invite.md
@@ -1,0 +1,18 @@
+---
+'@web/test-runner-commands': minor
+---
+
+Added support for holding and releasing keys to the sendKeys command. The command now supports two additional actions `down` and `up` which hold down, or release a key. This effectively allows to hold down modifier keys while pressing other keys, which allows key combinations such as `Shift+Tab`.
+
+@example
+```ts
+  await sendKeys({
+    down: 'Shift',
+  });
+  await sendKeys({
+    press: 'Tab',
+  });
+  await sendKeys({
+    up: 'Shift',
+  });
+```

--- a/packages/test-runner-commands/src/sendKeysPlugin.ts
+++ b/packages/test-runner-commands/src/sendKeysPlugin.ts
@@ -2,29 +2,57 @@ import { TestRunnerPlugin } from '@web/test-runner-core';
 import type { ChromeLauncher, puppeteerCore } from '@web/test-runner-chrome';
 import type { PlaywrightLauncher } from '@web/test-runner-playwright';
 
+type TypePayload = { type: string; };
+type PressPayload = { press: string; };
+type DownPayload = { down: string; };
+type UpPayload = { up: string; };
+
 export type SendKeysPayload =
-  | { type: string; press?: undefined }
-  | { type?: undefined; press: string };
+  | TypePayload
+  | PressPayload
+  | DownPayload
+  | UpPayload;
 
 function isObject(payload: unknown): payload is Record<string, unknown> {
   return payload != null && typeof payload === 'object';
 }
 
 function isSendKeysPayload(payload: unknown): boolean {
+  const validOptions = ['type', 'press', 'down', 'up'];
+
   if (!isObject(payload)) throw new Error('You must provide a `SendKeysPayload` object');
-  if (!!payload.type && !!payload.press)
+
+  const numberOfValidOptions = Object.keys(payload).filter(key => validOptions.includes(key)).length;
+  const unknownOptions = Object.keys(payload).filter(key => !validOptions.includes(key));
+
+  if (numberOfValidOptions > 1)
     throw new Error(
-      'You must provide ONLY one of the `type` or `press` properties for pass to the browser runner.',
+      `You must provide ONLY one of the following properties to pass to the browser runner: ${validOptions.join(', ')}.`,
     );
-  if (!payload.type && !payload.press)
+  if (numberOfValidOptions === 0)
     throw new Error(
-      'You mist provide one of the `type` or `press` properties for pass to the browser runner.',
+      `You must provide one of the following properties to pass to the browser runner: ${validOptions.join(', ')}.`,
     );
-  const payloadKeys = Object.keys(payload).filter(key => key !== 'press' && key !== 'type');
-  if (payloadKeys.length) {
-    throw new Error('Unknown options `' + payloadKeys.join(', ') + '` present.');
+  if (unknownOptions.length > 0) {
+    throw new Error('Unknown options `' + unknownOptions.join(', ') + '` present.');
   }
   return true;
+}
+
+function isTypePayload(payload: SendKeysPayload): payload is TypePayload {
+  return 'type' in payload;
+}
+
+function isPressPayload(payload: SendKeysPayload): payload is PressPayload {
+  return 'press' in payload;
+}
+
+function isDownPayload(payload: SendKeysPayload): payload is DownPayload {
+  return 'down' in payload;
+}
+
+function isUpPayload(payload: SendKeysPayload): payload is UpPayload {
+  return 'up' in payload;
 }
 
 export function sendKeysPlugin(): TestRunnerPlugin<SendKeysPayload> {
@@ -38,11 +66,17 @@ export function sendKeysPlugin(): TestRunnerPlugin<SendKeysPayload> {
         // handle specific behavior for playwright
         if (session.browser.type === 'playwright') {
           const page = (session.browser as PlaywrightLauncher).getPage(session.id);
-          if (payload.type) {
+          if (isTypePayload(payload)) {
             await page.keyboard.type(payload.type);
             return true;
-          } else if (payload.press) {
+          } else if (isPressPayload(payload)) {
             await page.keyboard.press(payload.press);
+            return true;
+          } else if (isDownPayload(payload)) {
+            await page.keyboard.down(payload.down);
+            return true;
+          } else if (isUpPayload(payload)) {
+            await page.keyboard.up(payload.up);
             return true;
           }
         }
@@ -50,11 +84,17 @@ export function sendKeysPlugin(): TestRunnerPlugin<SendKeysPayload> {
         // handle specific behavior for puppeteer
         if (session.browser.type === 'puppeteer') {
           const page = (session.browser as ChromeLauncher).getPage(session.id);
-          if (payload.type) {
+          if (isTypePayload(payload)) {
             await page.keyboard.type(payload.type);
             return true;
-          } else if (payload.press) {
+          } else if (isPressPayload(payload)) {
             await page.keyboard.press(payload.press as puppeteerCore.KeyInput);
+            return true;
+          } else if (isDownPayload(payload)) {
+            await page.keyboard.down(payload.down as puppeteerCore.KeyInput);
+            return true;
+          } else if (isUpPayload(payload)) {
+            await page.keyboard.up(payload.up as puppeteerCore.KeyInput);
             return true;
           }
         }

--- a/packages/test-runner-commands/src/sendKeysPlugin.ts
+++ b/packages/test-runner-commands/src/sendKeysPlugin.ts
@@ -2,16 +2,12 @@ import { TestRunnerPlugin } from '@web/test-runner-core';
 import type { ChromeLauncher, puppeteerCore } from '@web/test-runner-chrome';
 import type { PlaywrightLauncher } from '@web/test-runner-playwright';
 
-type TypePayload = { type: string; };
-type PressPayload = { press: string; };
-type DownPayload = { down: string; };
-type UpPayload = { up: string; };
+type TypePayload = { type: string };
+type PressPayload = { press: string };
+type DownPayload = { down: string };
+type UpPayload = { up: string };
 
-export type SendKeysPayload =
-  | TypePayload
-  | PressPayload
-  | DownPayload
-  | UpPayload;
+export type SendKeysPayload = TypePayload | PressPayload | DownPayload | UpPayload;
 
 function isObject(payload: unknown): payload is Record<string, unknown> {
   return payload != null && typeof payload === 'object';
@@ -22,16 +18,22 @@ function isSendKeysPayload(payload: unknown): boolean {
 
   if (!isObject(payload)) throw new Error('You must provide a `SendKeysPayload` object');
 
-  const numberOfValidOptions = Object.keys(payload).filter(key => validOptions.includes(key)).length;
+  const numberOfValidOptions = Object.keys(payload).filter(key =>
+    validOptions.includes(key),
+  ).length;
   const unknownOptions = Object.keys(payload).filter(key => !validOptions.includes(key));
 
   if (numberOfValidOptions > 1)
     throw new Error(
-      `You must provide ONLY one of the following properties to pass to the browser runner: ${validOptions.join(', ')}.`,
+      `You must provide ONLY one of the following properties to pass to the browser runner: ${validOptions.join(
+        ', ',
+      )}.`,
     );
   if (numberOfValidOptions === 0)
     throw new Error(
-      `You must provide one of the following properties to pass to the browser runner: ${validOptions.join(', ')}.`,
+      `You must provide one of the following properties to pass to the browser runner: ${validOptions.join(
+        ', ',
+      )}.`,
     );
   if (unknownOptions.length > 0) {
     throw new Error('Unknown options `' + unknownOptions.join(', ') + '` present.');

--- a/packages/test-runner-commands/test/send-keys/browser-test.js
+++ b/packages/test-runner-commands/test/send-keys/browser-test.js
@@ -1,7 +1,7 @@
 import { sendKeys } from '../../browser/commands.mjs';
 import { expect } from '../chai.js';
 
-it('sends keys to an input', async () => {
+it('natively types into an input', async () => {
   const keys = 'abc123';
   const input = document.createElement('input');
   document.body.append(input);
@@ -29,4 +29,62 @@ it('natively presses `Tab`', async () => {
   expect(document.activeElement).to.equal(input2);
   input1.remove();
   input2.remove();
+});
+
+it('natively presses `Shift+Tab`', async () => {
+  const input1 = document.createElement('input');
+  const input2 = document.createElement('input');
+  document.body.append(input1, input2);
+  input2.focus();
+  expect(document.activeElement).to.equal(input2);
+
+  await sendKeys({
+    down: 'Shift',
+  });
+  await sendKeys({
+    press: 'Tab',
+  });
+  await sendKeys({
+    up: 'Shift',
+  });
+
+  expect(document.activeElement).to.equal(input1);
+  input1.remove();
+  input2.remove();
+});
+
+it('natively holds and then releases a key', async () => {
+  const input = document.createElement('input');
+  document.body.append(input);
+  input.focus();
+
+  await sendKeys({
+    down: 'Shift',
+  });
+  // Note that pressed modifier keys are only respected when using `press` or
+  // `down`, and only when using the `Key...` variants.
+  await sendKeys({
+    press: 'KeyA',
+  });
+  await sendKeys({
+    press: 'KeyB',
+  });
+  await sendKeys({
+    press: 'KeyC',
+  });
+  await sendKeys({
+    up: 'Shift',
+  });
+  await sendKeys({
+    press: 'KeyA',
+  });
+  await sendKeys({
+    press: 'KeyB',
+  });
+  await sendKeys({
+    press: 'KeyC',
+  });
+
+  expect(input.value).to.equal('ABCabc');
+  input.remove();
 });


### PR DESCRIPTION
Currently it is not possible to send a key combination using the sendKeys command in all test runners that the plugin supports. The original PR states in the [changeset](https://github.com/modernweb-dev/web/commit/ce90c7c36dc53b03ba98fe47f83eadf427009137#diff-ae1d797ecb266266783436e2ef62e5ed325be942cf34b476e82c72490b651bdaR10) that combinations such as `Shift-Tab` are supported by the `press` command, which is not true from my testing (also there are no tests to verify this). My understanding is that Playwright supports it, but Puppeteer does not.

To solve this, this change introduces two additonal actions / properties to the sendKeys command: `down` and `up`. These allow to hold down a key, and then release a key. This effectively allows pressing key combinations or trigger other interactions that require holding down a key, such as text selection. 

Both new commands are supported by Playwright and Puppeteer and use the same API.

