### PR TITLE
Fix coverage branch fusion

### DIFF
--- a/.changeset/shy-frogs-hug.md
+++ b/.changeset/shy-frogs-hug.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-core': patch
+---
+
+fix(test-runner): fix error when merging multiple test-suites falsely reporting covered branches as uncovered

--- a/.changeset/ten-pens-tease.md
+++ b/.changeset/ten-pens-tease.md
@@ -1,0 +1,5 @@
+---
+"@web/test-runner": patch
+---
+
+Fix coverage branch fusion

--- a/packages/test-runner-core/src/coverage/getTestCoverage.ts
+++ b/packages/test-runner-core/src/coverage/getTestCoverage.ts
@@ -25,19 +25,28 @@ export interface TestCoverage {
 }
 
 const locEquals = (a: Location, b: Location) => a.column === b.column && a.line === b.line;
-const locBefore = (a: Location, b: Location) => a.line < b.line || (a.line === b.line && a.column <= b.column)
+const locBefore = (a: Location, b: Location) =>
+  a.line < b.line || (a.line === b.line && a.column <= b.column);
 const rangeEquals = (a: Range, b: Range) => locEquals(a.start, b.start) && locEquals(a.end, b.end);
-const rangeEncompass = (a: Range, b: Range) => locBefore(a.start, b.start) && locBefore(b.end, a.end);
+const rangeEncompass = (a: Range, b: Range) =>
+  locBefore(a.start, b.start) && locBefore(b.end, a.end);
 
 function getRangeDistance(encompassing: Range, range: Range) {
-  const startDistanceLine = range.start.line - encompassing.start.line
-  const startDistanceColumn = startDistanceLine ? range.start.column - encompassing.start.column : 0
+  const startDistanceLine = range.start.line - encompassing.start.line;
+  const startDistanceColumn = startDistanceLine
+    ? range.start.column - encompassing.start.column
+    : 0;
 
-  const endDistanceLine = encompassing.end.line - range.end.line
-  const endDistanceColumn = endDistanceLine ? encompassing.end.column - range.end.column : 0
+  const endDistanceLine = encompassing.end.line - range.end.line;
+  const endDistanceColumn = endDistanceLine ? encompassing.end.column - range.end.column : 0;
 
   // Multiply each line by 100_000, as lines length are unknown but should never reach this size
-  return startDistanceLine * 100_000 + endDistanceLine * 100_000 + startDistanceColumn + endDistanceColumn
+  return (
+    startDistanceLine * 100_000 +
+    endDistanceLine * 100_000 +
+    startDistanceColumn +
+    endDistanceColumn
+  );
 }
 
 function findKey<T extends BranchMapping | FunctionMapping>(items: Record<string, T>, item: T) {
@@ -48,19 +57,26 @@ function findKey<T extends BranchMapping | FunctionMapping>(items: Record<string
   }
 }
 
-function findEncompassingKey<T extends BranchMapping | FunctionMapping>(items: Record<string, T>, item: T) {
+function findEncompassingKey<T extends BranchMapping | FunctionMapping>(
+  items: Record<string, T>,
+  item: T,
+) {
   // Get all encompassing branches
-  const encompassingEntries = Object.entries(items).filter(([, m]) => rangeEncompass(m.loc, item.loc))
+  const encompassingEntries = Object.entries(items).filter(([, m]) =>
+    rangeEncompass(m.loc, item.loc),
+  );
 
   if (!encompassingEntries.length) {
-    return null
+    return null;
   }
 
   // Sort the encompassing branches by distance to the searched branch
-  encompassingEntries.sort((a, b) => getRangeDistance(a[1].loc, item.loc) - getRangeDistance(b[1].loc, item.loc))
+  encompassingEntries.sort(
+    (a, b) => getRangeDistance(a[1].loc, item.loc) - getRangeDistance(b[1].loc, item.loc),
+  );
 
   // Return the key of the narrowest encompassing branch
-  return encompassingEntries[0][0]
+  return encompassingEntries[0][0];
 }
 
 function collectCoverageItems<T extends BranchMapping | FunctionMapping>(

--- a/packages/test-runner-core/src/coverage/getTestCoverage.ts
+++ b/packages/test-runner-core/src/coverage/getTestCoverage.ts
@@ -25,7 +25,20 @@ export interface TestCoverage {
 }
 
 const locEquals = (a: Location, b: Location) => a.column === b.column && a.line === b.line;
+const locBefore = (a: Location, b: Location) => a.line < b.line || (a.line === b.line && a.column <= b.column)
 const rangeEquals = (a: Range, b: Range) => locEquals(a.start, b.start) && locEquals(a.end, b.end);
+const rangeEncompass = (a: Range, b: Range) => locBefore(a.start, b.start) && locBefore(b.end, a.end);
+
+function getRangeDistance(encompassing: Range, range: Range) {
+  const startDistanceLine = range.start.line - encompassing.start.line
+  const startDistanceColumn = startDistanceLine ? range.start.column - encompassing.start.column : 0
+
+  const endDistanceLine = encompassing.end.line - range.end.line
+  const endDistanceColumn = endDistanceLine ? encompassing.end.column - range.end.column : 0
+
+  // Multiply each line by 100_000, as lines length are unknown but should never reach this size
+  return startDistanceLine * 100_000 + endDistanceLine * 100_000 + startDistanceColumn + endDistanceColumn
+}
 
 function findKey<T extends BranchMapping | FunctionMapping>(items: Record<string, T>, item: T) {
   for (const [key, m] of Object.entries(items)) {
@@ -33,6 +46,21 @@ function findKey<T extends BranchMapping | FunctionMapping>(items: Record<string
       return key;
     }
   }
+}
+
+function findEncompassingKey<T extends BranchMapping | FunctionMapping>(items: Record<string, T>, item: T) {
+  // Get all encompassing branches
+  const encompassingEntries = Object.entries(items).filter(([, m]) => rangeEncompass(m.loc, item.loc))
+
+  if (!encompassingEntries.length) {
+    return null
+  }
+
+  // Sort the encompassing branches by distance to the searched branch
+  encompassingEntries.sort((a, b) => getRangeDistance(a[1].loc, item.loc) - getRangeDistance(b[1].loc, item.loc))
+
+  // Return the key of the narrowest encompassing branch
+  return encompassingEntries[0][0]
 }
 
 function collectCoverageItems<T extends BranchMapping | FunctionMapping>(
@@ -68,7 +96,7 @@ function patchCoverageItems<T extends BranchMapping | FunctionMapping, U extends
   itemIndex = {};
 
   for (const [key, mapping] of Object.entries(items)) {
-    const originalKey = findKey(originalItems, mapping);
+    const originalKey = findEncompassingKey(originalItems, mapping);
     if (originalKey != null) {
       itemIndex[key] = originalIndex[originalKey];
     } else {


### PR DESCRIPTION
## What I did

1. Add a `findEncompassingKey` function to `getTestCoverage.ts`
2. Use this instead of `findKey` in `patchCoverageItems`

Those two changes allow `patchCoverageItems` to fallback to an encompassing branch coverage status when adding an unreported branch to a session report.

The reasoning for this change is described here: https://github.com/modernweb-dev/web/issues/1468#issuecomment-864518266.

This Pull Request fixes #1468.

## Additional notes

I came up with this solution through trial & error, analysing the output of `coverage` maps received from the various sessions. I'm not sure whether this fix is proper or only a patchwork on a patchwork.

I tested the solution on a large codebase and only saw positive consequences, but I cannot guarantee that this does not bring unintended side-effects. I'd really appreciate if someone knowledgeable about the `getTestCoverage.ts` file and overall V8-to-Istanbul conversion could take a look at what I did!