### PR TITLE
fix(docs): example plugin should return undefined, not false

### DIFF
--- a/docs/docs/test-runner/commands.md
+++ b/docs/docs/test-runner/commands.md
@@ -406,7 +406,7 @@ export function takeScreenshotPlugin() {
           `Taking screenshots is not supported for browser type ${session.browser.type}.`,
         );
       }
-      return false;
+      return undefined;
     },
   };
 }


### PR DESCRIPTION
The docs specifically say that you should return `undefined`/`null `to signal a command _hasn't_ been handled. However, the example plugin returns `false` in this case. 

In my testing, it seems that `false` is treated as having handled the command, and so no other commands ever get executed. I just spent time debugging why one of my commands wouldn't execute, and eventually tracked it down to having based my plugins on this example :)
