### PR TITLE
fix: use encodeURIComponent to escape snapshot content

### DIFF
--- a/.changeset/pink-lobsters-develop.md
+++ b/.changeset/pink-lobsters-develop.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-commands': patch
+---
+
+Fix snapshots with # character

--- a/packages/test-runner-commands/browser/commands.mjs
+++ b/packages/test-runner-commands/browser/commands.mjs
@@ -123,7 +123,7 @@ const ESCAPE_REGEX = /snapshots\[[^\]]+] = (\n)?(?<content>`[^`]*`)/gm;
 
 const escapeContent = content => {
   [...content.matchAll(ESCAPE_REGEX)].forEach(({ groups: { content: itemContent } }) => {
-    content = content.replaceAll(itemContent, itemContent.replaceAll(/\n/g, '\\n'));
+    content = content.replaceAll(itemContent, encodeURIComponent(itemContent));
   });
 
   return content;

--- a/packages/test-runner-commands/test/snapshot/browser-test.js
+++ b/packages/test-runner-commands/test/snapshot/browser-test.js
@@ -98,3 +98,20 @@ c
     await removeSnapshot({ name });
   }
 });
+
+it('can store snapshots containing # character', async () => {
+  const name = 'hash-character';
+
+  try {
+    const content = `
+## This is a header
+
+And this is the content`;
+    await saveSnapshot({ name, content });
+
+    const savedContent = await getSnapshot({ name, cache: false });
+    expect(savedContent).to.equal(content);
+  } finally {
+    await removeSnapshot({ name });
+  }
+});


### PR DESCRIPTION
Fix #1690 by using `encodeURIComponent` to escape the snapshot content before building the data url instead of just escaping the line breaks. Please let me know if there's a better way to do this.