### PR TITLE
fix: support rollup plugins in manager.js

### DIFF
--- a/packages/dev-server-storybook/src/build/build.ts
+++ b/packages/dev-server-storybook/src/build/build.ts
@@ -50,12 +50,16 @@ interface BuildmanagerParams {
 
 async function buildManager(params: BuildmanagerParams) {
   const managerHtml = createManagerHtml(params.storybookConfig, params.rootDir);
-  const config = createRollupConfig({
+  let config = createRollupConfig({
     type: params.type,
     outputDir: params.outputDir,
     indexFilename: 'index.html',
     indexHtmlString: managerHtml,
   });
+
+  if (storybookConfig.mainJs.rollupConfig) {
+    config = (await params.storybookConfig.mainJs.rollupConfig(config)) ?? config;
+  }
 
   await buildAndWrite(config);
 }


### PR DESCRIPTION
## What I did

I noticed that running `build-storybook` was not reading in the rollup image plugin necessary for theme.js to load a brand image.  No issues with this in the `web-dev-server` command for running the local preview.  This adds processing for the rollup plugins for the manager assets as well.
