### PR TITLE
fix: add sendMousePlugin to the default test runner config

### DIFF
--- a/.changeset/kind-owls-rest.md
+++ b/.changeset/kind-owls-rest.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner': patch
+---
+
+Add `sendMousePlugin` to the default test runner config so that it will load automatically.

--- a/packages/test-runner/src/config/parseConfig.ts
+++ b/packages/test-runner/src/config/parseConfig.ts
@@ -7,6 +7,7 @@ import {
   sendKeysPlugin,
   filePlugin,
   snapshotPlugin,
+  sendMousePlugin,
 } from '@web/test-runner-commands/plugins';
 import { getPortPromise } from 'portfinder';
 import path from 'path';
@@ -252,6 +253,7 @@ export async function parseConfig(
     setUserAgentPlugin(),
     filePlugin(),
     sendKeysPlugin(),
+    sendMousePlugin(),
     snapshotPlugin({ updateSnapshots: !!cliArgs.updateSnapshots }),
   );
 


### PR DESCRIPTION
This PR adds `sendMousePlugin` to the default test runner config so that it will load automatically. This will fix the error that occurs when trying to use the `sendMouse` or `resetMouse` command:

> Error: Error while executing command reset-mouse: Unknown command reset-mouse. Did you install a plugin to handle this command?