### PR TITLE
fix(test-runner): escape snapshots to make them work in firefox and webkit

### DIFF
--- a/.changeset/thin-pigs-call.md
+++ b/.changeset/thin-pigs-call.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-commands': patch
+---
+
+Escape the snapshot contents to avoid problems in Firrefox and Webkit

--- a/packages/test-runner-commands/test/snapshot/browser-test.js
+++ b/packages/test-runner-commands/test/snapshot/browser-test.js
@@ -3,50 +3,58 @@ import { expect } from '../chai.js';
 
 it('can save, read and remove snapshot a', async () => {
   const name = 'a';
-  const content = 'this is snapshot A';
-  const savedContent1 = await getSnapshot({ name });
-  expect(savedContent1).to.equal(undefined);
+  try {
+    const content = 'this is snapshot A';
+    const savedContent1 = await getSnapshot({ name, cache: false });
+    expect(savedContent1).to.equal(undefined);
 
-  await saveSnapshot({ name, content });
+    await saveSnapshot({ name, content });
 
-  const savedContent2 = await getSnapshot({ name });
-  expect(savedContent2).to.equal(content);
-
-  await removeSnapshot({ name });
+    const savedContent2 = await getSnapshot({ name, cache: false });
+    expect(savedContent2).to.equal(content);
+  } finally {
+    await removeSnapshot({ name });
+  }
 });
 
 it('can save, read and remove snapshot b', async () => {
   const name = 'b';
-  const content = 'this is snapshot B';
-  await saveSnapshot({ name, content });
 
-  const savedContent = await getSnapshot({ name });
-  expect(content).to.equal(savedContent);
+  try {
+    const content = 'this is snapshot B';
+    await saveSnapshot({ name, content });
 
-  await removeSnapshot({ name });
+    const savedContent = await getSnapshot({ name, cache: false });
+    expect(content).to.equal(savedContent);
+  } finally {
+    await removeSnapshot({ name });
+  }
 });
 
 it('can save, read and remove multiple snapshots', async () => {
   const name1 = 'multi-1';
   const name2 = 'multi-2';
   const name3 = 'multi-3';
-  const content1 = 'this is snapshot multi-1';
-  const content2 = 'this is snapshot multi-2';
-  const content3 = 'this is snapshot multi-3';
-  await saveSnapshot({ name: name1, content: content1 });
-  await saveSnapshot({ name: name2, content: content2 });
-  await saveSnapshot({ name: name3, content: content3 });
 
-  const savedContent1 = await getSnapshot({ name: name1 });
-  const savedContent2 = await getSnapshot({ name: name2 });
-  const savedContent3 = await getSnapshot({ name: name3 });
-  expect(savedContent1).to.equal(content1);
-  expect(savedContent2).to.equal(content2);
-  expect(savedContent3).to.equal(content3);
+  try {
+    const content1 = 'this is snapshot multi-1';
+    const content2 = 'this is snapshot multi-2';
+    const content3 = 'this is snapshot multi-3';
+    await saveSnapshot({ name: name1, content: content1 });
+    await saveSnapshot({ name: name2, content: content2 });
+    await saveSnapshot({ name: name3, content: content3 });
 
-  await removeSnapshot({ name: name1 });
-  await removeSnapshot({ name: name2 });
-  await removeSnapshot({ name: name3 });
+    const savedContent1 = await getSnapshot({ name: name1, cache: false });
+    const savedContent2 = await getSnapshot({ name: name2, cache: false });
+    const savedContent3 = await getSnapshot({ name: name3, cache: false });
+    expect(savedContent1).to.equal(content1);
+    expect(savedContent2).to.equal(content2);
+    expect(savedContent3).to.equal(content3);
+  } finally {
+    await removeSnapshot({ name: name1 });
+    await removeSnapshot({ name: name2 });
+    await removeSnapshot({ name: name3 });
+  }
 });
 
 it('can persist snapshot A between test runs', async () => {
@@ -57,7 +65,7 @@ it('can persist snapshot A between test runs', async () => {
   // got deleted on disk
   // await saveSnapshot({ name, content });
 
-  const savedContent = await getSnapshot({ name });
+  const savedContent = await getSnapshot({ name, cache: false });
   expect(savedContent).to.equal(content);
 });
 
@@ -69,21 +77,24 @@ it('can persist snapshot B between test runs', async () => {
   // got deleted on disk
   // await saveSnapshot({ name, content });
 
-  const savedContent = await getSnapshot({ name });
+  const savedContent = await getSnapshot({ name, cache: false });
   expect(savedContent).to.equal(content);
 });
 
 it('can store multiline snapshots', async () => {
   const name = 'multiline';
-  const content = `
+
+  try {
+    const content = `
 a
 b
 c
 `;
-  await saveSnapshot({ name, content });
+    await saveSnapshot({ name, content });
 
-  const savedContent = await getSnapshot({ name });
-  expect(savedContent).to.equal(content);
-
-  await removeSnapshot({ name });
+    const savedContent = await getSnapshot({ name, cache: false });
+    expect(savedContent).to.equal(content);
+  } finally {
+    await removeSnapshot({ name });
+  }
 });


### PR DESCRIPTION
## What I did

1. First, I modified the test to be able to reproduce the issue. In order to do that I had to add an option to avoid the use of the snapshots memory cache, and secondly, add a random number in the file content before import it to avoid browser cache.
2. Then, I escaped the carriage returns in the snapshot. Otherwise, Firefox and Webkit seem to have problems. 


