### PR TITLE
feat(rollup-plugin-import-meta-assets): allow transform to skip processing asset

### DIFF
--- a/.changeset/cuddly-buttons-turn.md
+++ b/.changeset/cuddly-buttons-turn.md
@@ -1,0 +1,5 @@
+---
+'@web/rollup-plugin-import-meta-assets': patch
+---
+
+Allow ignoring assets during transformation

--- a/docs/docs/building/rollup-plugin-import-meta-assets.md
+++ b/docs/docs/building/rollup-plugin-import-meta-assets.md
@@ -80,6 +80,8 @@ By default, referenced assets detected by this plugin are just copied as is to t
 When `transform` is defined, this function will be called for each asset with two parameters, the content of the asset as a [Buffer](https://nodejs.org/api/buffer.html) and the absolute path.
 This allows you to conditionnaly match on the absolute path and maybe transform the content.
 
+When `transform` returns `null`, the asset is skipped from being processed.
+
 In this example, we use it to optimize SVG images with [svgo](https://github.com/svg/svgo):
 
 ```js

--- a/packages/rollup-plugin-import-meta-assets/src/rollup-plugin-import-meta-assets.js
+++ b/packages/rollup-plugin-import-meta-assets/src/rollup-plugin-import-meta-assets.js
@@ -80,6 +80,9 @@ function importMetaAssets({ include, exclude, warnOnError, transform } = {}) {
                 transform != null
                   ? await transform(assetContents, absoluteAssetPath)
                   : assetContents;
+              if (transformedAssetContents === null) {
+                return;
+              }
               const ref = this.emitFile({
                 type: 'asset',
                 name: assetName,

--- a/packages/rollup-plugin-import-meta-assets/test/snapshots/transform-bundle-ignored.js
+++ b/packages/rollup-plugin-import-meta-assets/test/snapshots/transform-bundle-ignored.js
@@ -1,0 +1,13 @@
+const justUrlObject = new URL(new URL('assets/one-d81655b9.svg', import.meta.url).href, import.meta.url);
+const href = new URL(new URL('assets/two-00516e7a.svg', import.meta.url).href, import.meta.url).href;
+const pathname = new URL(new URL('assets/three-0ba6692d.svg', import.meta.url).href, import.meta.url).pathname;
+const searchParams = new URL(new URL('assets/four-a00e2e1d.svg', import.meta.url).href, import.meta.url).searchParams;
+const someJpg = new URL('./image.jpg', import.meta.url);
+
+console.log({
+  justUrlObject,
+  href,
+  pathname,
+  searchParams,
+  someJpg,
+});


### PR DESCRIPTION
This allows users who pre-process a subset of assets separately to
skip processing the assets via this plugin.

As part of https://crrev.com/c/2939994 I am working on optimizing
our SVG assets dynamically. However, we also have other image
formats in our source tree, including `.png` and `.avif`. These images
are pre-optimized and we aren't sure yet whether we want to
dynamically optimize this during build time (as that tends to be
computationally expensive work).

However, when trying to integrate the plugin, I discovered that our
build system (GN + Ninja) started complaining about files being
out-of-date. I then discovered that the `.png` and `.avif` assets
were double copied: once by us in GN and once in the plugin.

I then attempted to include only the SVG files using `include` and was
confused as to why that wouldn't work. While reading the source
code of this plugin, I realized that the `include` pattern only works
for the actual JavaScript files and not the assets.

To allow users to conditionally define transformations for a subset
of assets, I would propose to update the plugin to ignore `null`
as transformation result. Alternatively, you can introduce separate
filters called `assetInclude` and `assetExclude`, but I think this
solution is more maintainable, as it provides users full control
without adding a lot more plugin options.

When I update our transform to the snippet below, everything
would be working as expected with GN + Rollup:

```js
importMetaAssets({
  async transform(assetBuffer, assetPath) {
    if (assetPath.endsWith('.svg')) {
      const {data} = await optimize(assetBuffer.toString());
      return data;
    }
    return null;
  }
}),
```