### PR TITLE
fix(test-runner): handle test exceptions with circular components

### DIFF
--- a/.changeset/angry-pandas-fry.md
+++ b/.changeset/angry-pandas-fry.md
@@ -1,0 +1,6 @@
+---
+'@web/test-runner-integration-tests': patch
+'@web/dev-server-core': patch
+---
+
+Safely stringify error messages in tests

--- a/integration/test-runner/tests/test-failure/browser-tests/fail-circular-error.test.js
+++ b/integration/test-runner/tests/test-failure/browser-tests/fail-circular-error.test.js
@@ -1,0 +1,7 @@
+import { expect } from '../../../../../node_modules/@esm-bundle/chai/esm/chai.js';
+
+it('bad predicate', function() {
+  const fixture = { x: 'x' }
+  fixture.circle = fixture;
+  expect(fixture).to.equal(null);
+})

--- a/integration/test-runner/tests/test-failure/runTestFailureTest.ts
+++ b/integration/test-runner/tests/test-failure/runTestFailureTest.ts
@@ -60,6 +60,18 @@ export function runTestFailureTest(
       }
     });
 
+    it('handles tests that error with a circular reference', () => {
+      const sessions = allSessions.filter(s => s.testFile.endsWith('fail-circular-error.test.js'));
+      expect(sessions.length === browserCount).to.equal(true);
+      for (const session of sessions) {
+        expect(session.testResults!.tests.map(t => t.name)).to.eql(['bad predicate']);
+        expect(session.passed).to.be.false;
+        expect(session.testResults!.tests![0].error!.message).to.equal(
+          "expected { x: 'x', circle: [Circular] } to equal null",
+        );
+      }
+    });
+
     it('handles tests that throw in afterEach', () => {
       const sessions = allSessions.filter(s => s.testFile.endsWith('fail-after-each.test.js'));
       expect(sessions.length === browserCount).to.equal(true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2462,6 +2462,13 @@
     "@wdio/logger" "7.5.3"
     "@wdio/types" "7.6.0"
 
+"@web/rollup-plugin-copy@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@web/rollup-plugin-copy/-/rollup-plugin-copy-0.2.0.tgz#425d32665fe06f39d81ae505ad0775c9354ba1ad"
+  integrity sha512-l3YInTLe/rbth6WuyoA7GY6DuXdt3iX6hQm6uoe5298fBzZfZPa3i0WVyUi3zPo6VttY0bjxPJyWK7JRQ37Cnw==
+  dependencies:
+    glob "^7.0.0"
+
 "@web/storybook-prebuilt@^0.1.20":
   version "0.1.20"
   resolved "https://registry.yarnpkg.com/@web/storybook-prebuilt/-/storybook-prebuilt-0.1.20.tgz#6d27f3387c462c7413967116d710bc16684d65b7"


### PR DESCRIPTION
## What I did

1. use code from `fast-safe-stringify` to stringify error messages across the ws channel.
2. Since `fast-safe-stringify` is cjs, I just copy-pasted.

BEFORE:

<img width="924" alt="Screen Shot 2021-05-26 at 18 49 40" src="https://user-images.githubusercontent.com/1466420/119691832-923d8380-be53-11eb-9fc6-1288ee449bd9.png">

AFTER:

<img width="571" alt="Screen Shot 2021-05-26 at 18 51 36" src="https://user-images.githubusercontent.com/1466420/119691850-9669a100-be53-11eb-9428-ce13090bd11d.png">

## Why?
This comes up often in apollo-elements, since ApolloClient has circular references, and it causes tests to hang without logging useful information to the console. If the user 'debugs' in a live browser, they can read the logs in the devtools console, but they might not think to do that.

Also relevant to highcharts, other circular objects 