### PR TITLE
chore: add Node 16 LTS to GitHub Actions

### DIFF
--- a/.github/workflows/verify-node.yml
+++ b/.github/workflows/verify-node.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['12', '14']
+        node-version: ['12', '14', '16']
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
## What I did

1. Added Node 16 LTS to the testing matrix.
