### PR TITLE
feat(rollup-plugin-html): exclude files

### DIFF
--- a/.changeset/little-fans-shake.md
+++ b/.changeset/little-fans-shake.md
@@ -1,0 +1,5 @@
+---
+'@web/rollup-plugin-html': minor
+---
+
+Add `exclude` option. Used e.g. to ignore html file assets when bundling.

--- a/docs/docs/building/rollup-plugin-html.md
+++ b/docs/docs/building/rollup-plugin-html.md
@@ -307,6 +307,8 @@ export interface InputHTMLOptions {
 export interface RollupPluginHTMLOptions {
   /** HTML file(s) to use as input. If not set, uses rollup input option. */
   input?: string | InputHTMLOptions | (string | InputHTMLOptions)[];
+  /** HTML file glob patterns or patterns to ignore */
+  exclude?: string | string[];
   /** Whether to minify the output HTML. */
   minify?: boolean;
   /** Whether to preserve or flatten the directory structure of the HTML file. */

--- a/packages/rollup-plugin-html/src/RollupPluginHTMLOptions.ts
+++ b/packages/rollup-plugin-html/src/RollupPluginHTMLOptions.ts
@@ -13,6 +13,8 @@ export interface InputHTMLOptions {
 export interface RollupPluginHTMLOptions {
   /** HTML file(s) to use as input. If not set, uses rollup input option. */
   input?: string | InputHTMLOptions | (string | InputHTMLOptions)[];
+  /** HTML file glob pattern or patterns to ignore */
+  exclude?: string | string[];
   /** Whether to minify the output HTML. */
   minify?: boolean;
   /** Whether to preserve or flatten the directory structure of the HTML file. */

--- a/packages/rollup-plugin-html/src/input/getInputData.ts
+++ b/packages/rollup-plugin-html/src/input/getInputData.ts
@@ -9,8 +9,8 @@ import { normalizeInputOptions } from './normalizeInputOptions';
 import { extractModulesAndAssets } from './extract/extractModulesAndAssets';
 import { InputOption } from 'rollup';
 
-function resolveGlob(fromGlob: string, rootDir: string) {
-  const files = glob.sync(fromGlob, { cwd: rootDir, absolute: true });
+function resolveGlob(fromGlob: string, opts: glob.IOptions) {
+  const files = glob.sync(fromGlob, { ...opts, absolute: true });
   return (
     files
       // filter out directories
@@ -64,6 +64,7 @@ export function getInputData(
     flattenOutput,
     extractAssets = true,
     absolutePathPrefix,
+    exclude: ignore,
   } = pluginOptions;
   const allInputs = normalizeInputOptions(pluginOptions, rollupInput);
 
@@ -80,7 +81,7 @@ export function getInputData(
       });
       result.push(data);
     } else if (typeof input.path === 'string') {
-      const filePaths = resolveGlob(input.path, rootDir);
+      const filePaths = resolveGlob(input.path, { cwd: rootDir, ignore });
       if (filePaths.length === 0) {
         throw new Error(
           `Could not find any HTML files for pattern: ${input.path}, resolved relative to ${rootDir}`,

--- a/packages/rollup-plugin-html/test/fixtures/rollup-plugin-html/exclude/assets/partial.html
+++ b/packages/rollup-plugin-html/test/fixtures/rollup-plugin-html/exclude/assets/partial.html
@@ -1,0 +1,1 @@
+<blink>I'm a partial!</blink>

--- a/packages/rollup-plugin-html/test/fixtures/rollup-plugin-html/exclude/index.html
+++ b/packages/rollup-plugin-html/test/fixtures/rollup-plugin-html/exclude/index.html
@@ -1,0 +1,1 @@
+<a href="assets/docs/partial.html"></a>

--- a/packages/rollup-plugin-html/test/rollup-plugin-html.test.ts
+++ b/packages/rollup-plugin-html/test/rollup-plugin-html.test.ts
@@ -421,6 +421,22 @@ describe('rollup-plugin-html', () => {
     expect(pageC).to.include('<script type="module" src="./shared.js"></script>');
   });
 
+  it('can exclude globs', async () => {
+    const config = {
+      plugins: [
+        rollupPluginHTML({
+          input: 'exclude/**/*.html',
+          exclude: '**/partial.html',
+          rootDir,
+        }),
+      ],
+    };
+
+    const bundle = await rollup(config);
+    const { output } = await bundle.generate(outputConfig);
+    expect(output.length).to.equal(2);
+  });
+
   it('creates unique inline script names', async () => {
     const config = {
       plugins: [


### PR DESCRIPTION
## What I did

1. add `exclude` option to rollup-plugin-html

### Case
User wishes to exclude assets (for example, 11ty html file _includes_, `playground-elements/playground-service-worker-proxy.html`) from the build.

#### Example Usage

in`rocket.config.js`
```js
setupBuildPlugins: [
  adjustPluginOptions('html', {
    ignore: ['**/_assets/**/*.html', '**/_merged_assets/**/*.html'],
  }),
],
```
