### PR TITLE
fix: move Babel types to the correct package

### DIFF
--- a/.changeset/chatty-zebras-dress.md
+++ b/.changeset/chatty-zebras-dress.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-core': patch
+---
+
+Move Babel types to the correct package

--- a/packages/test-runner-chrome/package.json
+++ b/packages/test-runner-chrome/package.json
@@ -51,7 +51,6 @@
     "puppeteer-core": "^9.1.0"
   },
   "devDependencies": {
-    "@types/babel__code-frame": "^7.0.2",
     "@types/istanbul-reports": "^3.0.0",
     "@web/test-runner-mocha": "^0.7.0"
   }

--- a/packages/test-runner-core/package.json
+++ b/packages/test-runner-core/package.json
@@ -51,6 +51,7 @@
   ],
   "dependencies": {
     "@babel/code-frame": "^7.12.11",
+    "@types/babel__code-frame": "^7.0.2",
     "@types/co-body": "^6.1.0",
     "@types/convert-source-map": "^1.5.1",
     "@types/debounce": "^1.2.0",


### PR DESCRIPTION
## What I did

1. Moved `@types/babel__code-frame` from `@web/test-runner-chrome` dev dependencies to the `@web/test-runner-core` where this dependency is actually used, and added it to `dependencies` to align with the other types dependencies.
