### PR TITLE
fix: update Rollup dependency to 2.56.2

### DIFF
--- a/.changeset/seven-rocks-judge.md
+++ b/.changeset/seven-rocks-judge.md
@@ -1,0 +1,6 @@
+---
+'@web/dev-server-rollup': patch
+'@web/dev-server': patch
+---
+
+Update Rollup dependency to 2.56.2

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "prettier": "^2.2.1",
     "prettier-plugin-package": "^1.3.0",
     "rimraf": "^3.0.2",
-    "rollup": "^2.35.1",
+    "rollup": "^2.56.2",
     "rollup-plugin-terser": "^7.0.2",
     "ts-node": "^9.1.1",
     "typescript": "4.1.3"

--- a/packages/dev-server-rollup/package.json
+++ b/packages/dev-server-rollup/package.json
@@ -50,7 +50,7 @@
     "@web/dev-server-core": "^0.3.3",
     "chalk": "^4.1.0",
     "parse5": "^6.0.1",
-    "rollup": "^2.35.1",
+    "rollup": "^2.56.2",
     "whatwg-url": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/dev-server-rollup/test/node/rollupBundlePlugin.test.ts
+++ b/packages/dev-server-rollup/test/node/rollupBundlePlugin.test.ts
@@ -49,17 +49,17 @@ describe('rollupBundlePlugin', () => {
       const textA1 = await fetchText(`${host}/a1.js`);
       expectIncludes(textA1, "import { b as bc, d } from './__rollup-generated__d.js';");
       expectIncludes(textA1, 'var a1 = `a ${bc} ${d}`;');
-      expectIncludes(textA1, 'export default a1;');
+      expectIncludes(textA1, 'export { a1 as default };');
 
       const textA2 = await fetchText(`${host}/a2.js`);
       expectIncludes(textA2, "import { b as bc, d } from './__rollup-generated__d.js';");
       expectIncludes(textA2, 'var a2 = `a ${bc} ${d}`;');
-      expectIncludes(textA2, 'export default a2;');
+      expectIncludes(textA2, 'export { a2 as default };');
 
       const textA3 = await fetchText(`${host}/a3.js`);
       expectIncludes(textA3, "import { b as bc, d } from './__rollup-generated__d.js';");
       expectIncludes(textA3, 'var a3 = `a ${bc} ${d}`;');
-      expectIncludes(textA3, 'export default a3;');
+      expectIncludes(textA3, 'export { a3 as default };');
 
       const textD = await fetchText(`${host}/__rollup-generated__d.js`);
       expectIncludes(textD, "var c = 'c';");

--- a/yarn.lock
+++ b/yarn.lock
@@ -10581,10 +10581,10 @@ rollup-pluginutils@^2.8.2:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^2.35.1, rollup@^2.43.1:
-  version "2.52.8"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.52.8.tgz#b6462f9c16ffe8995b9a2b313f2e4247fa75e4d9"
-  integrity sha512-IjAB0C6KK5/lvqzJWAzsvOik+jV5Bt907QdkQ/gDP4j+R9KYNI1tjqdxiPitGPVrWC21Mf/ucXgowUjN/VemaQ==
+rollup@^2.35.1, rollup@^2.43.1, rollup@^2.56.2:
+  version "2.56.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.56.2.tgz#a045ff3f6af53ee009b5f5016ca3da0329e5470f"
+  integrity sha512-s8H00ZsRi29M2/lGdm1u8DJpJ9ML8SUOpVVBd33XNeEeL3NVaTiUcSBHzBdF3eAyR0l7VSpsuoVUGrRHq7aPwQ==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
## What I did

1. Updated Rollup dependency to 2.56.2
2. Fixed tests to align with the change landed in 2.55 - https://github.com/rollup/rollup/pull/4182 (see [this article](https://jakearchibald.com/2021/export-default-thing-vs-thing-as-default/) for an overview of how the mutable live bindings work).
