### PR TITLE
fix(dev-server-storybook): rename storybook config file

### DIFF
--- a/.changeset/metal-teachers-lay.md
+++ b/.changeset/metal-teachers-lay.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server-storybook': minor
+---
+
+rename .storybook/main.js to .storybook/main.cjs to make it work in packages with "type": "module"

--- a/docs/docs/dev-server/plugins/storybook.md
+++ b/docs/docs/dev-server/plugins/storybook.md
@@ -51,7 +51,7 @@ Other project types could be supported, let us know if you are interested in thi
 
 ### main.js and preview.js
 
-We read the `.storybook/main.js` and `.storybook/preview.js` files like regular storybook.
+We read the `.storybook/main.cjs` and `.storybook/preview.js` files like regular storybook.
 
 ### Customizing storybook directory
 

--- a/docs/guides/dev-server/storybook.md
+++ b/docs/guides/dev-server/storybook.md
@@ -23,7 +23,7 @@ export default {
 };
 ```
 
-Add a `.storybook/main.js` file:
+Add a `.storybook/main.cjs` file:
 
 ```js
 module.exports = {

--- a/packages/dev-server-storybook/src/shared/config/readStorybookConfig.ts
+++ b/packages/dev-server-storybook/src/shared/config/readStorybookConfig.ts
@@ -12,14 +12,14 @@ function validateMainJs(mainJs: MainJs): MainJs {
     throw createError('main.js must export an bject');
   }
   if (mainJs.stories == null) {
-    throw createError('Missing stories option in main.js');
+    throw createError('Missing stories option in main.cjs');
   }
   if (!Array.isArray(mainJs.stories)) {
-    throw createError('Stories option main.js must be an array');
+    throw createError('Stories option main.cjs must be an array');
   }
   if (mainJs.addons != null) {
     if (!Array.isArray(mainJs.addons)) {
-      throw createError('Addons in main.js must be an array');
+      throw createError('Addons in main.cjs must be an array');
     }
     if (mainJs.addons.some(addon => addon.startsWith('@storybook'))) {
       throw createError(
@@ -34,7 +34,7 @@ export function readStorybookConfig(pluginConfig: StorybookPluginConfig): Storyb
   const configDir = pluginConfig.configDir
     ? path.resolve(pluginConfig.configDir)
     : defaultConfigDir;
-  const mainJsPath = path.join(configDir, 'main.js');
+  const mainJsPath = path.join(configDir, 'main.cjs');
   const managerJsPath = path.join(configDir, 'manager.js');
   const previewJsPath = path.join(configDir, 'preview.js');
   const managerHeadPath = path.join(configDir, 'manager-head.html');


### PR DESCRIPTION
## Why I did this change
I had a bug and couldn't start storybook in my package with type: module

Steps to reproduce:
1. start a package with packcage.json `"type: module"` (or for example clone or download https://github.com/lit/lit-element-starter-ts)
2. according to the current [guide](https://modern-web.dev/guides/dev-server/storybook/) add the dev-server-storybook
  - create a `.storybook/main.js` with `exports.default = ` (N.B. - it's the source of issue)
  - create a `.storybook/server.config.mjs`
3. run `wds --config .storybook/server.config.mjs`
4. got the error `ERR_REQUIRE_ESM` `require() of ES modules is not supported`

## What I did
So the fastest and easiest fix that works both in commonjs and module packages - rename main.js to main.cjs
1. renamed hardcoded filename in `packages/dev-server-storybook/src/shared/config/readStorybookConfig.ts`
2. changed docs and guide - rename main.js to main.cjs 
