### PR TITLE
feat: allows the use of exclusion patterns in files globs

### DIFF
--- a/.changeset/breezy-apples-deny.md
+++ b/.changeset/breezy-apples-deny.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-core': patch
+---
+
+Allows the use of exclusion patterns in files globs

--- a/packages/test-runner-core/src/runner/collectTestFiles.ts
+++ b/packages/test-runner-core/src/runner/collectTestFiles.ts
@@ -2,15 +2,8 @@ import globby from 'globby';
 import path from 'path';
 
 export function collectTestFiles(patterns: string | string[], baseDir = process.cwd()) {
-  const testFiles = new Set<string>();
+  // @ts-ignore
+  const filePatterns = [].concat(patterns).map(pattern => pattern.split(path.sep).join('/'));
 
-  for (const pattern of Array.isArray(patterns) ? patterns : [patterns]) {
-    const normalizedPattern = pattern.split(path.sep).join('/');
-    const foundFiles = globby.sync(normalizedPattern, { cwd: baseDir, absolute: true });
-    for (const file of foundFiles) {
-      testFiles.add(file);
-    }
-  }
-
-  return Array.from(testFiles);
+  return globby.sync(filePatterns, { cwd: baseDir, absolute: true });
 }


### PR DESCRIPTION
## What I did

1. I changed the way collectTestFiles process the globs to allow the use of exclusion patterns.

Fixes #368 
