### PR TITLE
docs: close details tag in commands docs

### DIFF
--- a/docs/docs/test-runner/commands.md
+++ b/docs/docs/test-runner/commands.md
@@ -210,6 +210,8 @@ it('does something with mouse', async () => {
 });
 ```
 
+</details>
+
 ### Send keys
 
 The `sendKeys` command will cause the browser to press keys or type a sequence of characters as if it received those keys from the keyboard. This greatly simplifies interactions with form elements during test and surfaces the ability to directly inspect the way focus flows through test content in response to the `Tab` key. The function is async and should be awaited.


### PR DESCRIPTION
## What I did

It turns out that I didn't close correctly `<details>` tag when writing docs for the `resetMouse` command in #1816. In consequence, all the content following the command became hidden. So I'm fixing that here in this PR.
