### PR TITLE
fix(test-runner): make snapshots work on all browsers

### DIFF
--- a/.changeset/famous-turtles-compete.md
+++ b/.changeset/famous-turtles-compete.md
@@ -1,0 +1,6 @@
+---
+'@web/test-runner': patch
+'@web/test-runner-commands': patch
+---
+
+make snapshots work on all browsers

--- a/packages/test-runner-commands/src/snapshotPlugin.ts
+++ b/packages/test-runner-commands/src/snapshotPlugin.ts
@@ -70,7 +70,7 @@ class SnapshotStore {
     // store in cache
     const content = (await fileExists(snapshotPath))
       ? await readFile(snapshotPath, 'utf-8')
-      : '// @web/test-runner snapshot v1\n\nexport const snapshots = {}\n\n';
+      : 'export const snapshotsVersion = 1;\nexport const snapshots = {};\n\n';
     this.snapshots.set(snapshotPath, content);
 
     // resolve read promise to let others who are waiting continue

--- a/packages/test-runner/demo/test/__snapshots__/pass-snapshot.test.snap.js
+++ b/packages/test-runner/demo/test/__snapshots__/pass-snapshot.test.snap.js
@@ -1,18 +1,14 @@
-// @web/test-runner snapshot v1
-
+export const snapshotsVersion = 1;
 export const snapshots = {}
 
-// snapshot snapshot-a
 snapshots["snapshot-a"] = 
 `some snapshot A`;
 // end snapshot snapshot-a
 
-// snapshot snapshot-b
 snapshots["snapshot-b"] = 
 `some snapshot B`;
 // end snapshot snapshot-b
 
-// snapshot snapshot-c
 snapshots["snapshot-c"] = 
 `some snapshot B`;
 // end snapshot snapshot-c


### PR DESCRIPTION
## What I did

When dynamically importing a module using a data URL, it cannot start with a comment on firefox on safari. On Chrome it works fine. It's quite a strange bug.

This change uses a variable instead for the version marker.