### PR TITLE
feat(test-runner-visual-regression): output diff file path on failure

### DIFF
--- a/.changeset/happy-singers-own.md
+++ b/.changeset/happy-singers-own.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-visual-regression': patch
+---
+
+Output diff file path to console on snapshot mismatch, making it easier to inspect results.

--- a/packages/test-runner-visual-regression/src/visualDiffCommand.ts
+++ b/packages/test-runner-visual-regression/src/visualDiffCommand.ts
@@ -44,6 +44,7 @@ export async function visualDiffCommand(
 
   const diffName = options.getDiffName({ browser, name });
   const failedName = options.getFailedName({ browser, name });
+  const diffFilePath = resolveImagePath(baseDir, diffName);
 
   const saveFailed = async () => {
     await options.saveFailed({
@@ -56,7 +57,7 @@ export async function visualDiffCommand(
 
   const saveDiff = async () => {
     await options.saveDiff({
-      filePath: resolveImagePath(baseDir, diffName),
+      filePath: diffFilePath,
       baseDir,
       name: diffName,
       content: diffImage,
@@ -100,7 +101,9 @@ export async function visualDiffCommand(
 
   return {
     errorMessage: !passed
-      ? `Visual diff failed. New screenshot is ${diffPercentage.toFixed(2)} % different.`
+      ? `Visual diff failed. New screenshot is ${diffPercentage.toFixed(
+          2,
+        )}% different.\nSee diff for details: ${diffFilePath}`
       : undefined,
     diffPercentage: -1,
     passed,


### PR DESCRIPTION
this makes it easy and quick to open the diff from the CLI, inspect the results, and work out what went wrong

## What I did

1. Append file path for diff image to existing error message
