### PR TITLE
fix: resolve missing peer dependency of @rollup/plugin-node-resolve

### DIFF
--- a/.changeset/thick-camels-heal.md
+++ b/.changeset/thick-camels-heal.md
@@ -1,0 +1,6 @@
+---
+'@web/dev-server': patch
+'@web/dev-server-rollup': patch
+---
+
+Resolve missing peer dependency of @rollup/plugin-node-resolve by moving and exposing @rollup/plugin-node-resolve to @web/dev-server-rollup

--- a/packages/dev-server-rollup/package.json
+++ b/packages/dev-server-rollup/package.json
@@ -47,6 +47,7 @@
     "transform"
   ],
   "dependencies": {
+    "@rollup/plugin-node-resolve": "^11.0.1",
     "@web/dev-server-core": "^0.3.16",
     "nanocolors": "^0.2.1",
     "parse5": "^6.0.1",
@@ -58,7 +59,6 @@
     "@rollup/plugin-alias": "^3.1.1",
     "@rollup/plugin-babel": "^5.2.2",
     "@rollup/plugin-commonjs": "^18.0.0",
-    "@rollup/plugin-node-resolve": "^11.0.1",
     "@rollup/plugin-replace": "^3.0.0",
     "@types/parse5": "^6.0.1",
     "@types/whatwg-url": "^8.0.0",

--- a/packages/dev-server-rollup/src/index.ts
+++ b/packages/dev-server-rollup/src/index.ts
@@ -1,3 +1,4 @@
+export { RollupNodeResolveOptions, nodeResolve } from '@rollup/plugin-node-resolve';
 export { fromRollup } from './fromRollup';
 export { rollupAdapter } from './rollupAdapter';
 export { rollupBundlePlugin } from './rollupBundlePlugin';

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -56,7 +56,6 @@
   ],
   "dependencies": {
     "@babel/code-frame": "^7.12.11",
-    "@rollup/plugin-node-resolve": "^11.0.1",
     "@types/command-line-args": "^5.0.0",
     "@web/config-loader": "^0.1.3",
     "@web/dev-server-core": "^0.3.17",

--- a/packages/dev-server/src/config/DevServerConfig.ts
+++ b/packages/dev-server/src/config/DevServerConfig.ts
@@ -1,5 +1,5 @@
 import { DevServerCoreConfig } from '@web/dev-server-core';
-import { RollupNodeResolveOptions } from '@rollup/plugin-node-resolve';
+import { RollupNodeResolveOptions } from '@web/dev-server-rollup';
 
 export interface DevServerConfig extends DevServerCoreConfig {
   /**

--- a/packages/dev-server/src/index.ts
+++ b/packages/dev-server/src/index.ts
@@ -1,9 +1,9 @@
+export { RollupNodeResolveOptions } from '@web/dev-server-rollup';
 export { startDevServer } from './startDevServer';
 export { mergeConfigs } from './config/mergeConfigs';
 export { DevServerStartError } from './DevServerStartError';
 export { esbuildPlugin } from './plugins/esbuildPlugin';
 export { nodeResolvePlugin } from './plugins/nodeResolvePlugin';
-export { RollupNodeResolveOptions } from '@rollup/plugin-node-resolve';
 
 import type { DevServerConfig as FullDevServerConfig } from './config/DevServerConfig';
 export type DevServerConfig = Partial<FullDevServerConfig>;

--- a/packages/dev-server/src/plugins/nodeResolvePlugin.ts
+++ b/packages/dev-server/src/plugins/nodeResolvePlugin.ts
@@ -1,6 +1,5 @@
-import { rollupAdapter } from '@web/dev-server-rollup';
+import { nodeResolve, rollupAdapter, RollupNodeResolveOptions } from '@web/dev-server-rollup';
 import { Plugin } from '@web/dev-server-core';
-import { nodeResolve, RollupNodeResolveOptions } from '@rollup/plugin-node-resolve';
 import deepmerge from 'deepmerge';
 
 export function nodeResolvePlugin(


### PR DESCRIPTION
Move the @rollup/plugin-node-resolve dependency to @web/dev-server-rollup, which already has a dependency on the one package that is missing for @rollup/plugin-node-resolve: rollup.

Fixes #1542
