### PR TITLE
feat(browser-logs): add extra logging when catching an unhandled rejection

### DIFF
--- a/.changeset/silly-pans-prove.md
+++ b/.changeset/silly-pans-prove.md
@@ -1,0 +1,5 @@
+---
+'@web/browser-logs': patch
+---
+
+add extra logging when catching an unhandled rejection

--- a/packages/browser-logs/src/logUncaughtErrors.ts
+++ b/packages/browser-logs/src/logUncaughtErrors.ts
@@ -4,6 +4,9 @@ window.addEventListener('error', e => {
 
 window.addEventListener('unhandledrejection', e => {
   e.promise.catch(error => {
+    console.error(
+      'An error was thrown in a Promise outside a test. Did you forget to await a function or assertion?',
+    );
     console.error(error);
   });
 });


### PR DESCRIPTION
## What I did

add extra logging when catching an unhandled rejection