### PR TITLE
fix: support method names in objects containing a dash

### DIFF
--- a/.changeset/cuddly-snails-beg.md
+++ b/.changeset/cuddly-snails-beg.md
@@ -1,0 +1,5 @@
+---
+"@web/browser-logs": patch
+---
+
+fix: support method names in objects containing a dash

--- a/packages/browser-logs/src/deserialize.ts
+++ b/packages/browser-logs/src/deserialize.ts
@@ -42,10 +42,10 @@ function createReviver(promises: Promise<unknown>[], options?: DeserializeOption
           }
           return;
         case 'Function':
-          if(value.name.includes('-')) {
+          if (value.name.includes('-')) {
             const { name } = value;
             // eslint-disable-next-line
-            const placeholder = { [name]: () => {}};
+            const placeholder = { [name]: () => {} };
             return placeholder[name];
           }
           // Create a fake function with the same name. We don't log the function implementation.

--- a/packages/browser-logs/src/deserialize.ts
+++ b/packages/browser-logs/src/deserialize.ts
@@ -42,6 +42,12 @@ function createReviver(promises: Promise<unknown>[], options?: DeserializeOption
           }
           return;
         case 'Function':
+          if(value.name.includes('-')) {
+            const { name } = value;
+            // eslint-disable-next-line
+            const placeholder = { [name]: () => {}};
+            return placeholder[name];
+          }
           // Create a fake function with the same name. We don't log the function implementation.
           return new Function(
             `return function ${value.name.replace(

--- a/packages/browser-logs/test/serialize-deserialize.test.ts
+++ b/packages/browser-logs/test/serialize-deserialize.test.ts
@@ -209,7 +209,7 @@ describe('serialize deserialize', () => {
         baz: function baz() {
           return 'baz';
         },
-        'my-element': () => 'bar'
+        'my-element': () => 'bar',
       }),
     );
     const deserialized = await deserialize(serialized);

--- a/packages/browser-logs/test/serialize-deserialize.test.ts
+++ b/packages/browser-logs/test/serialize-deserialize.test.ts
@@ -209,6 +209,7 @@ describe('serialize deserialize', () => {
         baz: function baz() {
           return 'baz';
         },
+        'my-element': () => 'bar'
       }),
     );
     const deserialized = await deserialize(serialized);
@@ -218,6 +219,8 @@ describe('serialize deserialize', () => {
     expect(deserialized.bar.name).to.equal('bar');
     expect(deserialized.baz).to.be.a('function');
     expect(deserialized.baz.name).to.equal('baz');
+    expect(deserialized['my-element']).to.be.a('function');
+    expect(deserialized['my-element'].name).to.equal('my-element');
   });
 
   it('handles deep objects', async () => {


### PR DESCRIPTION
fixes https://github.com/modernweb-dev/web/issues/1557

## What I did

1. The serializer currently crashes on function names containing a hyphen (in objects, e.g. `{'a-b': ()=>{}}`, because the deserializer tries to revive them like so:

```js
new Function(`return function my-function() {}`);
```
which is invalid
