### PR TITLE
[test-runner-junit-reporter] Add filepaths and line numbers to output

### DIFF
--- a/.changeset/hot-ladybugs-tan.md
+++ b/.changeset/hot-ladybugs-tan.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-core': patch
+---
+
+Adds limited reporter support to test-helpers

--- a/.changeset/long-adults-compare.md
+++ b/.changeset/long-adults-compare.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-junit-reporter': patch
+---
+
+Adds file and line number support to junit reporter

--- a/.github/workflows/verify-windows.yml
+++ b/.github/workflows/verify-windows.yml
@@ -29,5 +29,9 @@ jobs:
       - name: Build
         run: yarn build
 
+      # build for production in CI to make sure tests can run with production build
+      - name: Build for production
+        run: yarn build:production
+
       - name: Test
         run: yarn test

--- a/packages/test-runner-core/src/test-helpers.ts
+++ b/packages/test-runner-core/src/test-helpers.ts
@@ -65,7 +65,25 @@ export async function runTests(
     // });
 
     let finished = false;
-    runner.on('finished', () => {
+
+    runner.on('test-run-finished', ({ testRun, testCoverage }) => {
+      for (const reporter of finalConfig.reporters) {
+        reporter.onTestRunFinished?.({
+          testRun,
+          sessions: Array.from(runner.sessions.all()),
+          testCoverage,
+          focusedTestFile: runner.focusedTestFile,
+        });
+      }
+    });
+
+    runner.on('finished', async () => {
+      for (const reporter of finalConfig.reporters) {
+        await reporter.stop?.({
+          sessions: Array.from(runner.sessions.all()),
+          focusedTestFile: runner.focusedTestFile,
+        });
+      }
       finished = true;
       runner.stop();
     });

--- a/packages/test-runner-junit-reporter/src/junitReporter.ts
+++ b/packages/test-runner-junit-reporter/src/junitReporter.ts
@@ -171,7 +171,7 @@ function testCaseXMLAttributes(
 
   const classname = getSuiteName(test);
 
-  const file = getTestFile(test).replace(`${rootDir}/`, '');
+  const file = getTestFile(test).replace(`${rootDir}${path.sep}`, '');
 
   const [, line] = stripXMLInvalidChars(test.error?.stack ?? '').match(/(\d+):\d+/m) ?? [];
 
@@ -252,7 +252,7 @@ function testSuitePropertiesXMLElement(
       property: {
         _attr: {
           name: 'test.fileName',
-          value: testFile.replace(`${rootDir}/`, ''),
+          value: testFile.replace(`${rootDir}${path.sep}`, ''),
         },
       },
     },

--- a/packages/test-runner-junit-reporter/src/junitReporter.ts
+++ b/packages/test-runner-junit-reporter/src/junitReporter.ts
@@ -8,6 +8,8 @@ import XML from 'xml';
 export interface JUnitReporterArgs {
   outputPath?: string;
   reportLogs?: boolean;
+  /* package root dir. defaults to cwd */
+  rootDir?: string;
 }
 
 type TestSessionMetadata = Omit<TestSession, 'tests'>;
@@ -29,6 +31,8 @@ interface TestCaseXMLAttributes {
   _attr: {
     name: string;
     time: number;
+    file: string;
+    line?: string;
     classname: string;
   };
 }
@@ -110,9 +114,13 @@ const isSkippedTest = (test: TestResult): boolean => !!test.skipped;
 const addSuiteTime = (time: number, test: TestResultWithMetadata) =>
   time + (test.duration || 0) / 1000;
 
-const getTestName = (test: TestResultWithMetadata): string => test.name;
+type TestMetaGetter<T = string> = (test: TestResultWithMetadata) => T;
 
-const getSuiteName = (test: TestResultWithMetadata): string => test.suiteName;
+const getTestName: TestMetaGetter = test => test.name;
+
+const getSuiteName: TestMetaGetter = test => test.suiteName;
+
+const getTestFile: TestMetaGetter = test => test.testFile;
 
 const getTestDurationInSeconds = ({ duration }: TestResult): number =>
   (typeof duration === 'undefined' ? 0 : duration) / 1000;
@@ -124,6 +132,9 @@ const getTestDurationInSeconds = ({ duration }: TestResult): number =>
 const INVALID_CHARACTERS_REGEX =
   // eslint-disable-next-line no-control-regex
   /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007f-\u0084\u0086-\u009f\uD800-\uDFFF\uFDD0-\uFDFF\uFFFF\uC008]/g;
+
+const STACK_TRACE_UNIQUE_IDS_REGEX =
+  /localhost:\d+|wtr-session-id=[\w\d]+-[\w\d]+-[\w\d]+-[\w\d]+-[\w\d]+|/g;
 
 const stripXMLInvalidChars = (x: string): string =>
   x && x.replace ? x.replace(INVALID_CHARACTERS_REGEX, '') : x;
@@ -138,11 +149,11 @@ function testFailureXMLElement(test: TestResultWithMetadata): TestFailureXMLElem
 
   const stack = stripXMLInvalidChars(error?.stack ?? '');
 
-  const type = stack.match(/^\w+Error:/) ? stack.split(':')[0] : '';
+  const type = error?.name ?? (stack.match(/^\w+Error:/) ? stack.split(':')[0] : '');
 
   return {
     _attr: { message, type },
-    _cdata: stack || message || undefined,
+    _cdata: `${type}: ${message}\n${stack}`.replace(STACK_TRACE_UNIQUE_IDS_REGEX, ''),
   };
 }
 
@@ -150,18 +161,27 @@ function testFailureXMLElement(test: TestResultWithMetadata): TestFailureXMLElem
  * Makes attributes for a `<testcase>` element
  * @param test Test Result
  */
-function testCaseXMLAttributes(test: TestResultWithMetadata): TestCaseXMLAttributes {
+function testCaseXMLAttributes(
+  test: TestResultWithMetadata,
+  rootDir: string,
+): TestCaseXMLAttributes {
   const name = getTestName(test);
 
   const time = getTestDurationInSeconds(test);
 
   const classname = getSuiteName(test);
 
+  const file = getTestFile(test).replace(`${rootDir}/`, '');
+
+  const [, line] = stripXMLInvalidChars(test.error?.stack ?? '').match(/(\d+):\d+/m) ?? [];
+
   return {
     _attr: {
       name,
       time,
       classname,
+      file,
+      ...(!!line && { line }),
     },
   };
 }
@@ -169,8 +189,8 @@ function testCaseXMLAttributes(test: TestResultWithMetadata): TestCaseXMLAttribu
 /**
  * Makes a `<testcase>` element
  */
-function testCaseXMLElement(test: TestResultWithMetadata): TestCaseXMLElement {
-  const attributes = testCaseXMLAttributes(test);
+function testCaseXMLElement(test: TestResultWithMetadata, rootDir: string): TestCaseXMLElement {
+  const attributes = testCaseXMLAttributes(test, rootDir);
 
   // prettier-ignore
   if (isSkippedTest(test))
@@ -225,13 +245,14 @@ function testSuitePropertiesXMLElement(
   testFile: string,
   browserName: string,
   launcherType: string,
+  rootDir: string,
 ): TestSuitePropertiesXMLElement[] {
   return [
     {
       property: {
         _attr: {
           name: 'test.fileName',
-          value: testFile,
+          value: testFile.replace(`${rootDir}/`, ''),
         },
       },
     },
@@ -259,7 +280,15 @@ function testSuitePropertiesXMLElement(
  * then stringifies the XML.
  * @param sessions Test Sessions
  */
-function getTestRunXML(sessions: TestSession[], reportLogs: boolean): string {
+function getTestRunXML({
+  reportLogs,
+  rootDir,
+  sessions,
+}: {
+  sessions: TestSession[];
+  reportLogs: boolean;
+  rootDir: string;
+}): string {
   const testsuites = Object.entries(
     sessions
       .flatMap(assignSessionAndSuitePropertiesToTests)
@@ -276,9 +305,9 @@ function getTestRunXML(sessions: TestSession[], reportLogs: boolean): string {
 
     const attributes = testSuiteXMLAttributes(name, testRun, tests);
 
-    const properties = testSuitePropertiesXMLElement(testFile, browserName, launcherType);
+    const properties = testSuitePropertiesXMLElement(testFile, browserName, launcherType, rootDir);
 
-    const testcases = tests.map(testCaseXMLElement);
+    const testcases = tests.map(t => testCaseXMLElement(t, rootDir));
 
     const systemOut = !reportLogs ? [] : tests.flatMap(escapeLogs).map(x => ({ 'system-out': x }));
 
@@ -298,13 +327,14 @@ function getTestRunXML(sessions: TestSession[], reportLogs: boolean): string {
 export function junitReporter({
   outputPath = './test-results.xml',
   reportLogs = false,
+  rootDir = process.cwd(),
 }: JUnitReporterArgs = {}): Reporter {
+  const filepath = path.resolve(rootDir, outputPath);
+  const dir = path.dirname(filepath);
   return {
     onTestRunFinished({ sessions }) {
-      const filepath = path.resolve(process.cwd(), outputPath);
-      const dir = path.dirname(filepath);
-      const xml = getTestRunXML(sessions, reportLogs);
-      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      const xml = getTestRunXML({ reportLogs, rootDir, sessions });
+      fs.mkdirSync(dir, { recursive: true });
       fs.writeFileSync(filepath, xml);
     },
   };

--- a/packages/test-runner-junit-reporter/test/fixtures/multiple/expected.xml
+++ b/packages/test-runner-junit-reporter/test/fixtures/multiple/expected.xml
@@ -1,30 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="Chrome_puppeteer_/test/fixtures/multiple/nested-test.js" id="0" tests="1" skipped="0" errors="0" failures="0" time="0.001">
+  <testsuite name="Chrome_puppeteer_/packages/test-runner-junit-reporter/test/fixtures/multiple/nested-test.js" id="0" tests="1" skipped="0" errors="0" failures="0" time="0.001">
     <properties>
-      <property name="test.fileName" value="<<cwd>>/packages/test-runner-junit-reporter/test/fixtures/multiple/nested-test.js"/>
+      <property name="test.fileName" value="packages/test-runner-junit-reporter/test/fixtures/multiple/nested-test.js"/>
       <property name="browser.name" value="Chrome"/>
       <property name="browser.launcher" value="puppeteer"/>
-      <property name="browser.userAgent" value="<<useragent>>"/>
     </properties>
-    <testcase name="is equivalent to map (f.g) f a" time="<<computed>>" classname="given a functor f and a function a -&gt; b map f map g f a"/>
+    <testcase name="is equivalent to map (f.g) f a" time="<<computed>>" classname="given a functor f and a function a -&gt; b map f map g f a" file="packages/test-runner-junit-reporter/test/fixtures/multiple/nested-test.js"/>
   </testsuite>
-  <testsuite name="Chrome_puppeteer_/test/fixtures/multiple/simple-test.js" id="0" tests="5" skipped="1" errors="1" failures="1" time="0.001">
+  <testsuite name="Chrome_puppeteer_/packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js" id="0" tests="5" skipped="1" errors="1" failures="1" time="0.001">
     <properties>
-      <property name="test.fileName" value="<<cwd>>/packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js"/>
+      <property name="test.fileName" value="packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js"/>
       <property name="browser.name" value="Chrome"/>
       <property name="browser.launcher" value="puppeteer"/>
-      <property name="browser.userAgent" value="<<useragent>>"/>
     </properties>
-    <testcase name="under addition" time="0.001" classname="real numbers forming a monoid"/>
-    <testcase name="null hypothesis" time="0.001" classname="off-by-one boolean logic errors"/>
-    <testcase name="asserts error" time="0.001" classname="off-by-one boolean logic errors">
+    <testcase name="under addition" time="0.001" classname="real numbers forming a monoid" file="packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js"/>
+    <testcase name="null hypothesis" time="0.001" classname="off-by-one boolean logic errors" file="packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js"/>
+    <testcase name="asserts error" time="0.001" classname="off-by-one boolean logic errors" file="packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js" line="15">
       <failure message="expected false to be true" type="AssertionError"><![CDATA[AssertionError: expected false to be true
-    at Context.<anonymous> (packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js?<<unique>>:15:29)]]></failure>
+  at o.<anonymous> (packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js:15:29)]]></failure>
     </testcase>
-    <testcase name="tbd: confirm true positive" time="0" classname="off-by-one boolean logic errors">
+    <testcase name="tbd: confirm true positive" time="0" classname="off-by-one boolean logic errors" file="packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js">
       <skipped/>
     </testcase>
-    <testcase name="reports logs to JUnit" time="0.001" classname="logging during a test"/>
+    <testcase name="reports logs to JUnit" time="0.001" classname="logging during a test" file="packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js"/>
   </testsuite>
 </testsuites>

--- a/packages/test-runner-junit-reporter/test/fixtures/nested/expected.xml
+++ b/packages/test-runner-junit-reporter/test/fixtures/nested/expected.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="Chrome_puppeteer_/test/fixtures/nested/nested-test.js" id="0" tests="1" skipped="0" errors="0" failures="0" time="0.001">
+  <testsuite name="Chrome_puppeteer_/packages/test-runner-junit-reporter/test/fixtures/nested/nested-test.js" id="0" tests="1" skipped="0" errors="0" failures="0" time="0.001">
     <properties>
-      <property name="test.fileName" value="<<cwd>>/packages/test-runner-junit-reporter/test/fixtures/nested/nested-test.js"/>
+      <property name="test.fileName" value="packages/test-runner-junit-reporter/test/fixtures/nested/nested-test.js"/>
       <property name="browser.name" value="Chrome"/>
       <property name="browser.launcher" value="puppeteer"/>
-      <property name="browser.userAgent" value="<<useragent>>"/>
     </properties>
-    <testcase name="is equivalent to map (f.g) f a" time="<<computed>>" classname="given a functor f and a function a -&gt; b map f map g f a"/>
+    <testcase name="is equivalent to map (f.g) f a" time="<<computed>>" classname="given a functor f and a function a -&gt; b map f map g f a" file="packages/test-runner-junit-reporter/test/fixtures/nested/nested-test.js"/>
   </testsuite>
 </testsuites>

--- a/packages/test-runner-junit-reporter/test/fixtures/simple/expected.xml
+++ b/packages/test-runner-junit-reporter/test/fixtures/simple/expected.xml
@@ -1,21 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="Chrome_puppeteer_/test/fixtures/simple/simple-test.js" id="0" tests="5" skipped="1" errors="1" failures="1" time="0.001">
+  <testsuite name="Chrome_puppeteer_/packages/test-runner-junit-reporter/test/fixtures/simple/simple-test.js" id="0" tests="6" skipped="1" errors="2" failures="2" time="0.001">
     <properties>
-      <property name="test.fileName" value="<<cwd>>/packages/test-runner-junit-reporter/test/fixtures/simple/simple-test.js"/>
+      <property name="test.fileName" value="packages/test-runner-junit-reporter/test/fixtures/simple/simple-test.js"/>
       <property name="browser.name" value="Chrome"/>
       <property name="browser.launcher" value="puppeteer"/>
-      <property name="browser.userAgent" value="<<useragent>>"/>
     </properties>
-    <testcase name="under addition" time="0.001" classname="real numbers forming a monoid"/>
-    <testcase name="null hypothesis" time="0.001" classname="off-by-one boolean logic errors"/>
-    <testcase name="asserts error" time="0.001" classname="off-by-one boolean logic errors">
+    <testcase name="under addition" time="0.001" classname="real numbers forming a monoid" file="packages/test-runner-junit-reporter/test/fixtures/simple/simple-test.js"/>
+    <testcase name="null hypothesis" time="0.001" classname="off-by-one boolean logic errors" file="packages/test-runner-junit-reporter/test/fixtures/simple/simple-test.js"/>
+    <testcase name="asserts error" time="0.001" classname="off-by-one boolean logic errors" file="packages/test-runner-junit-reporter/test/fixtures/simple/simple-test.js" line="17">
       <failure message="expected false to be true" type="AssertionError"><![CDATA[AssertionError: expected false to be true
-    at Context.<anonymous> (packages/test-runner-junit-reporter/test/fixtures/simple/simple-test.js?<<unique>>:15:29)]]></failure>
+  at o.<anonymous> (packages/test-runner-junit-reporter/test/fixtures/simple/simple-test.js:17:29)]]></failure>
     </testcase>
-    <testcase name="tbd: confirm true positive" time="0" classname="off-by-one boolean logic errors">
+    <testcase name="tbd: confirm true positive" time="0" classname="off-by-one boolean logic errors" file="packages/test-runner-junit-reporter/test/fixtures/simple/simple-test.js">
       <skipped/>
     </testcase>
-    <testcase name="reports logs to JUnit" time="0.001" classname="logging during a test"/>
+    <testcase name="reports logs to JUnit" time="0.001" classname="logging during a test" file="packages/test-runner-junit-reporter/test/fixtures/simple/simple-test.js"/>
+    <testcase name="fails with source trace" time="<<computed>>" classname="logging during a test" file="packages/test-runner-junit-reporter/test/fixtures/simple/simple-test.js" line="2">
+      <failure message="failed" type="Error"><![CDATA[Error: failed
+  at fail (packages/test-runner-junit-reporter/test/fixtures/simple/simple-source.js:2:9)
+  at o.<anonymous> (packages/test-runner-junit-reporter/test/fixtures/simple/simple-test.js:33:17)]]></failure>
+    </testcase>
   </testsuite>
 </testsuites>

--- a/packages/test-runner-junit-reporter/test/fixtures/simple/simple-source.js
+++ b/packages/test-runner-junit-reporter/test/fixtures/simple/simple-source.js
@@ -1,0 +1,3 @@
+export function fail() {
+  throw new Error("failed");
+}

--- a/packages/test-runner-junit-reporter/test/fixtures/simple/simple-test.js
+++ b/packages/test-runner-junit-reporter/test/fixtures/simple/simple-test.js
@@ -1,5 +1,7 @@
 import '../../../../../node_modules/chai/chai.js';
 
+import { fail } from './simple-source.js';
+
 describe('real numbers forming a monoid', function() {
   it('under addition', function() {
     chai.expect(1 + 1).to.equal(2);
@@ -25,5 +27,9 @@ describe('logging during a test', function() {
     const actual = '🤷‍♂️';
     console.log('actual is ', actual);
     chai.expect(typeof actual).to.equal('string');
+  });
+
+  it('fails with source trace', function() {
+    chai.expect(fail()).to.equal('string');
   });
 });

--- a/packages/test-runner-junit-reporter/test/junitReporter.test.ts
+++ b/packages/test-runner-junit-reporter/test/junitReporter.test.ts
@@ -18,7 +18,13 @@ const normalizeOutput = (cwd: string, output: string) =>
   output
     .replace(NON_ZERO_TIME_VALUE_REGEX, 'time="<<computed>>"')
     .replace(USER_AGENT_STRING_REGEX, '"<<useragent>>"')
-    .replace(/\s+$/, '');
+    // don't judge - normalizing paths for windblows
+    .replace(/\/>/g, '🙈>')
+    .replace(/<\//g, '<🙈')
+    .replace(/\//g, path.sep)
+    .replace(/🙈>/g, '/>')
+    .replace(/<🙈/g, '</')
+    .trimEnd();
 
 const readNormalized = (filePath: string): Promise<string> =>
   fs.readFile(filePath, 'utf-8').then(out => normalizeOutput(rootDir, out));

--- a/packages/test-runner-junit-reporter/test/junitReporter.test.ts
+++ b/packages/test-runner-junit-reporter/test/junitReporter.test.ts
@@ -1,102 +1,75 @@
 import { expect } from 'chai';
+import { promises as fs } from 'fs';
 import path from 'path';
-import fs from 'fs';
 import globby from 'globby';
 
 import { chromeLauncher } from '@web/test-runner-chrome';
-import { TestRunner, TestRunnerCoreConfig } from '@web/test-runner-core';
-import { junitReporter } from '../src/index';
-
-import { getPortPromise } from 'portfinder';
-
-const STACK_TRACE_UNIQUE_IDS_REGEX =
-  /localhost:\d+|wtr-session-id=[\w\d]+-[\w\d]+-[\w\d]+-[\w\d]+-[\w\d]+|\.js:\d+:\d+/g;
+import { TestRunnerCoreConfig } from '@web/test-runner-core';
+import { runTests } from '@web/test-runner-core/test-helpers';
+import { junitReporter } from '../src/junitReporter';
 
 const NON_ZERO_TIME_VALUE_REGEX = /time="((\d\.\d+)|(\d))"/g;
 
 const USER_AGENT_STRING_REGEX = /"Mozilla\/5\.0 (.*)"/g;
 
-const MONOREPO_PATH_REGEX = /\/packages\/test-runner-junit-reporter/g;
+const rootDir = path.join(__dirname, '..', '..', '..');
 
 const normalizeOutput = (cwd: string, output: string) =>
   output
-    .replace(STACK_TRACE_UNIQUE_IDS_REGEX, '<<unique>>')
     .replace(NON_ZERO_TIME_VALUE_REGEX, 'time="<<computed>>"')
     .replace(USER_AGENT_STRING_REGEX, '"<<useragent>>"')
-    .replace(MONOREPO_PATH_REGEX, '')
-    .replace(new RegExp(cwd, 'g'), '<<cwd>>');
+    .replace(/\s+$/, '');
 
-function createConfig(): Omit<TestRunnerCoreConfig, 'rootDir' | 'port' | 'files' | 'reporters'> {
+const readNormalized = (filePath: string): Promise<string> =>
+  fs.readFile(filePath, 'utf-8').then(out => normalizeOutput(rootDir, out));
+
+function createConfig({
+  files,
+  reporters,
+}: Partial<TestRunnerCoreConfig>): Partial<TestRunnerCoreConfig> {
   return {
-    testFramework: { path: require.resolve('@web/test-runner-mocha/dist/autorun.js') },
-    protocol: 'http:',
-    hostname: 'localhost',
-    concurrentBrowsers: 2,
-    concurrency: 6,
-    browserStartTimeout: 30000,
-    testsStartTimeout: 10000,
-    testsFinishTimeout: 20000,
+    files,
+    reporters,
+    rootDir,
     coverageConfig: {
       report: false,
       reportDir: process.cwd(),
     },
     browserLogs: true,
     watch: false,
-    logger: {
-      ...console,
-      debug() {
-        //
-      },
-      logSyntaxError(error) {
-        console.error(error);
-      },
-    },
     browsers: [chromeLauncher()],
   };
 }
 
-const rootDir = path.join(__dirname, '..', '..', '..');
-
-async function launchTestRunner(cwd: string): Promise<{ actual: string; expected: string }> {
-  const files = await globby('*.test.js', { absolute: true, cwd });
-  const port = await getPortPromise({ port: 9000 + Math.floor(Math.random() * 1000) });
+async function run(cwd: string): Promise<{ actual: string; expected: string }> {
+  const files = await globby('*-test.js', { absolute: true, cwd });
   const outputPath = path.join(cwd, './test-results.xml');
   const reporters = [junitReporter({ outputPath })];
-  const config: TestRunnerCoreConfig = { ...createConfig(), rootDir, port, files, reporters };
-
-  const runner = new TestRunner(config);
-
-  await runner.start();
-
-  return new Promise(resolve => {
-    runner.on('stopped', async () => {
-      const actual = normalizeOutput(rootDir, fs.readFileSync(outputPath, 'utf-8'));
-      const expected = normalizeOutput(
-        rootDir,
-        fs.readFileSync(path.join(cwd, './expected.xml'), 'utf-8'),
-      );
-      resolve({ actual, expected });
-    });
+  await runTests(createConfig({ files, reporters }), [], {
+    allowFailure: true,
+    reportErrors: false,
   });
+  const actual = await readNormalized(outputPath);
+  const expected = await readNormalized(path.join(cwd, './expected.xml'));
+  return { actual, expected };
 }
 
-describe.skip('junitReporter', function () {
+async function cleanupFixtures() {
+  for (const file of await globby('fixtures/**/test-results.xml', {
+    absolute: true,
+    cwd: __dirname,
+  }))
+    await fs.unlink(file);
+}
+
+describe('junitReporter', function () {
   this.timeout(10000);
-
-  async function cleanUpFixtures() {
-    for (const file of await globby('fixtures/**/test-results.xml', {
-      absolute: true,
-      cwd: __dirname,
-    }))
-      fs.unlinkSync(file);
-  }
-
-  after(cleanUpFixtures);
+  after(cleanupFixtures);
 
   describe('for a simple case', function () {
     const fixtureDir = path.join(__dirname, 'fixtures/simple');
     it('produces expected results', async function () {
-      const { actual, expected } = await launchTestRunner(fixtureDir);
+      const { actual, expected } = await run(fixtureDir);
       expect(actual).to.equal(expected);
     });
   });
@@ -104,7 +77,7 @@ describe.skip('junitReporter', function () {
   describe('for a nested suite', function () {
     const fixtureDir = path.join(__dirname, 'fixtures/nested');
     it('produces expected results', async function () {
-      const { actual, expected } = await launchTestRunner(fixtureDir);
+      const { actual, expected } = await run(fixtureDir);
       expect(actual).to.equal(expected);
     });
   });
@@ -112,7 +85,7 @@ describe.skip('junitReporter', function () {
   describe('for multiple test files', function () {
     const fixtureDir = path.join(__dirname, 'fixtures/multiple');
     it('produces expected results', async function () {
-      const { actual, expected } = await launchTestRunner(fixtureDir);
+      const { actual, expected } = await run(fixtureDir);
       expect(actual).to.equal(expected);
     });
   });

--- a/packages/test-runner-selenium/test/seleniumLauncher.test.ts
+++ b/packages/test-runner-selenium/test/seleniumLauncher.test.ts
@@ -6,13 +6,13 @@ import { runIntegrationTests } from '../../../integration/test-runner';
 import { seleniumLauncher } from '../src/seleniumLauncher';
 
 async function startSeleniumServer() {
-  let server;
+  let server: selenium.ChildProcess;
 
   try {
     await selenium.install({
       drivers: {
         chrome: { version: '96.0.4664.18' },
-        firefox: { version: 'latest' },
+        firefox: { version: '0.30.0' },
       },
     });
   } catch (err) {
@@ -24,12 +24,13 @@ async function startSeleniumServer() {
     server = await selenium.start({
       drivers: {
         chrome: { version: '96.0.4664.18' },
-        firefox: { version: 'latest' },
+        firefox: { version: '0.30.0' },
       },
       seleniumArgs: ['--port', '8888'],
     });
   } catch (err) {
     console.error('Error occurred when starting selenium.');
+    console.log(err);
     throw err;
   }
 
@@ -43,6 +44,10 @@ describe('test-runner-selenium', function testRunnerSelenium() {
 
   before(async function () {
     seleniumServer = await startSeleniumServer();
+  });
+
+  after(() => {
+    seleniumServer.kill();
   });
 
   function createConfig() {
@@ -77,8 +82,4 @@ describe('test-runner-selenium', function testRunnerSelenium() {
     // FIXME: timed out with selenium-standalone v7
     locationChanged: false,
   });
-});
-
-after(() => {
-  seleniumServer.kill();
 });

--- a/packages/test-runner-webdriver/test/webdriverLauncher.test.ts
+++ b/packages/test-runner-webdriver/test/webdriverLauncher.test.ts
@@ -41,6 +41,10 @@ describe('test-runner-webdriver', function testRunnerWebdriver() {
     seleniumServer = await startSeleniumServer();
   });
 
+  after(() => {
+    seleniumServer.kill();
+  });
+
   function createConfig() {
     return {
       browserStartTimeout: 1000 * 60 * 2,
@@ -81,9 +85,5 @@ describe('test-runner-webdriver', function testRunnerWebdriver() {
     testFailure: true,
     // FIXME: timed out with selenium-standalone v7
     locationChanged: false,
-  });
-
-  after(() => {
-    seleniumServer.kill();
   });
 });


### PR DESCRIPTION
## What I did

1. update the XML format with line numbers
2. add a test case that includes a source file (for stack traces)
3. fix tests to run properly
4. run all windows node tests against the production build
