### PR TITLE
chore: update release workflow to Node 16 LTS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - name: Setup Node.js 12
+      - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '12'
+          node-version: '16'
           cache: 'yarn'
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
## What I did

1. Updated Node version to 16, maybe this helps to run the release workflow (for now it is always skipped).
