### PR TITLE
test: remove describe.only to run all tests

### DIFF
--- a/packages/test-runner-commands/test/snapshot/snapshotPlugin.test.ts
+++ b/packages/test-runner-commands/test/snapshot/snapshotPlugin.test.ts
@@ -4,7 +4,7 @@ import { playwrightLauncher } from '@web/test-runner-playwright';
 
 import { snapshotPlugin } from '../../src/snapshotPlugin';
 
-describe.only('snapshotPlugin', function test() {
+describe('snapshotPlugin', function test() {
   this.timeout(20000);
 
   it('passes snapshot tests', async () => {


### PR DESCRIPTION
## What I did

1. Removed incorrect `describe.only` to make sure all the tests are executed.
