### PR TITLE
feat: update Rollup to 2.58.0, use isEntry flag

### DIFF
--- a/.changeset/wise-ways-search.md
+++ b/.changeset/wise-ways-search.md
@@ -1,0 +1,6 @@
+---
+'@web/dev-server-rollup': patch
+'@web/dev-server': patch
+---
+
+Update Rollup to 2.58.0, use isEntry flag

--- a/packages/dev-server-rollup/package.json
+++ b/packages/dev-server-rollup/package.json
@@ -50,7 +50,7 @@
     "@web/dev-server-core": "^0.3.16",
     "nanocolors": "^0.2.1",
     "parse5": "^6.0.1",
-    "rollup": "^2.56.2",
+    "rollup": "^2.58.0",
     "whatwg-url": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/dev-server-rollup/src/rollupAdapter.ts
+++ b/packages/dev-server-rollup/src/rollupAdapter.ts
@@ -150,7 +150,7 @@ export function rollupAdapter(
           rollupPluginContext,
           resolvableImport,
           filePath,
-          {},
+          { isEntry: false },
         );
 
         if (!result && injectedFilePath) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10292,10 +10292,10 @@ rollup-pluginutils@^2.8.2:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^2.35.1, rollup@^2.43.1, rollup@^2.56.2:
-  version "2.57.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.57.0.tgz#c1694475eb22e1022477c0f4635fd0ac80713173"
-  integrity sha512-bKQIh1rWKofRee6mv8SrF2HdP6pea5QkwBZSMImJysFj39gQuiV8MEPBjXOCpzk3wSYp63M2v2wkWBmFC8O/rg==
+rollup@^2.35.1, rollup@^2.43.1, rollup@^2.56.2, rollup@^2.58.0:
+  version "2.58.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.58.0.tgz#a643983365e7bf7f5b7c62a8331b983b7c4c67fb"
+  integrity sha512-NOXpusKnaRpbS7ZVSzcEXqxcLDOagN6iFS8p45RkoiMqPHDLwJm758UF05KlMoCRbLBTZsPOIa887gZJ1AiXvw==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
## What I did

1. Updated `rollup` dependency to `2.58.0`
2. Added `isEntry` flag, see https://github.com/rollup/rollup/pull/4230