### PR TITLE
docs: fix typos in write your own test framework page

### DIFF
--- a/docs/docs/test-runner/test-frameworks/write-your-own.md
+++ b/docs/docs/test-runner/test-frameworks/write-your-own.md
@@ -1,6 +1,6 @@
 # Test Runner >> Test Frameworks >> Write Your Own ||20
 
-You can Write Your Own test framework for web test runner by wrap an existing testing framework or create a specific once for your project.
+You can Write Your Own test framework for web test runner by wrapping an existing testing framework or create a specific one for your project.
 
 This is a minimal example:
 

--- a/docs/docs/test-runner/test-frameworks/write-your-own.md
+++ b/docs/docs/test-runner/test-frameworks/write-your-own.md
@@ -1,6 +1,6 @@
 # Test Runner >> Test Frameworks >> Write Your Own ||20
 
-You can Write Your Own test framework for web test runner by wrapping an existing testing framework or create a specific one for your project.
+You can Write Your Own test framework for web test runner by wrapping an existing testing framework or creating a specific one for your project.
 
 This is a minimal example:
 


### PR DESCRIPTION

## What I did

1. this commit fixes two small typos in the first line of the page:
- 'wrap' to 'wrapping'
- 'once' to 'one'

