### PR TITLE
fix(dev-server-core): support iframes in a csp protected environment

### DIFF
--- a/.changeset/olive-trees-refuse.md
+++ b/.changeset/olive-trees-refuse.md
@@ -1,0 +1,7 @@
+---
+'@web/dev-server-core': patch
+'@web/dev-server': patch
+---
+
+When serving content to an iframe within a csp restricted page, the websocket script may not be able to access the parent window.
+Accessing it may result in an uncaught DOMException which we now handle.

--- a/packages/dev-server-core/src/web-sockets/webSocketsPlugin.ts
+++ b/packages/dev-server-core/src/web-sockets/webSocketsPlugin.ts
@@ -142,7 +142,16 @@ function setupFetch() {
 }
 
 function setupWebSocket() {
-  if (window.parent !== window && window.parent.__WDS_WEB_SOCKET__ !== undefined) {
+  let useParent = false;
+  try {
+    // if window is an iframe and accessing a cross origin frame is not allowed this will throw
+    // therefore we try/catch it here so it does not disable all web sockets
+    if (window.parent !== window && window.parent.__WDS_WEB_SOCKET__ !== undefined) {
+      useParent = true;
+    }
+  } catch(e) {}
+
+  if (useParent) {
     // get the websocket instance from the parent element if present
     const info = window.parent.__WDS_WEB_SOCKET__;
     webSocket = info.webSocket;


### PR DESCRIPTION
## What I did

1. makes sure websockets also work for iframes in csp protected environments

Error I got


<img width="607" alt="Screenshot 2021-11-06 at 00 48 29" src="https://user-images.githubusercontent.com/24378/140590775-fa7f9812-a1b3-4ce7-9e43-0828779d7a6d.png">
PS: this will enable usage of web dev sever in VS Code extensions 💪