### PR TITLE
Update commands.d.ts

### DIFF
--- a/packages/test-runner-commands/browser/commands.d.ts
+++ b/packages/test-runner-commands/browser/commands.d.ts
@@ -155,7 +155,7 @@ export function writeFile(payload: WriteFilePayload): Promise<void>;
  *    const content = await readFile({ path: 'hello-world.txt' });
  * ```
  */
-export function readFile(payload: WriteFilePayload): Promise<string | undefined>;
+export function readFile(payload: ReadFilePayload): Promise<string | undefined>;
 
 /**
  * Removes a file from disk.


### PR DESCRIPTION
## What I did

1. Changed the payload of `readFile` from `WriteFilePayload` to `ReadFilePayload`. Currently `readFile` has to be used like this per type definition:

```ts
const content = await readFile({
  path: "test-data/hello-world.txt",
  content: "This parameter isn't used",
});
```
