### PR TITLE
docs(import-maps): fix typo in web dev server config file name

### DIFF
--- a/docs/docs/dev-server/plugins/import-maps.md
+++ b/docs/docs/dev-server/plugins/import-maps.md
@@ -45,7 +45,7 @@ Install the package:
 npm i --save-dev @web/dev-server-import-maps
 ```
 
-Add the plugin to your `web-dev-server-config.mjs` or `web-test-runner.config.js`:
+Add the plugin to your `web-dev-server.config.mjs` or `web-test-runner.config.js`:
 
 ```js
 import { importMapsPlugin } from '@web/dev-server-import-maps';


### PR DESCRIPTION
## What I did

1. Fix typo in config file name
