### PR TITLE
feat(rollup-plugin-copy): exclude

### DIFF
--- a/.changeset/plenty-kangaroos-design.md
+++ b/.changeset/plenty-kangaroos-design.md
@@ -1,0 +1,17 @@
+---
+'@web/rollup-plugin-copy': minor
+---
+
+Added `exclude` option for rollup-plugin-copy.
+
+Example: Exclude single directory:
+
+```js
+copy({ pattern: '**/*.svg', exclude: 'node_modules' })
+```
+
+Example: Exclude multiple globs:
+
+```js
+copy({ pattern: '**/*.svg', exclude: ['node_modules', 'src/graphics'] })
+```

--- a/docs/docs/building/rollup-plugin-copy.md
+++ b/docs/docs/building/rollup-plugin-copy.md
@@ -31,18 +31,25 @@ Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#comma
 
 ### `patterns`
 
-Type: `String|String[]`<br>
+Type: `string|string[]`<br>
 Mandatory: true
 
 Does accept a string pattern or an array of strings patterns.
 
 ### `rootDir`
 
-Type: `String`<br>
+Type: `string`<br>
 Default: current working directory
 
 Patterns are relative to this directory and all found files will be resolved relative to it.
 If files can not be found `path.resolve('./my/path)` may be used to ensure a full path.
+
+### `exclude`
+
+Type: `string|string[]`
+Default: `undefined`
+
+A glob or array of globs to exclude from copying.
 
 ## Examples
 
@@ -88,4 +95,65 @@ Result:
 ```
 .
 └── sub-a.svg
+```
+
+### Exclude single directory
+
+```js
+copy({ pattern: '**/*.svg', exclude: 'node_modules' });
+```
+
+Source directory
+
+```
+.
+├── node_modules
+│   ├── many modules...
+├── sub
+│   ├── sub-a.svg
+│   └── sub-b.txt
+├── a.svg
+└── b.svg
+```
+
+Result:
+
+```
+.
+├── sub
+│   └── sub-a.svg
+├── a.svg
+└── b.svg
+```
+
+### Exclude multiple globs
+
+Source directory
+
+```
+.
+├── node_modules
+│   ├── many modules...
+├── src
+│   └── graphics
+│     └── a-unoptimized.svg
+├── sub
+│   ├── sub-a.svg
+│   └── sub-b.txt
+├── a.svg
+└── b.svg
+```
+
+Result:
+
+```
+.
+├── sub
+│   └── sub-a.svg
+├── a.svg
+└── b.svg
+```
+
+```js
+copy({ pattern: '**/*.svg', exclude: ['node_modules', 'src/graphics'] });
 ```

--- a/packages/rollup-plugin-copy/src/copy.js
+++ b/packages/rollup-plugin-copy/src/copy.js
@@ -17,17 +17,18 @@ const { patternsToFiles } = require('./patternsToFiles.js');
  *
  * @param {object} options
  * @param {string|string[]} options.patterns Single glob or an array of globs
+ * @param {string|string[]} options.exclude Single glob or an array of globs
  * @param {string} [options.rootDir] Defaults to current working directory
  * @return {import('rollup').Plugin} A Rollup Plugin
  */
-function copy({ patterns = [], rootDir = process.cwd() }) {
+function copy({ patterns = [], rootDir = process.cwd(), exclude }) {
   const resolvedRootDir = path.resolve(rootDir);
   /** @type {string[]} */
   let filesToCopy = [];
   return {
     name: '@web/rollup-plugin-copy',
     async buildStart() {
-      filesToCopy = await patternsToFiles(patterns, rootDir);
+      filesToCopy = await patternsToFiles(patterns, rootDir, exclude);
       for (const filePath of filesToCopy) {
         this.addWatchFile(filePath);
       }

--- a/packages/rollup-plugin-copy/src/listFiles.js
+++ b/packages/rollup-plugin-copy/src/listFiles.js
@@ -9,10 +9,11 @@ const path = require('path');
  *
  * @param {string} fromGlob
  * @param {string} rootDir
+ * @param {string|string[]} [ignore]
  */
-function listFiles(fromGlob, rootDir) {
+function listFiles(fromGlob, rootDir, ignore) {
   return new Promise(resolve => {
-    glob(fromGlob, { cwd: rootDir, dot: true }, (er, files) => {
+    glob(fromGlob, { cwd: rootDir, dot: true, ignore }, (er, files) => {
       // remember, each filepath returned is relative to rootDir
       resolve(
         files

--- a/packages/rollup-plugin-copy/src/patternsToFiles.js
+++ b/packages/rollup-plugin-copy/src/patternsToFiles.js
@@ -4,10 +4,11 @@ const { listFiles } = require('./listFiles.js');
  *
  * @param {string|string[]} inPatterns
  * @param {string} rootDir
+ * @param {string|string[]} [exclude]
  */
-async function patternsToFiles(inPatterns, rootDir) {
+async function patternsToFiles(inPatterns, rootDir, exclude) {
   const patterns = typeof inPatterns === 'string' ? [inPatterns] : inPatterns;
-  const listFilesPromises = patterns.map(pattern => listFiles(pattern, rootDir));
+  const listFilesPromises = patterns.map(pattern => listFiles(pattern, rootDir, exclude));
   const arrayOfFilesArrays = await Promise.all(listFilesPromises);
   const files = [];
 


### PR DESCRIPTION
## What I did

Added `exclude` option for rollup-plugin-copy.

Example: Exclude single directory:

```js
copy({ pattern: '**/*.svg', exclude: 'node_modules' })
```

Example: Exclude multiple globs:

```js
copy({ pattern: '**/*.svg', exclude: ['node_modules', 'src/graphics'] })
```

