### PR TITLE
fix: allow stripXMLInvalidChars when replace it not available

### DIFF
--- a/.changeset/small-timers-sort.md
+++ b/.changeset/small-timers-sort.md
@@ -1,0 +1,6 @@
+---
+"@web/test-runner-junit-reporter": patch
+"@web/test-runner": patch
+---
+
+fix: allow stripXMLInvalidChars when replace it not available

--- a/packages/test-runner-junit-reporter/src/junitReporter.ts
+++ b/packages/test-runner-junit-reporter/src/junitReporter.ts
@@ -125,7 +125,8 @@ const INVALID_CHARACTERS_REGEX =
   // eslint-disable-next-line no-control-regex
   /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007f-\u0084\u0086-\u009f\uD800-\uDFFF\uFDD0-\uFDFF\uFFFF\uC008]/g;
 
-const stripXMLInvalidChars = (x: string): string => x.replace(INVALID_CHARACTERS_REGEX, '');
+const stripXMLInvalidChars = (x: string): string =>
+  x && x.replace ? x.replace(INVALID_CHARACTERS_REGEX, '') : x;
 
 /**
  * Makes a `<failure>` element


### PR DESCRIPTION
## What I did

1. gated the replace behind the presence of replace

I know there has to be something underlying this issue, but I can't seem to find it... this change safely allows the use of replace without seeming to break anything else, so I'd like your thoughts.
