### PR TITLE
fix(test-runner-visual-regression): improve output when very small diff percentage

### DIFF
--- a/.changeset/curly-cameras-deliver.md
+++ b/.changeset/curly-cameras-deliver.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-visual-regression': patch
+---
+
+improve output in visual regression tests when very small differences from baseline

--- a/packages/test-runner-visual-regression/src/visualDiffCommand.ts
+++ b/packages/test-runner-visual-regression/src/visualDiffCommand.ts
@@ -104,11 +104,14 @@ export async function visualDiffCommand(
     await saveFailed();
   }
 
+  // if diff is suitably small, output raw value, otherwise to two decimal points.
+  // this avoids outputting a message like "New screenshot is 0.00% different"
+  const diffPercentageToDisplay =
+    diffPercentage < 0.005 ? diffPercentage : diffPercentage.toFixed(2);
+
   return {
     errorMessage: !passed
-      ? `Visual diff failed. New screenshot is ${diffPercentage.toFixed(
-          2,
-        )}% different.\nSee diff for details: ${diffFilePath}`
+      ? `Visual diff failed. New screenshot is ${diffPercentageToDisplay}% different.\nSee diff for details: ${diffFilePath}`
       : undefined,
     diffPercentage: -1,
     passed,


### PR DESCRIPTION
## What I did

1. in cases where diff percentage was very small the output would be like `New screenshot is 0.00% different` which is confusing
2. i kept formatting to 2 decimal places when the value is large enough, otherwise output the raw value
3. this avoid cases as in (1)