### PR TITLE
chore: disable FORCE_COLOR on GitHub Actions

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Setup Node.js 12
         uses: actions/setup-node@v2
+        env:
+          FORCE_COLOR: 0
         with:
           node-version: 12.x
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
+        env:
+          FORCE_COLOR: 0
         with:
           node-version: '16'
           cache: 'yarn'

--- a/.github/workflows/verify-browserstack.yml
+++ b/.github/workflows/verify-browserstack.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Setup Node 14
         uses: actions/setup-node@v2
+        env:
+          FORCE_COLOR: 0
         with:
           node-version: '14'
           cache: 'yarn'

--- a/.github/workflows/verify-node.yml
+++ b/.github/workflows/verify-node.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@v2
+        env:
+          FORCE_COLOR: 0
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn

--- a/.github/workflows/verify-saucelabs.yml
+++ b/.github/workflows/verify-saucelabs.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Setup Node 14
         uses: actions/setup-node@v2
+        env:
+          FORCE_COLOR: 0
         with:
           node-version: '14'
           cache: 'yarn'

--- a/.github/workflows/verify-windows.yml
+++ b/.github/workflows/verify-windows.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Setup Node '12'
         uses: actions/setup-node@v2
+        env:
+          FORCE_COLOR: 0
         with:
           node-version: '12'
           cache: 'yarn'


### PR DESCRIPTION
## What I did

Added a workaround for cache issue that causes GitHub Actions to fail:

```
Post job cleanup.
/usr/local/bin/yarn --version
1.22.17
/usr/local/bin/yarn cache dir
/home/runner/.cache/yarn/v6
Error: Cache folder path is retrieved for yarn but doesn't exist on disk: /home/runner/.cache/yarn/v6
```

See https://github.com/TryGhost/Ghost/commit/aec14e5cf34bbb96720e303c32e1cae3fc884169
See https://github.com/actions/setup-node/issues/317#issuecomment-929694556


