### PR TITLE
Use the runners config which will be bound to the group selected. 

### DIFF
--- a/packages/test-runner/src/startTestRunner.ts
+++ b/packages/test-runner/src/startTestRunner.ts
@@ -58,7 +58,7 @@ export async function startTestRunner(options: StartTestRunnerParams = {}) {
     const { config, groupConfigs } = await parseConfig(mergedConfig, cliArgs);
 
     const runner = new TestRunner(config, groupConfigs);
-    const cli = new TestRunnerCli(config, runner);
+    const cli = new TestRunnerCli(runner.config, runner);
 
     function stop() {
       runner.stop();


### PR DESCRIPTION
This allows groups to overwrite all options from the config, but if they do not specify the property it will fall back to the one defined in the root config.