### PR TITLE
fix(dev-server-esbuild): null checks in transform function, allowing …

### DIFF
--- a/packages/dev-server-esbuild/src/EsbuildPlugin.ts
+++ b/packages/dev-server-esbuild/src/EsbuildPlugin.ts
@@ -97,10 +97,10 @@ export class EsbuildPlugin implements Plugin {
   async transform(context: Context) {
     let loader: Loader;
 
-    if (context.response.is('html')) {
+    if (context && context.response.is('html')) {
       // we are transforming inline scripts
       loader = 'js';
-    } else {
+    } else if (context.path) {
       const fileExtension = path.posix.extname(context.path);
       loader = this.esbuildConfig.loaders[fileExtension];
     }


### PR DESCRIPTION
…the use of this plugin for .storybook/main.js with @rollup/plugin-typescript

```javascript
config.plugins.unshift(
      esbuildPlugin({ 
        ts: true, 
        json: true,
        target: 'auto' }),
      typescript()
    );
```

## What I did
null checked context.response and context.path
```typescript
if (context.response && context.response.is('html')) {
    // we are transforming inline scripts
    loader = 'js';
}
else if(context.path) {
    const fileExtension = path_1.default.posix.extname(context.path);
    loader = this.esbuildConfig.loaders[fileExtension];
  }
```