### PR TITLE
Update createPolyfillsLoader.ts

### DIFF
--- a/packages/polyfills-loader/src/createPolyfillsLoader.ts
+++ b/packages/polyfills-loader/src/createPolyfillsLoader.ts
@@ -18,7 +18,10 @@ import path from 'path';
  * because Promise might not be loaded yet
  */
 const loadScriptFunction = `
-  function loadScript(src, type, attributes = []) {
+  function loadScript(src, type, attributes) {
+    if(attributes == null){
+       attributes = [];
+    }
     return new Promise(function (resolve) {
       var script = document.createElement('script');
       function onLoaded() {
@@ -29,7 +32,7 @@ const loadScriptFunction = `
       }
       script.src = src;
       script.onload = onLoaded;
-      attributes.forEach(att => {
+      attributes.forEach(function(att) {
         script.setAttribute(att.name, att.value);
       });
       script.onerror = function () {


### PR DESCRIPTION
## What I did

1. I have changed the code from ES6 to a more native javascript approach mainly since these polyfills are used for older browsers who do not support arrow functions and declared parameters
