### PR TITLE
docs: update TransformAssetFunction docs to match type

### DIFF
--- a/docs/docs/building/rollup-plugin-html.md
+++ b/docs/docs/building/rollup-plugin-html.md
@@ -374,7 +374,7 @@ export type TransformHtmlFunction = (
 ) => string | Promise<string>;
 
 export type TransformAssetFunction = (
-  filePath: string,
   content: Buffer,
+  filePath: string,
 ) => string | Buffer | Promise<string | Buffer>;
 ```


### PR DESCRIPTION
## What I did

1. Swapped lines in documentation to match correct spec in https://github.com/modernweb-dev/web/blob/master/packages/rollup-plugin-html/src/RollupPluginHTMLOptions.ts
