### PR TITLE
fix(dev-server): fixes #1536, correctly handle outside-root paths

### DIFF
--- a/.changeset/curly-cheetahs-argue.md
+++ b/.changeset/curly-cheetahs-argue.md
@@ -1,0 +1,6 @@
+---
+"@web/dev-server-rollup": patch
+"@web/dev-server": patch
+---
+
+fix(dev-server): fixes #1536, correctly handle outside-root paths

--- a/packages/dev-server-rollup/src/rollupAdapter.ts
+++ b/packages/dev-server-rollup/src/rollupAdapter.ts
@@ -28,6 +28,7 @@ import { createRollupPluginContexts, RollupPluginContexts } from './createRollup
 const NULL_BYTE_PARAM = 'web-dev-server-rollup-null-byte';
 const VIRTUAL_FILE_PREFIX = '/__web-dev-server__/rollup';
 const WDS_FILE_PREFIX = '/__web-dev-server__';
+const OUTSIDE_ROOT_REGEXP = /\/__wds-outside-root__\/([0-9]+)\/(.*)/;
 
 /**
  * Wraps rollup error in a custom error for web dev server.
@@ -193,7 +194,7 @@ export function rollupAdapter(
             resolvedImportPath.replace(/\0*/g, '').split('?')[0].split('#')[0],
           );
           // if the resolve import path is outside our normal root, fully resolve the file path for rollup
-          const matches = resolvedImportPath.match(/\/__wds-outside-root__\/([0-9]+)\/(.*)/);
+          const matches = resolvedImportPath.match(OUTSIDE_ROOT_REGEXP);
           if (matches) {
             const upDirs = new Array(parseInt(matches[1], 10) + 1).join(`..${path.sep}`);
             resolvedImportPath = `\0${path.resolve(`${upDirs}${matches[2]}`)}`;

--- a/packages/dev-server-rollup/src/rollupAdapter.ts
+++ b/packages/dev-server-rollup/src/rollupAdapter.ts
@@ -192,6 +192,12 @@ export function rollupAdapter(
           const filename = path.basename(
             resolvedImportPath.replace(/\0*/g, '').split('?')[0].split('#')[0],
           );
+          // if the resolve import path is outside our normal root, fully resolve the file path for rollup
+          const matches = resolvedImportPath.match(/\/__wds-outside-root__\/([0-9]+)\/(.*)/);
+          if (matches) {
+            const upDirs = new Array(parseInt(matches[1], 10) + 1).join(`..${path.sep}`);
+            resolvedImportPath = `\0${path.resolve(`${upDirs}${matches[2]}`)}`;
+          }
           const urlParam = encodeURIComponent(resolvedImportPath);
           return `${VIRTUAL_FILE_PREFIX}/${filename}?${NULL_BYTE_PARAM}=${urlParam}`;
         }


### PR DESCRIPTION
## What I did

1. Fully resolve `resolvedImportPath` for files outside of the root before passing to plugins.

## Case

Using rollup plugins like `@rollup/plugin-commonjs` in a monorepo environment. In these cases we can be serving dependencies from outside of the 'root' (where we're executing the test runner or WDS). In these cases we were previously passing the `/__wds-outside-root__/` prefix to the plugins which was causing them to not resolve the files being processed properly. Doing full path resolution seems to fix it.
