### PR TITLE
fix: do not process scripts with non-JS type attribute

### DIFF
--- a/.changeset/shy-kangaroos-clap.md
+++ b/.changeset/shy-kangaroos-clap.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server-esbuild': patch
+---
+
+Do not process scripts with non-JS type attribute

--- a/packages/dev-server-esbuild/src/EsbuildPlugin.ts
+++ b/packages/dev-server-esbuild/src/EsbuildPlugin.ts
@@ -134,7 +134,14 @@ export class EsbuildPlugin implements Plugin {
     const documentAst = parseHtml(context.body as string);
     const inlineScripts = queryAll(
       documentAst,
-      predicates.AND(predicates.hasTagName('script'), predicates.NOT(predicates.hasAttr('src'))),
+      predicates.AND(
+        predicates.hasTagName('script'),
+        predicates.NOT(predicates.hasAttr('src')),
+        predicates.OR(
+          predicates.NOT(predicates.hasAttr('type')),
+          predicates.hasAttrValue('type', 'module'),
+        ),
+      ),
     );
 
     if (inlineScripts.length === 0) {


### PR DESCRIPTION
## What I did

1. dev-server-esbuild: fix "importmap" or other non-js type in html file
