### PR TITLE
Remove `dedupe` option

### DIFF
--- a/docs/docs/dev-server/cli-and-configuration.md
+++ b/docs/docs/dev-server/cli-and-configuration.md
@@ -137,7 +137,6 @@ You can pass extra configuration using the `nodeResolve` option in the config:
 export default {
   nodeResolve: {
     exportConditions: ['development'],
-    dedupe: true,
   },
 };
 ```


### PR DESCRIPTION
The `dedupe` option is an array of strings (https://github.com/rollup/plugins/tree/master/packages/node-resolve/#dedupe)

## What I did

1. Removed the `dedupe` option

The `dedupe` option is an array of strings and the configuration is wrong when a boolean is used (https://github.com/rollup/plugins/tree/master/packages/node-resolve/#dedupe)
