### PR TITLE
fix(test-runner): use block comments in snapshots to make them work in all browsers

### DIFF
--- a/.changeset/curvy-actors-dance.md
+++ b/.changeset/curvy-actors-dance.md
@@ -1,0 +1,6 @@
+---
+'@web/test-runner': patch
+'@web/test-runner-commands': patch
+---
+
+Use block comments in snapshots to make them work in all browsers

--- a/packages/test-runner-commands/src/snapshotPlugin.ts
+++ b/packages/test-runner-commands/src/snapshotPlugin.ts
@@ -70,7 +70,7 @@ class SnapshotStore {
     // store in cache
     const content = (await fileExists(snapshotPath))
       ? await readFile(snapshotPath, 'utf-8')
-      : 'export const snapshotsVersion = 1;\nexport const snapshots = {};\n\n';
+      : '/* @web/test-runner snapshot v1 */\nexport const snapshots = {};\n\n';
     this.snapshots.set(snapshotPath, content);
 
     // resolve read promise to let others who are waiting continue
@@ -83,7 +83,7 @@ class SnapshotStore {
     const snapshotPath = getSnapshotPath(testFilePath);
     const nameStr = JSON.stringify(name);
     const startMarker = `snapshots[${nameStr}]`;
-    const endMarker = `// end snapshot ${name}\n\n`;
+    const endMarker = `/* end snapshot ${name} */\n\n`;
     const replacement = updatedSnapshot
       ? `${startMarker} = \n\`${updatedSnapshot}\`;\n${endMarker}`
       : '';
@@ -109,7 +109,7 @@ class SnapshotStore {
     }
 
     this.snapshots.set(snapshotPath, updatedContent);
-    if (updatedContent.includes('// end snapshot')) {
+    if (updatedContent.includes('/* end snapshot')) {
       // update or create snapshot
       const fileDir = path.dirname(snapshotPath);
       await mkdirp(fileDir);

--- a/packages/test-runner-commands/test/snapshot/__snapshots__/browser-test.snap.js
+++ b/packages/test-runner-commands/test/snapshot/__snapshots__/browser-test.snap.js
@@ -1,9 +1,9 @@
-// @web/test-runner snapshot v1
+/* @web/test-runner snapshot v1 */
 
 export const snapshots = {};
 
 snapshots['persistent-a'] = `this is snapshot A`;
-// end snapshot persistent-a
+/* end snapshot persistent-a */
 
 snapshots['persistent-b'] = `this is snapshot B`;
-// end snapshot persistent-b
+/* end snapshot persistent-b */

--- a/packages/test-runner-commands/test/snapshot/snapshotPlugin.test.ts
+++ b/packages/test-runner-commands/test/snapshot/snapshotPlugin.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { runTests } from '@web/test-runner-core/test-helpers';
-import { chromeLauncher } from '@web/test-runner-chrome';
+import { playwrightLauncher } from '@web/test-runner-playwright';
 
 import { snapshotPlugin } from '../../src/snapshotPlugin';
 
@@ -10,13 +10,21 @@ describe.only('snapshotPlugin', function test() {
   it('passes snapshot tests', async () => {
     await runTests({
       files: [path.join(__dirname, 'browser-test.js')],
-      browsers: [chromeLauncher()],
+      browsers: [
+        playwrightLauncher({ product: 'firefox' }),
+        playwrightLauncher({ product: 'chromium' }),
+        playwrightLauncher({ product: 'webkit' }),
+      ],
       plugins: [snapshotPlugin()],
     });
 
     await runTests({
       files: [path.join(__dirname, 'src', 'nested-test.js')],
-      browsers: [chromeLauncher()],
+      browsers: [
+        playwrightLauncher({ product: 'firefox' }),
+        playwrightLauncher({ product: 'chromium' }),
+        playwrightLauncher({ product: 'webkit' }),
+      ],
       plugins: [snapshotPlugin()],
     });
   });

--- a/packages/test-runner-commands/test/snapshot/src/__snapshots__/nested-test.snap.js
+++ b/packages/test-runner-commands/test/snapshot/src/__snapshots__/nested-test.snap.js
@@ -1,9 +1,9 @@
-// @web/test-runner snapshot v1
+/* @web/test-runner snapshot v1 */
 
 export const snapshots = {};
 
 snapshots['persistent-a'] = `this is nested snapshot A`;
-// end snapshot persistent-a
+/* end snapshot persistent-a */
 
 snapshots['persistent-b'] = `this is nested snapshot B`;
-// end snapshot persistent-b
+/* end snapshot persistent-b */

--- a/packages/test-runner/demo/test/__snapshots__/pass-snapshot.test.snap.js
+++ b/packages/test-runner/demo/test/__snapshots__/pass-snapshot.test.snap.js
@@ -1,15 +1,16 @@
-export const snapshotsVersion = 1;
+/* @web/test-runner snapshot v1 */
+
 export const snapshots = {}
 
 snapshots["snapshot-a"] = 
 `some snapshot A`;
-// end snapshot snapshot-a
+/* end snapshot snapshot-a */
 
 snapshots["snapshot-b"] = 
 `some snapshot B`;
-// end snapshot snapshot-b
+/* end snapshot snapshot-b */
 
 snapshots["snapshot-c"] = 
 `some snapshot B`;
-// end snapshot snapshot-c
+/* end snapshot snapshot-c */
 


### PR DESCRIPTION
## What I did

1. I changed the way markers are done in snapshots because Firefox and Webkit have some problems with line comments, and using block comments seems to work properly.
