### PR TITLE
feat: add sendMouse command

### DIFF
--- a/.changeset/real-oranges-protect.md
+++ b/.changeset/real-oranges-protect.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-commands': minor
+---
+
+Add the sendMouse command for moving the mouse and clicking mouse buttons

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "start:build": "node packages/dev-server/dist/bin.js --root-dir _site --open",
     "test": "yarn test:node && yarn test:browser && node scripts/workspaces-scripts-bin.mjs test:ci",
     "test:browser": "node packages/test-runner/dist/bin.js \"packages/*/test-browser/**/*.test.{js,ts}\"",
-    "test:node": "mocha \"packages/*/test/**/*.test.{ts,js,mjs,cjs}\" --require ts-node/register --exit --retries 3",
+    "test:node": "mocha \"packages/test-runner-commands/test/**/*.test.{ts,js,mjs,cjs}\" --require ts-node/register --exit --retries 3",
     "update": "npm run update:mjs-dts-entrypoints && npm run update:tsconfigs",
     "update-dependency": "node scripts/update-dependency.js",
     "update:mjs-dts-entrypoints": "node scripts/generate-mjs-dts-entrypoints.mjs && yarn format",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "start:build": "node packages/dev-server/dist/bin.js --root-dir _site --open",
     "test": "yarn test:node && yarn test:browser && node scripts/workspaces-scripts-bin.mjs test:ci",
     "test:browser": "node packages/test-runner/dist/bin.js \"packages/*/test-browser/**/*.test.{js,ts}\"",
-    "test:node": "mocha \"packages/test-runner-commands/test/**/*.test.{ts,js,mjs,cjs}\" --require ts-node/register --exit --retries 3",
+    "test:node": "mocha \"packages/**/test/**/*.test.{ts,js,mjs,cjs}\" --require ts-node/register --exit --retries 3",
     "update": "npm run update:mjs-dts-entrypoints && npm run update:tsconfigs",
     "update-dependency": "node scripts/update-dependency.js",
     "update:mjs-dts-entrypoints": "node scripts/generate-mjs-dts-entrypoints.mjs && yarn format",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "start:build": "node packages/dev-server/dist/bin.js --root-dir _site --open",
     "test": "yarn test:node && yarn test:browser && node scripts/workspaces-scripts-bin.mjs test:ci",
     "test:browser": "node packages/test-runner/dist/bin.js \"packages/*/test-browser/**/*.test.{js,ts}\"",
-    "test:node": "mocha \"packages/**/test/**/*.test.{ts,js,mjs,cjs}\" --require ts-node/register --exit --retries 3",
+    "test:node": "mocha \"packages/*/test/**/*.test.{ts,js,mjs,cjs}\" --require ts-node/register --exit --retries 3",
     "update": "npm run update:mjs-dts-entrypoints && npm run update:tsconfigs",
     "update-dependency": "node scripts/update-dependency.js",
     "update:mjs-dts-entrypoints": "node scripts/generate-mjs-dts-entrypoints.mjs && yarn format",

--- a/packages/test-runner-commands/browser/commands.d.ts
+++ b/packages/test-runner-commands/browser/commands.d.ts
@@ -76,9 +76,9 @@ export function setUserAgent(userAgent: string): Promise<void>;
 export function sendKeys(payload: SendKeysPayload): Promise<void>;
 
 /**
- * Sends an action for the mouse to move it to a specific position or click a mouse button.
+ * Sends an action for the mouse to move it to a specific position or click a mouse button (left, middle or right).
  *
- * @param payload An object including a `type` property and a `position` property (required for the `move` and `click` types).
+ * @param payload An object representing a mouse action specified by the `type` property (move, click, down, up) and including properties permitted for this type.
  *
  * @example
  * ```ts
@@ -92,7 +92,8 @@ export function sendKeys(payload: SendKeysPayload): Promise<void>;
  * ```ts
  *    await sendMouse({
  *        type: 'click',
- *        position: [100, 100]
+ *        position: [100, 100],
+ *        button: 'right'
  *    });
  * ```
  *

--- a/packages/test-runner-commands/browser/commands.d.ts
+++ b/packages/test-runner-commands/browser/commands.d.ts
@@ -8,7 +8,7 @@ import {
   RemoveFilePayload,
   SnapshotPluginConfig,
   SaveSnapshotPayload,
-  SendMousePayload
+  SendMousePayload,
 } from '../dist/index';
 
 /**
@@ -104,7 +104,7 @@ export function sendKeys(payload: SendKeysPayload): Promise<void>;
  * ```
  *
  **/
- export function sendMouse(payload: SendMousePayload): Promise<void>;
+export function sendMouse(payload: SendMousePayload): Promise<void>;
 
 /**
  * Request a snapshot of the Accessibility Tree of the entire page or starting from

--- a/packages/test-runner-commands/browser/commands.d.ts
+++ b/packages/test-runner-commands/browser/commands.d.ts
@@ -8,6 +8,7 @@ import {
   RemoveFilePayload,
   SnapshotPluginConfig,
   SaveSnapshotPayload,
+  SendMousePayload
 } from '../dist/index';
 
 /**
@@ -73,6 +74,37 @@ export function setUserAgent(userAgent: string): Promise<void>;
  *
  **/
 export function sendKeys(payload: SendKeysPayload): Promise<void>;
+
+/**
+ * Sends an action for the mouse to move it to a specific position or click a mouse button.
+ *
+ * @param payload An object including a `type` property and a `position` property (required for the `move` and `click` types).
+ *
+ * @example
+ * ```ts
+ *    await sendMouse({
+ *        type: 'move',
+ *        position: [100, 100]
+ *    });
+ * ```
+ *
+ * @example
+ * ```ts
+ *    await sendMouse({
+ *        type: 'click',
+ *        position: [100, 100]
+ *    });
+ * ```
+ *
+ * @example
+ * ```ts
+ *    await sendMouse({
+ *        type: 'down'
+ *    });
+ * ```
+ *
+ **/
+ export function sendMouse(payload: SendMousePayload): Promise<void>;
 
 /**
  * Request a snapshot of the Accessibility Tree of the entire page or starting from

--- a/packages/test-runner-commands/browser/commands.mjs
+++ b/packages/test-runner-commands/browser/commands.mjs
@@ -69,6 +69,10 @@ export function sendKeys(options) {
   return executeServerCommand('send-keys', options);
 }
 
+export function sendMouse(options) {
+  return executeServerCommand('send-mouse', options);
+}
+
 export function a11ySnapshot(options) {
   return executeServerCommand('a11y-snapshot', options);
 }

--- a/packages/test-runner-commands/src/index.ts
+++ b/packages/test-runner-commands/src/index.ts
@@ -2,6 +2,7 @@ export { Viewport, setViewportPlugin } from './setViewportPlugin';
 export { Media, emulateMediaPlugin } from './emulateMediaPlugin';
 export { setUserAgentPlugin } from './setUserAgentPlugin';
 export { sendKeysPlugin, SendKeysPayload } from './sendKeysPlugin';
+export { sendMousePlugin, SendMousePayload } from './sendMousePlugin';
 export { a11ySnapshotPlugin, A11ySnapshotPayload } from './a11ySnapshotPlugin';
 export { WriteFilePayload, ReadFilePayload, RemoveFilePayload, filePlugin } from './filePlugin';
 export { SaveSnapshotPayload, SnapshotPluginConfig, snapshotPlugin } from './snapshotPlugin';

--- a/packages/test-runner-commands/src/sendMousePlugin.ts
+++ b/packages/test-runner-commands/src/sendMousePlugin.ts
@@ -1,6 +1,7 @@
 import { TestRunnerPlugin } from '@web/test-runner-core';
 import type { ChromeLauncher } from '@web/test-runner-chrome';
 import type { PlaywrightLauncher } from '@web/test-runner-playwright';
+import type { WebdriverLauncher } from '@web/test-runner-webdriver';
 
 type MousePosition = [number, number];
 type MouseButton = 'left' | 'middle' | 'right';
@@ -102,6 +103,25 @@ export function sendMousePlugin(): TestRunnerPlugin<SendMousePayload> {
               return true;
             case 'up':
               await page.mouse.up({ button: payload.button });
+              return true;
+          }
+        }
+
+        // handle specific behavior for webdriver
+        if (session.browser.type === 'webdriver') {
+          const page = session.browser as WebdriverLauncher;
+          switch(payload.type) {
+            case 'move':
+              await page.sendMouseMove(session.id, payload.position[0], payload.position[1]);
+              return true;
+            case 'click':
+              await page.sendMouseClick(session.id, payload.position[0], payload.position[1], payload.button);
+              return true;
+            case 'down':
+              await page.sendMouseDown(session.id, payload.button);
+              return true;
+            case 'up':
+              await page.sendMouseUp(session.id, payload.button);
               return true;
           }
         }

--- a/packages/test-runner-commands/src/sendMousePlugin.ts
+++ b/packages/test-runner-commands/src/sendMousePlugin.ts
@@ -52,7 +52,8 @@ function isSendMousePayload(payload: unknown): payload is SendMousePayload {
       !Array.isArray(payload.position) ||
       typeof payload.position[0] !== 'number' ||
       typeof payload.position[1] !== 'number' ||
-      !/^\d+$/.test(payload.position.join(''))
+      !Number.isInteger(payload.position[0]) ||
+      !Number.isInteger(payload.position[1])
     ) {
       throw new Error(
         'You must provide a position option as a [x, y] tuple where x and y are integers.',

--- a/packages/test-runner-commands/src/sendMousePlugin.ts
+++ b/packages/test-runner-commands/src/sendMousePlugin.ts
@@ -1,0 +1,104 @@
+import { TestRunnerPlugin } from '@web/test-runner-core';
+import type { ChromeLauncher } from '@web/test-runner-chrome';
+import type { PlaywrightLauncher } from '@web/test-runner-playwright';
+
+export type SendMousePayload = MovePayload | ClickPayload | DownPayload | UpPayload;
+
+export type MovePayload = {
+  type: 'move',
+  position: [number, number]
+};
+
+export type ClickPayload = {
+  type: 'click',
+  position: [number, number],
+  // TODO: button: 'left' | 'right' | 'middle'
+}
+
+export type DownPayload = {
+  type: 'down',
+  // TODO: button: 'left' | 'right' | 'middle'
+}
+
+export type UpPayload = {
+  type: 'up',
+  // TODO: button: 'left' | 'right' | 'middle'
+}
+
+function isObject(payload: unknown): payload is Record<string, unknown> {
+  return payload != null && typeof payload === 'object';
+}
+
+function isSendMousePayload(payload: unknown): payload is SendMousePayload {
+  const validTypes = ['move', 'click', 'down', 'up'];
+
+  if (!isObject(payload)) {
+    throw new Error('You must provide a `SendMousePayload` object');
+  }
+
+  if (typeof payload.type !== 'string' || !validTypes.includes(payload.type)) {
+    throw new Error(`You must provide a type option with one of the following values: ${validTypes.join(', ')}.`);
+  }
+
+  if (['click', 'move'].includes(payload.type)) {
+    if (!Array.isArray(payload.position) || typeof payload.position[0] !== 'number' || typeof payload.position[1] !== 'number') {
+      throw new Error('You must provide a position option as a numerical [x, y] tuple.');
+    }
+  }
+
+  return true;
+}
+
+export function sendMousePlugin(): TestRunnerPlugin<SendMousePayload> {
+  return {
+    name: 'send-mouse-command',
+    async executeCommand({ command, payload, session }): Promise<any> {
+      if (command === 'send-mouse') {
+        if (!payload || !isSendMousePayload(payload)) {
+          throw new Error('You must provide a `SendMousePayload` object');
+        }
+
+        // handle specific behavior for playwright
+        if (session.browser.type === 'playwright') {
+          const page = (session.browser as PlaywrightLauncher).getPage(session.id);
+          switch(payload.type) {
+            case 'move':
+              await page.mouse.move(payload.position[0], payload.position[1]);
+              return true;
+            case 'click':
+              await page.mouse.click(payload.position[0], payload.position[1]);
+              return true;
+            case 'down':
+              await page.mouse.down();
+              return true;
+            case 'up':
+              await page.mouse.up();
+              return true;
+          }
+        }
+
+        // handle specific behavior for puppeteer
+        if (session.browser.type === 'puppeteer') {
+          const page = (session.browser as ChromeLauncher).getPage(session.id);
+          switch(payload.type) {
+            case 'move':
+              await page.mouse.move(payload.position[0], payload.position[1]);
+              return true;
+            case 'click':
+              await page.mouse.click(payload.position[0], payload.position[1]);
+              return true;
+            case 'down':
+              await page.mouse.down();
+              return true;
+            case 'up':
+              await page.mouse.up();
+              return true;
+          }
+        }
+
+        // you might not be able to support all browser launchers
+        throw new Error(`Sending mouse is not supported for browser type ${session.browser.type}.`);
+      }
+    },
+  };
+}

--- a/packages/test-runner-commands/src/sendMousePlugin.ts
+++ b/packages/test-runner-commands/src/sendMousePlugin.ts
@@ -9,25 +9,25 @@ type MouseButton = 'left' | 'middle' | 'right';
 export type SendMousePayload = MovePayload | ClickPayload | DownPayload | UpPayload;
 
 export type MovePayload = {
-  type: 'move',
-  position: MousePosition
+  type: 'move';
+  position: MousePosition;
 };
 
 export type ClickPayload = {
-  type: 'click',
-  position: MousePosition,
-  button?: MouseButton
-}
+  type: 'click';
+  position: MousePosition;
+  button?: MouseButton;
+};
 
 export type DownPayload = {
-  type: 'down',
-  button?: MouseButton
-}
+  type: 'down';
+  button?: MouseButton;
+};
 
 export type UpPayload = {
-  type: 'up',
-  button?: MouseButton
-}
+  type: 'up';
+  button?: MouseButton;
+};
 
 function isObject(payload: unknown): payload is Record<string, unknown> {
   return payload != null && typeof payload === 'object';
@@ -42,18 +42,31 @@ function isSendMousePayload(payload: unknown): payload is SendMousePayload {
   }
 
   if (typeof payload.type !== 'string' || !validTypes.includes(payload.type)) {
-    throw new Error(`You must provide a type option with one of the following values: ${validTypes.join(', ')}.`);
+    throw new Error(
+      `You must provide a type option with one of the following values: ${validTypes.join(', ')}.`,
+    );
   }
 
   if (['click', 'move'].includes(payload.type)) {
-    if (!Array.isArray(payload.position) || typeof payload.position[0] !== 'number' || typeof payload.position[1] !== 'number' || !/^\d+$/.test(payload.position.join(''))) {
-      throw new Error('You must provide a position option as a [x, y] tuple where x and y are integers.');
+    if (
+      !Array.isArray(payload.position) ||
+      typeof payload.position[0] !== 'number' ||
+      typeof payload.position[1] !== 'number' ||
+      !/^\d+$/.test(payload.position.join(''))
+    ) {
+      throw new Error(
+        'You must provide a position option as a [x, y] tuple where x and y are integers.',
+      );
     }
   }
 
   if (['click', 'up', 'down'].includes(payload.type)) {
     if (typeof payload.button === 'string' && !validButtons.includes(payload.button)) {
-      throw new Error(`The button option must be one of the following values when provided: ${validButtons.join(', ')}.`)
+      throw new Error(
+        `The button option must be one of the following values when provided: ${validButtons.join(
+          ', ',
+        )}.`,
+      );
     }
   }
 
@@ -72,12 +85,14 @@ export function sendMousePlugin(): TestRunnerPlugin<SendMousePayload> {
         // handle specific behavior for playwright
         if (session.browser.type === 'playwright') {
           const page = (session.browser as PlaywrightLauncher).getPage(session.id);
-          switch(payload.type) {
+          switch (payload.type) {
             case 'move':
               await page.mouse.move(payload.position[0], payload.position[1]);
               return true;
             case 'click':
-              await page.mouse.click(payload.position[0], payload.position[1], { button: payload.button });
+              await page.mouse.click(payload.position[0], payload.position[1], {
+                button: payload.button,
+              });
               return true;
             case 'down':
               await page.mouse.down({ button: payload.button });
@@ -91,12 +106,14 @@ export function sendMousePlugin(): TestRunnerPlugin<SendMousePayload> {
         // handle specific behavior for puppeteer
         if (session.browser.type === 'puppeteer') {
           const page = (session.browser as ChromeLauncher).getPage(session.id);
-          switch(payload.type) {
+          switch (payload.type) {
             case 'move':
               await page.mouse.move(payload.position[0], payload.position[1]);
               return true;
             case 'click':
-              await page.mouse.click(payload.position[0], payload.position[1], { button: payload.button });
+              await page.mouse.click(payload.position[0], payload.position[1], {
+                button: payload.button,
+              });
               return true;
             case 'down':
               await page.mouse.down({ button: payload.button });
@@ -110,12 +127,17 @@ export function sendMousePlugin(): TestRunnerPlugin<SendMousePayload> {
         // handle specific behavior for webdriver
         if (session.browser.type === 'webdriver') {
           const page = session.browser as WebdriverLauncher;
-          switch(payload.type) {
+          switch (payload.type) {
             case 'move':
               await page.sendMouseMove(session.id, payload.position[0], payload.position[1]);
               return true;
             case 'click':
-              await page.sendMouseClick(session.id, payload.position[0], payload.position[1], payload.button);
+              await page.sendMouseClick(
+                session.id,
+                payload.position[0],
+                payload.position[1],
+                payload.button,
+              );
               return true;
             case 'down':
               await page.sendMouseDown(session.id, payload.button);

--- a/packages/test-runner-commands/test/selenium-server.ts
+++ b/packages/test-runner-commands/test/selenium-server.ts
@@ -1,0 +1,21 @@
+import selenium from 'selenium-standalone';
+
+export async function startSeleniumServer(drivers: { [browser: string]: selenium.DriverOptions }) {
+  let server: selenium.ChildProcess;
+
+  try {
+    await selenium.install({ drivers });
+  } catch (err) {
+    console.error('Error occurred when installing selenium.');
+    throw err;
+  }
+
+  try {
+    server = await selenium.start({ drivers });
+  } catch (err) {
+    console.error('Error occurred when starting selenium.');
+    throw err;
+  }
+
+  return server;
+}

--- a/packages/test-runner-commands/test/send-mouse/browser-test.js
+++ b/packages/test-runner-commands/test/send-mouse/browser-test.js
@@ -69,9 +69,6 @@ describe('click', () => {
     spy = spyEvent();
     div.addEventListener('mousedown', spy);
     div.addEventListener('mouseup', spy);
-    div.addEventListener('contextmenu', event => {
-      event.preventDefault();
-    });
 
     [x, y] = getMiddleOfElement(div);
   });

--- a/packages/test-runner-commands/test/send-mouse/browser-test.js
+++ b/packages/test-runner-commands/test/send-mouse/browser-test.js
@@ -1,0 +1,123 @@
+import { sendMouse } from '../../browser/commands.mjs';
+import { expect } from '../chai.js';
+
+function spyEvent() {
+  const events = [];
+
+  const callback = event => events.push(event);
+  callback.getEvents = () => events;
+  callback.getLastEvent = () => events[events.length - 1];
+
+  return callback;
+}
+
+function getMiddleOfElement(element) {
+  const { top, left, width, height } = element.getBoundingClientRect();
+
+  return [left + window.pageXOffset + height / 2, top + window.pageYOffset + width / 2];
+}
+
+let div;
+
+before(() => {
+  document.body.style.display = 'flex';
+  document.body.style.alignItems = 'center';
+  document.body.style.justifyContent = 'center';
+  document.body.style.height = '100vh';
+
+  div = document.createElement('div');
+  div.style.width = '100px';
+  div.style.height = '100px';
+
+  document.body.appendChild(div);
+});
+
+describe('move', () => {
+  let spy;
+
+  beforeEach(() => {
+    spy = spyEvent();
+    document.addEventListener('mousemove', spy);
+  });
+
+  afterEach(() => {
+    document.removeEventListener('mousemove', spy);
+  });
+
+  it('can move mouse to a position', async () => {
+    const [x, y] = getMiddleOfElement(div);
+
+    await sendMouse({ type: 'move', position: [x, y] });
+
+    expect(spy.getLastEvent()).to.include({ pageX: x, pageY: y });
+  });
+});
+
+describe('click', () => {
+  let spy;
+
+  beforeEach(() => {
+    spy = spyEvent();
+    div.addEventListener('mousedown', spy);
+    div.addEventListener('mouseup', spy);
+    div.addEventListener('click', spy);
+  });
+
+  afterEach(() => {
+    div.addEventListener('mousedown', spy);
+    div.addEventListener('mouseup', spy);
+    div.addEventListener('click', spy);
+  });
+
+  it('can click mouse button', async () => {
+    const [x, y] = getMiddleOfElement(div);
+
+    await sendMouse({ type: 'click', position: [x, y] });
+
+    expect(spy.getEvents()).to.have.lengthOf(3);
+    expect(spy.getEvents()[0]).to.include({ type: 'mousedown', pageX: x, pageY: y });
+    expect(spy.getEvents()[1]).to.include({ type: 'mouseup', pageX: x, pageY: y });
+    expect(spy.getEvents()[2]).to.include({ type: 'click' });
+  });
+});
+
+describe('down and up', () => {
+  let spy, x, y;
+
+  beforeEach(async () => {
+    spy = spyEvent();
+    div.addEventListener('mousedown', spy);
+    div.addEventListener('mouseup', spy);
+    div.addEventListener('click', spy);
+
+    [x, y] = getMiddleOfElement(div);
+
+    await sendMouse({
+      type: 'move',
+      position: [x, y],
+    });
+  });
+
+  afterEach(() => {
+    div.addEventListener('mousedown', spy);
+    div.addEventListener('mouseup', spy);
+    div.addEventListener('click', spy);
+  });
+
+  it('can down mouse button', async () => {
+    await sendMouse({ type: 'down' });
+
+    expect(spy.getEvents()).to.have.lengthOf(1);
+    expect(spy.getEvents()[0]).to.include({ type: 'mousedown', pageX: x, pageY: y });
+  });
+
+  it('can down and up mouse button', async () => {
+    await sendMouse({ type: 'down' });
+    await sendMouse({ type: 'up' });
+
+    expect(spy.getEvents()).to.have.lengthOf(3);
+    expect(spy.getEvents()[0]).to.include({ type: 'mousedown', pageX: x, pageY: y });
+    expect(spy.getEvents()[1]).to.include({ type: 'mouseup', pageX: x, pageY: y });
+    expect(spy.getEvents()[2]).to.include({ type: 'click' });
+  });
+});

--- a/packages/test-runner-commands/test/send-mouse/browser-test.js
+++ b/packages/test-runner-commands/test/send-mouse/browser-test.js
@@ -54,7 +54,7 @@ describe('move', () => {
 describe('click', () => {
   let spy;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     spy = spyEvent();
     element.addEventListener('mousedown', spy);
     element.addEventListener('mouseup', spy);

--- a/packages/test-runner-commands/test/send-mouse/browser-test.js
+++ b/packages/test-runner-commands/test/send-mouse/browser-test.js
@@ -2,43 +2,34 @@ import { sendMouse } from '../../browser/commands.mjs';
 import { expect } from '../chai.js';
 
 function spyEvent() {
-  const events = [];
+  let events = [];
 
   const callback = event => events.push(event);
   callback.getEvents = () => events;
   callback.getLastEvent = () => events[events.length - 1];
+  callback.resetHistory = () => {
+    events = [];
+  };
 
   return callback;
 }
 
-function getMiddleOfElement(element) {
-  const { top, left, width, height } = element.getBoundingClientRect();
-
-  return [
-    Math.floor(left + window.pageXOffset + height / 2),
-    Math.floor(top + window.pageYOffset + width / 2),
-  ];
-}
-
-let div;
-
-before(() => {
-  document.body.style.display = 'flex';
-  document.body.style.alignItems = 'center';
-  document.body.style.justifyContent = 'center';
-  document.body.style.height = '100vh';
-});
+let element, x, y;
 
 beforeEach(() => {
-  div = document.createElement('div');
-  div.style.width = '100px';
-  div.style.height = '100px';
+  element = document.createElement('div');
+  element.style.width = '100px';
+  element.style.height = '100px';
+  element.style.margin = '100px';
 
-  document.body.appendChild(div);
+  x = 150; // Horizontal middle of the element.
+  y = 150; // Vertical middle of the element.
+
+  document.body.appendChild(element);
 });
 
 afterEach(() => {
-  document.body.removeChild(div);
+  element.remove();
 });
 
 describe('move', () => {
@@ -54,70 +45,63 @@ describe('move', () => {
   });
 
   it('can move mouse to a position', async () => {
-    const [x, y] = getMiddleOfElement(div);
-
     await sendMouse({ type: 'move', position: [x, y] });
 
-    expect(spy.getLastEvent()).to.include({ pageX: x, pageY: y });
+    expect(spy.getLastEvent()).to.include({ x, y });
   });
 });
 
 describe('click', () => {
-  let spy, x, y;
+  let spy;
 
   beforeEach(() => {
     spy = spyEvent();
-    div.addEventListener('mousedown', spy);
-    div.addEventListener('mouseup', spy);
+    element.addEventListener('mousedown', spy);
+    element.addEventListener('mouseup', spy);
 
-    [x, y] = getMiddleOfElement(div);
+    await sendMouse({ type: 'move', position: [0, 0] });
   });
 
   it('can click the left mouse button', async () => {
     await sendMouse({ type: 'click', position: [x, y], button: 'left' });
 
     expect(spy.getEvents()).to.have.lengthOf(2);
-    expect(spy.getEvents()[0]).to.include({ type: 'mousedown', button: 0, pageX: x, pageY: y });
-    expect(spy.getEvents()[1]).to.include({ type: 'mouseup', button: 0, pageX: x, pageY: y });
+    expect(spy.getEvents()[0]).to.include({ type: 'mousedown', button: 0, x, y });
+    expect(spy.getEvents()[1]).to.include({ type: 'mouseup', button: 0, x, y });
   });
 
   it('should click the left mouse button by default', async () => {
     await sendMouse({ type: 'click', position: [x, y] });
 
     expect(spy.getEvents()).to.have.lengthOf(2);
-    expect(spy.getEvents()[0]).to.include({ type: 'mousedown', button: 0, pageX: x, pageY: y });
-    expect(spy.getEvents()[1]).to.include({ type: 'mouseup', button: 0, pageX: x, pageY: y });
+    expect(spy.getEvents()[0]).to.include({ type: 'mousedown', button: 0, x, y });
+    expect(spy.getEvents()[1]).to.include({ type: 'mouseup', button: 0, x, y });
   });
 
   it('can click the middle mouse button', async () => {
     await sendMouse({ type: 'click', position: [x, y], button: 'middle' });
 
     expect(spy.getEvents()).to.have.lengthOf(2);
-    expect(spy.getEvents()[0]).to.include({ type: 'mousedown', button: 1, pageX: x, pageY: y });
-    expect(spy.getEvents()[1]).to.include({ type: 'mouseup', button: 1, pageX: x, pageY: y });
+    expect(spy.getEvents()[0]).to.include({ type: 'mousedown', button: 1, x, y });
+    expect(spy.getEvents()[1]).to.include({ type: 'mouseup', button: 1, x, y });
   });
 
   it('can click the right mouse button', async () => {
     await sendMouse({ type: 'click', position: [x, y], button: 'right' });
 
     expect(spy.getEvents()).to.have.lengthOf(2);
-    expect(spy.getEvents()[0]).to.include({ type: 'mousedown', button: 2, pageX: x, pageY: y });
-    expect(spy.getEvents()[1]).to.include({ type: 'mouseup', button: 2, pageX: x, pageY: y });
+    expect(spy.getEvents()[0]).to.include({ type: 'mousedown', button: 2, x, y });
+    expect(spy.getEvents()[1]).to.include({ type: 'mouseup', button: 2, x, y });
   });
 });
 
 describe('down and up', () => {
-  let spy, x, y;
+  let spy;
 
   beforeEach(async () => {
     spy = spyEvent();
-    div.addEventListener('mousedown', spy);
-    div.addEventListener('mouseup', spy);
-    div.addEventListener('contextmenu', event => {
-      event.preventDefault();
-    });
-
-    [x, y] = getMiddleOfElement(div);
+    element.addEventListener('mousedown', spy);
+    element.addEventListener('mouseup', spy);
 
     await sendMouse({ type: 'move', position: [x, y] });
   });
@@ -126,47 +110,51 @@ describe('down and up', () => {
     await sendMouse({ type: 'down', button: 'left' });
 
     expect(spy.getEvents()).to.have.lengthOf(1);
-    expect(spy.getEvents()[0]).to.include({ type: 'mousedown', button: 0, pageX: x, pageY: y });
+    expect(spy.getEvents()[0]).to.include({ type: 'mousedown', button: 0, x, y });
 
+    spy.resetHistory();
     await sendMouse({ type: 'up', button: 'left' });
 
-    expect(spy.getEvents()).to.have.lengthOf(2);
-    expect(spy.getEvents()[1]).to.include({ type: 'mouseup', button: 0, pageX: x, pageY: y });
+    expect(spy.getEvents()).to.have.lengthOf(1);
+    expect(spy.getEvents()[0]).to.include({ type: 'mouseup', button: 0, x, y });
   });
 
   it('should down and up the left mouse button by default', async () => {
     await sendMouse({ type: 'down' });
 
     expect(spy.getEvents()).to.have.lengthOf(1);
-    expect(spy.getEvents()[0]).to.include({ type: 'mousedown', button: 0, pageX: x, pageY: y });
+    expect(spy.getEvents()[0]).to.include({ type: 'mousedown', button: 0, x, y });
 
+    spy.resetHistory();
     await sendMouse({ type: 'up' });
 
-    expect(spy.getEvents()).to.have.lengthOf(2);
-    expect(spy.getEvents()[1]).to.include({ type: 'mouseup', button: 0, pageX: x, pageY: y });
+    expect(spy.getEvents()).to.have.lengthOf(1);
+    expect(spy.getEvents()[0]).to.include({ type: 'mouseup', button: 0, x, y });
   });
 
   it('can down and up the middle mouse button', async () => {
     await sendMouse({ type: 'down', button: 'middle' });
 
     expect(spy.getEvents()).to.have.lengthOf(1);
-    expect(spy.getEvents()[0]).to.include({ type: 'mousedown', button: 1, pageX: x, pageY: y });
+    expect(spy.getEvents()[0]).to.include({ type: 'mousedown', button: 1, x, y });
 
+    spy.resetHistory();
     await sendMouse({ type: 'up', button: 'middle' });
 
-    expect(spy.getEvents()).to.have.lengthOf(2);
-    expect(spy.getEvents()[1]).to.include({ type: 'mouseup', button: 1, pageX: x, pageY: y });
+    expect(spy.getEvents()).to.have.lengthOf(1);
+    expect(spy.getEvents()[0]).to.include({ type: 'mouseup', button: 1, x, y });
   });
 
   it('can down and up the right mouse button', async () => {
     await sendMouse({ type: 'down', button: 'right' });
 
     expect(spy.getEvents()).to.have.lengthOf(1);
-    expect(spy.getEvents()[0]).to.include({ type: 'mousedown', button: 2, pageX: x, pageY: y });
+    expect(spy.getEvents()[0]).to.include({ type: 'mousedown', button: 2, x, y });
 
+    spy.resetHistory();
     await sendMouse({ type: 'up', button: 'right' });
 
-    expect(spy.getEvents()).to.have.lengthOf(2);
-    expect(spy.getEvents()[1]).to.include({ type: 'mouseup', button: 2, pageX: x, pageY: y });
+    expect(spy.getEvents()).to.have.lengthOf(1);
+    expect(spy.getEvents()[0]).to.include({ type: 'mouseup', button: 2, x, y });
   });
 });

--- a/packages/test-runner-commands/test/send-mouse/browser-test.js
+++ b/packages/test-runner-commands/test/send-mouse/browser-test.js
@@ -16,6 +16,14 @@ function spyEvent() {
 
 let element, x, y;
 
+before(() => {
+  // The native context menu needs to be prevented from opening at least in WebKit
+  // where it doesn't get automatically closed that, in turn, blocks the next `mouseup` event.
+  document.addEventListener('contextmenu', event => {
+    event.preventDefault();
+  });
+});
+
 beforeEach(() => {
   element = document.createElement('div');
   element.style.width = '100px';

--- a/packages/test-runner-commands/test/send-mouse/sendMousePlugin.test.ts
+++ b/packages/test-runner-commands/test/send-mouse/sendMousePlugin.test.ts
@@ -1,0 +1,34 @@
+import path from 'path';
+import { platform } from 'os';
+import { runTests } from '@web/test-runner-core/test-helpers';
+import { chromeLauncher } from '@web/test-runner-chrome';
+import { playwrightLauncher } from '@web/test-runner-playwright';
+
+import { sendMousePlugin } from '../../src/sendMousePlugin';
+
+describe.only('sendMousePlugin', function test() {
+  this.timeout(20000);
+
+  it('can send mouse on puppeteer', async () => {
+    await runTests({
+      files: [path.join(__dirname, 'browser-test.js')],
+      browsers: [chromeLauncher()],
+      plugins: [sendMousePlugin()],
+    });
+  });
+
+  // playwright doesn't work on windows VM right now
+  if (platform() !== 'win32') {
+    it('can send mouse on playwright', async () => {
+      await runTests({
+        files: [path.join(__dirname, 'browser-test.js')],
+        browsers: [
+          playwrightLauncher({ product: 'chromium' }),
+          playwrightLauncher({ product: 'firefox' }),
+          playwrightLauncher({ product: 'webkit' }),
+        ],
+        plugins: [sendMousePlugin()],
+      });
+    });
+  }
+});

--- a/packages/test-runner-commands/test/send-mouse/sendMousePlugin.test.ts
+++ b/packages/test-runner-commands/test/send-mouse/sendMousePlugin.test.ts
@@ -41,7 +41,9 @@ describe('sendMousePlugin', function test() {
     });
 
     after(() => {
-      seleniumServer.kill();
+      if (seleniumServer) {
+        seleniumServer.kill();
+      }
     });
 
     it('can send mouse on webdriver', async () => {

--- a/packages/test-runner-commands/test/send-mouse/sendMousePlugin.test.ts
+++ b/packages/test-runner-commands/test/send-mouse/sendMousePlugin.test.ts
@@ -12,17 +12,6 @@ let seleniumServer: selenium.ChildProcess;
 describe('sendMousePlugin', function test() {
   this.timeout(50000);
 
-  before(async function () {
-    seleniumServer = await startSeleniumServer({
-      chrome: { version: '94.0.4606.41' },
-      firefox: { version: 'latest' },
-    });
-  });
-
-  after(() => {
-    seleniumServer.kill();
-  });
-
   it('can send mouse on puppeteer', async () => {
     await runTests({
       files: [path.join(__dirname, 'browser-test.js')],
@@ -44,6 +33,11 @@ describe('sendMousePlugin', function test() {
   });
 
   it('can send mouse on webdriver', async () => {
+    seleniumServer = await startSeleniumServer({
+      chrome: { version: '94.0.4606.41' },
+      firefox: { version: 'latest' },
+    });
+
     await runTests({
       files: [path.join(__dirname, 'browser-test.js')],
       concurrency: 1,
@@ -71,5 +65,7 @@ describe('sendMousePlugin', function test() {
       ],
       plugins: [sendMousePlugin()],
     });
+
+    seleniumServer.kill();
   });
 });

--- a/packages/test-runner-commands/test/send-mouse/sendMousePlugin.test.ts
+++ b/packages/test-runner-commands/test/send-mouse/sendMousePlugin.test.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import { platform } from 'os';
 import selenium from 'selenium-standalone';
 import { runTests } from '@web/test-runner-core/test-helpers';
 import { chromeLauncher } from '@web/test-runner-chrome';
@@ -11,7 +10,7 @@ import { startSeleniumServer } from '../selenium-server';
 let seleniumServer: selenium.ChildProcess;
 
 describe('sendMousePlugin', function test() {
-  this.timeout(20000);
+  this.timeout(50000);
 
   before(async function () {
     seleniumServer = await startSeleniumServer({
@@ -32,20 +31,17 @@ describe('sendMousePlugin', function test() {
     });
   });
 
-  // playwright doesn't work on windows VM right now
-  if (platform() !== 'win32') {
-    it('can send mouse on playwright', async () => {
-      await runTests({
-        files: [path.join(__dirname, 'browser-test.js')],
-        browsers: [
-          playwrightLauncher({ product: 'chromium' }),
-          playwrightLauncher({ product: 'firefox' }),
-          playwrightLauncher({ product: 'webkit' }),
-        ],
-        plugins: [sendMousePlugin()],
-      });
+  it('can send mouse on playwright', async () => {
+    await runTests({
+      files: [path.join(__dirname, 'browser-test.js')],
+      browsers: [
+        playwrightLauncher({ product: 'chromium' }),
+        playwrightLauncher({ product: 'firefox' }),
+        playwrightLauncher({ product: 'webkit' }),
+      ],
+      plugins: [sendMousePlugin()],
     });
-  }
+  });
 
   it('can send mouse on webdriver', async () => {
     await runTests({

--- a/packages/test-runner-commands/test/send-mouse/sendMousePlugin.test.ts
+++ b/packages/test-runner-commands/test/send-mouse/sendMousePlugin.test.ts
@@ -1,13 +1,28 @@
 import path from 'path';
 import { platform } from 'os';
+import selenium from 'selenium-standalone';
 import { runTests } from '@web/test-runner-core/test-helpers';
 import { chromeLauncher } from '@web/test-runner-chrome';
+import { webdriverLauncher } from '@web/test-runner-webdriver';
 import { playwrightLauncher } from '@web/test-runner-playwright';
-
 import { sendMousePlugin } from '../../src/sendMousePlugin';
+import { startSeleniumServer } from '../selenium-server';
 
-describe.only('sendMousePlugin', function test() {
+let seleniumServer: selenium.ChildProcess;
+
+describe('sendMousePlugin', function test() {
   this.timeout(20000);
+
+  before(async function () {
+    seleniumServer = await startSeleniumServer({
+      chrome: { version: 'latest' },
+      firefox: { version: 'latest' },
+    });
+  });
+
+  after(() => {
+    seleniumServer.kill();
+  });
 
   it('can send mouse on puppeteer', async () => {
     await runTests({
@@ -31,4 +46,34 @@ describe.only('sendMousePlugin', function test() {
       });
     });
   }
+
+  it.only('can send mouse on webdriver', async () => {
+    await runTests({
+      files: [path.join(__dirname, 'browser-test.js')],
+      concurrency: 1,
+      browsers: [
+        webdriverLauncher({
+          automationProtocol: 'webdriver',
+          path: '/wd/hub/',
+          capabilities: {
+            browserName: 'chrome',
+            'goog:chromeOptions': {
+              args: ['--no-sandbox', '--headless'],
+            },
+          },
+        }),
+        webdriverLauncher({
+          automationProtocol: 'webdriver',
+          path: '/wd/hub/',
+          capabilities: {
+            browserName: 'firefox',
+            'moz:firefoxOptions': {
+              args: ['-headless'],
+            },
+          },
+        }),
+      ],
+      plugins: [sendMousePlugin()]
+    });
+  });
 });

--- a/packages/test-runner-commands/test/send-mouse/sendMousePlugin.test.ts
+++ b/packages/test-runner-commands/test/send-mouse/sendMousePlugin.test.ts
@@ -47,7 +47,7 @@ describe('sendMousePlugin', function test() {
     });
   }
 
-  it.only('can send mouse on webdriver', async () => {
+  it('can send mouse on webdriver', async () => {
     await runTests({
       files: [path.join(__dirname, 'browser-test.js')],
       concurrency: 1,

--- a/packages/test-runner-commands/test/send-mouse/sendMousePlugin.test.ts
+++ b/packages/test-runner-commands/test/send-mouse/sendMousePlugin.test.ts
@@ -15,7 +15,7 @@ describe('sendMousePlugin', function test() {
 
   before(async function () {
     seleniumServer = await startSeleniumServer({
-      chrome: { version: 'latest' },
+      chrome: { version: '94.0.4606.41' },
       firefox: { version: 'latest' },
     });
   });

--- a/packages/test-runner-commands/test/send-mouse/sendMousePlugin.test.ts
+++ b/packages/test-runner-commands/test/send-mouse/sendMousePlugin.test.ts
@@ -7,8 +7,6 @@ import { playwrightLauncher } from '@web/test-runner-playwright';
 import { sendMousePlugin } from '../../src/sendMousePlugin';
 import { startSeleniumServer } from '../selenium-server';
 
-let seleniumServer: selenium.ChildProcess;
-
 describe('sendMousePlugin', function test() {
   this.timeout(50000);
 
@@ -32,40 +30,48 @@ describe('sendMousePlugin', function test() {
     });
   });
 
-  it('can send mouse on webdriver', async () => {
-    seleniumServer = await startSeleniumServer({
-      chrome: { version: '94.0.4606.41' },
-      firefox: { version: 'latest' },
+  describe('webdriver', () => {
+    let seleniumServer!: selenium.ChildProcess;
+
+    before(async () => {
+      seleniumServer = await startSeleniumServer({
+        chrome: { version: '96.0.4664.18' },
+        firefox: { version: 'latest' },
+      });
     });
 
-    await runTests({
-      files: [path.join(__dirname, 'browser-test.js')],
-      concurrency: 1,
-      browsers: [
-        webdriverLauncher({
-          automationProtocol: 'webdriver',
-          path: '/wd/hub/',
-          capabilities: {
-            browserName: 'chrome',
-            'goog:chromeOptions': {
-              args: ['--no-sandbox', '--headless'],
-            },
-          },
-        }),
-        webdriverLauncher({
-          automationProtocol: 'webdriver',
-          path: '/wd/hub/',
-          capabilities: {
-            browserName: 'firefox',
-            'moz:firefoxOptions': {
-              args: ['-headless'],
-            },
-          },
-        }),
-      ],
-      plugins: [sendMousePlugin()],
+    after(() => {
+      seleniumServer.kill();
     });
 
-    seleniumServer.kill();
+    it('can send mouse on webdriver', async () => {
+      await runTests({
+        files: [path.join(__dirname, 'browser-test.js')],
+        concurrency: 1,
+        browsers: [
+          webdriverLauncher({
+            automationProtocol: 'webdriver',
+            path: '/wd/hub/',
+            capabilities: {
+              browserName: 'chrome',
+              'goog:chromeOptions': {
+                args: ['--no-sandbox', '--headless'],
+              },
+            },
+          }),
+          webdriverLauncher({
+            automationProtocol: 'webdriver',
+            path: '/wd/hub/',
+            capabilities: {
+              browserName: 'firefox',
+              'moz:firefoxOptions': {
+                args: ['-headless'],
+              },
+            },
+          }),
+        ],
+        plugins: [sendMousePlugin()],
+      });
+    });
   });
 });

--- a/packages/test-runner-commands/test/send-mouse/sendMousePlugin.test.ts
+++ b/packages/test-runner-commands/test/send-mouse/sendMousePlugin.test.ts
@@ -73,7 +73,7 @@ describe('sendMousePlugin', function test() {
           },
         }),
       ],
-      plugins: [sendMousePlugin()]
+      plugins: [sendMousePlugin()],
     });
   });
 });

--- a/packages/test-runner-webdriver/src/IFrameManager.ts
+++ b/packages/test-runner-webdriver/src/IFrameManager.ts
@@ -157,7 +157,9 @@ export class IFrameManager {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async performActions(_: string, _actions: object[]) {
-    console.warn('Device actions are not supported in the concurrent mode.');
+    console.warn(
+      'Unsupported operation. In order to use device actions in Webdriver, set "concurrency" to 1.',
+    );
   }
 
   async takeScreenshot(sessionId: string, locator: string): Promise<Buffer> {

--- a/packages/test-runner-webdriver/src/IFrameManager.ts
+++ b/packages/test-runner-webdriver/src/IFrameManager.ts
@@ -157,7 +157,9 @@ export class IFrameManager {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async performActions(_: string, _actions: object[]) {
-    throw new Error('Unsupported operation. In order to use device actions in Webdriver, set "concurrency" to 1.');
+    throw new Error(
+      'Unsupported operation. In order to use device actions in Webdriver, set "concurrency" to 1.',
+    );
   }
 
   async takeScreenshot(sessionId: string, locator: string): Promise<Buffer> {

--- a/packages/test-runner-webdriver/src/IFrameManager.ts
+++ b/packages/test-runner-webdriver/src/IFrameManager.ts
@@ -155,6 +155,11 @@ export class IFrameManager {
     return this.driver.keys(keys);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async performActions(_: string, _actions: object[]) {
+    console.warn('Device actions are not supported in the concurrent mode.');
+  }
+
   async takeScreenshot(sessionId: string, locator: string): Promise<Buffer> {
     const frameId = this.getFrameId(sessionId);
 

--- a/packages/test-runner-webdriver/src/IFrameManager.ts
+++ b/packages/test-runner-webdriver/src/IFrameManager.ts
@@ -157,9 +157,7 @@ export class IFrameManager {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async performActions(_: string, _actions: object[]) {
-    console.warn(
-      'Unsupported operation. In order to use device actions in Webdriver, set "concurrency" to 1.',
-    );
+    throw new Error('Unsupported operation. In order to use device actions in Webdriver, set "concurrency" to 1.');
   }
 
   async takeScreenshot(sessionId: string, locator: string): Promise<Buffer> {

--- a/packages/test-runner-webdriver/src/SessionManager.ts
+++ b/packages/test-runner-webdriver/src/SessionManager.ts
@@ -80,6 +80,10 @@ export class SessionManager {
     return { testCoverage: this.config.coverage ? testCoverage : undefined };
   }
 
+  async performActions(_: string, actions: object[]) {
+    return this.driver.performActions(actions);
+  }
+
   async sendKeys(_: string, keys: string[]) {
     return this.driver.keys(keys);
   }

--- a/packages/test-runner-webdriver/src/webdriverLauncher.ts
+++ b/packages/test-runner-webdriver/src/webdriverLauncher.ts
@@ -4,6 +4,19 @@ import { IFrameManager } from './IFrameManager';
 import { SessionManager } from './SessionManager';
 import { getBrowserLabel } from './utils';
 
+type MouseButton = 'left' | 'middle' | 'right';
+
+function getMouseButtonCode(button: MouseButton) {
+  switch(button) {
+    case 'left':
+      return 0;
+    case 'middle':
+      return 1;
+    case 'right':
+      return 2;
+  }
+}
+
 export class WebdriverLauncher implements BrowserLauncher {
   public name = 'Initializing...';
   public type = 'webdriver';
@@ -122,6 +135,78 @@ export class WebdriverLauncher implements BrowserLauncher {
         }
       }
     }, 60000);
+  }
+
+  sendMouseMove(sessionId: string, x: number, y: number) {
+    if (!this.driverManager) {
+      throw new Error('Not initialized');
+    }
+
+    return this.driverManager.performActions(sessionId, [
+      {
+        type: 'pointer',
+        id: 'finger1',
+        actions: [
+          { type: 'pointerMove', duration: 0, x, y }
+        ]
+      }
+    ]);
+  }
+
+  sendMouseClick(sessionId: string, x: number, y: number, button: MouseButton = 'left') {
+    if (!this.driverManager) {
+      throw new Error('Not initialized');
+    }
+
+    const buttonCode = getMouseButtonCode(button);
+
+    return this.driverManager.performActions(sessionId, [
+      {
+        type: 'pointer',
+        id: 'finger1',
+        actions: [
+          { type: 'pointerMove', duration: 0, x, y },
+          { type: 'pointerDown', button: buttonCode },
+          { type: 'pointerUp', button: buttonCode }
+        ]
+      }
+    ]);
+  }
+
+  sendMouseDown(sessionId: string, button: MouseButton = 'left') {
+    if (!this.driverManager) {
+      throw new Error('Not initialized');
+    }
+
+    const buttonCode = getMouseButtonCode(button);
+
+    return this.driverManager.performActions(sessionId, [
+      {
+        type: 'pointer',
+        id: 'finger1',
+        actions: [
+          { type: 'pointerDown', button: buttonCode }
+        ]
+      }
+    ]);
+  }
+
+  sendMouseUp(sessionId: string, button: MouseButton = 'left') {
+    if (!this.driverManager) {
+      throw new Error('Not initialized');
+    }
+
+    const buttonCode = getMouseButtonCode(button);
+
+    return this.driverManager.performActions(sessionId, [
+      {
+        type: 'pointer',
+        id: 'finger1',
+        actions: [
+          { type: 'pointerUp', button: buttonCode }
+        ]
+      }
+    ])
   }
 
   sendKeys(sessionId: string, keys: string[]) {

--- a/packages/test-runner-webdriver/src/webdriverLauncher.ts
+++ b/packages/test-runner-webdriver/src/webdriverLauncher.ts
@@ -7,7 +7,7 @@ import { getBrowserLabel } from './utils';
 type MouseButton = 'left' | 'middle' | 'right';
 
 function getMouseButtonCode(button: MouseButton) {
-  switch(button) {
+  switch (button) {
     case 'left':
       return 0;
     case 'middle':
@@ -146,10 +146,8 @@ export class WebdriverLauncher implements BrowserLauncher {
       {
         type: 'pointer',
         id: 'finger1',
-        actions: [
-          { type: 'pointerMove', duration: 0, x, y }
-        ]
-      }
+        actions: [{ type: 'pointerMove', duration: 0, x, y }],
+      },
     ]);
   }
 
@@ -167,9 +165,9 @@ export class WebdriverLauncher implements BrowserLauncher {
         actions: [
           { type: 'pointerMove', duration: 0, x, y },
           { type: 'pointerDown', button: buttonCode },
-          { type: 'pointerUp', button: buttonCode }
-        ]
-      }
+          { type: 'pointerUp', button: buttonCode },
+        ],
+      },
     ]);
   }
 
@@ -184,10 +182,8 @@ export class WebdriverLauncher implements BrowserLauncher {
       {
         type: 'pointer',
         id: 'finger1',
-        actions: [
-          { type: 'pointerDown', button: buttonCode }
-        ]
-      }
+        actions: [{ type: 'pointerDown', button: buttonCode }],
+      },
     ]);
   }
 
@@ -202,11 +198,9 @@ export class WebdriverLauncher implements BrowserLauncher {
       {
         type: 'pointer',
         id: 'finger1',
-        actions: [
-          { type: 'pointerUp', button: buttonCode }
-        ]
-      }
-    ])
+        actions: [{ type: 'pointerUp', button: buttonCode }],
+      },
+    ]);
   }
 
   sendKeys(sessionId: string, keys: string[]) {


### PR DESCRIPTION
## What I did

- [x] Introduced a new command `sendMouse`.
- [x] Added basic unit tests.
- [x] Added support for Playwright.
- [x] Added support for Puppeteer.
- [x] Added support for WebDriver.
- [x] Make unit tests work in Playwright Webkit.
- [x] Make unit tests work in Windows Chrome.

## Command API

### Move
```ts
function sendMouse(payload: {
  type: 'move',
  position: [number, number]
}): Promise<void>;
```

### Click
```ts
function sendMouse(payload: {
  type: 'click',
  position: [number, number],
  button?: 'left' | 'middle' | 'right'
}): Promise<void>;
```

### Down
```ts
function sendMouse(payload: {
  type: 'down',
  button?: 'left' | 'middle' | 'right'
}): Promise<void>;
```

### Up
```ts
function sendMouse(payload: {
  type: 'up',
  button?: 'left' | 'middle' | 'right'
}): Promise<void>;
```

## Future improvements

It is possible to extend the command's API in the future to also support sending a sequence of mouse actions, e.g.:

```js
await sendMouse([
  { type: 'move', position: [100, 100] },
  { type: 'move', position: [200, 200] }
]);
```