### PR TITLE
Fix up changeset to only include @web/dev-server-storybook

### DIFF
--- a/.changeset/four-owls-smash.md
+++ b/.changeset/four-owls-smash.md
@@ -1,6 +1,5 @@
 ---
 "@web/dev-server-storybook": patch
-"@web/dev-server": patch
 ---
 
 Use latest upstream dependencies

--- a/.changeset/moody-taxis-cheat.md
+++ b/.changeset/moody-taxis-cheat.md
@@ -1,6 +1,5 @@
 ---
 "@web/dev-server-storybook": patch
-"@web/dev-server": patch
 ---
 
 Use the latest Storybook Prebuilt which uses the latest Storybook which allows for the use of pre and post `lit@2.0` versions of the Lit libraries.


### PR DESCRIPTION
## What I did

1. Removed `@web/dev-server` from the changeset


Both @web-padawan and @abdonrd caught this inclusion in #1625 Hard to track where it came in as this package is no longer touched by the changes listed in that closed PR. I've remove it from the changeset to prevent it bumping version.