### PR TITLE
docs(css): registering properties inheritance

### DIFF
--- a/docs/guides/going-buildless/css.md
+++ b/docs/guides/going-buildless/css.md
@@ -112,13 +112,15 @@ For example
 
 ```html
 <my-layout gap="md">
-  // will set its --layout-gap to 16px
+  <!-- will set its --layout-gap to 16px -->
   <my-layout>
-    // --layout-gap is authored to default to an initial value of 4px BUT // as its parent _layout_
-    component "pierces the shadow boundary" it'll set this child _layout_ component --layout-gap
-    with the 16px unexpectedly
-  </my-layout></my-layout
->
+    <!--
+    --layout-gap is authored to default to an initial value of 4px BUT
+    as its parent _layout_component "pierces the shadow boundary" it'll set
+    this child _layout_ component --layout-gap with the 16px unexpectedly
+    -->
+  </my-layout>
+</my-layout>
 ```
 
 In this case, [registering your Custom Property](https://developer.mozilla.org/en-US/docs/Web/CSS/@property) can help prevent inheritance if explicitly set to.

--- a/docs/guides/going-buildless/css.md
+++ b/docs/guides/going-buildless/css.md
@@ -112,11 +112,11 @@ For example
 
 ```html
 <my-layout gap="md">
-  <!-- will set its `--layout-gap` to 16px -->
+  <!-- will set its --layout-gap to 16px -->
   <my-layout>
     <!--
     --layout-gap is authored to default to an initial value of 4px BUT
-    as its parent layout component "pierces the shadow boundary" it'll set
+    as its parent layout component pierces the Shadow boundary it'll set
     this child layout component --layout-gap with the 16px unexpectedly
     -->
   </my-layout>

--- a/docs/guides/going-buildless/css.md
+++ b/docs/guides/going-buildless/css.md
@@ -109,12 +109,16 @@ html {
 
 However, you might still need to contain custom properties in a self containing component.
 For example
+
 ```html
 <my-layout gap="md">
   // will set its --layout-gap to 16px
   <my-layout>
-    // --layout-gap is authored to default to an initial value of 4px BUT
-    // as its parent _layout_ component "pierces the shadow boundary" it'll set this child _layout_ component --layout-gap with the 16px unexpectedly
-
+    // --layout-gap is authored to default to an initial value of 4px BUT // as its parent _layout_
+    component "pierces the shadow boundary" it'll set this child _layout_ component --layout-gap
+    with the 16px unexpectedly
+  </my-layout></my-layout
+>
 ```
+
 In this case, [registering your Custom Property](https://developer.mozilla.org/en-US/docs/Web/CSS/@property) can help prevent inheritance if explicitly set to.

--- a/docs/guides/going-buildless/css.md
+++ b/docs/guides/going-buildless/css.md
@@ -106,3 +106,15 @@ html {
   --theme-gap: 16px;
 }
 ```
+
+However, you might still need to contain custom properties in a self containing component.
+For example
+```html
+<my-layout gap="md">
+  // will set its --layout-gap to 16px
+  <my-layout>
+    // --layout-gap is authored to default to an initial value of 4px BUT
+    // as its parent _layout_ component "pierces the shadow boundary" it'll set this child _layout_ component --layout-gap with the 16px unexpectedly
+
+```
+In this case, [registering your Custom Property](https://developer.mozilla.org/en-US/docs/Web/CSS/@property) can help prevent inheritance if explicitly set to.

--- a/docs/guides/going-buildless/css.md
+++ b/docs/guides/going-buildless/css.md
@@ -112,12 +112,12 @@ For example
 
 ```html
 <my-layout gap="md">
-  <!-- will set its --layout-gap to 16px -->
+  <!-- will set its `--layout-gap` to 16px -->
   <my-layout>
     <!--
     --layout-gap is authored to default to an initial value of 4px BUT
-    as its parent _layout_component "pierces the shadow boundary" it'll set
-    this child _layout_ component --layout-gap with the 16px unexpectedly
+    as its parent layout component "pierces the shadow boundary" it'll set
+    this child layout component --layout-gap with the 16px unexpectedly
     -->
   </my-layout>
 </my-layout>


### PR DESCRIPTION
as discussed at WICG/webcomponents#945

still not a broadly supported
1. should note that?
2. is it even applicable due to lack of support?

## What I did

1. added documentation on how to prevent custom elements from piercing
