### PR TITLE
fix: check isTTY to prevent node from crashing/exiting early

### DIFF
--- a/.changeset/check-tty-stop-early-exit.md
+++ b/.changeset/check-tty-stop-early-exit.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-core': patch
+---
+
+Check isTTY to prevent node from crashing/exiting early

--- a/packages/test-runner-core/src/cli/terminal/DynamicTerminal.ts
+++ b/packages/test-runner-core/src/cli/terminal/DynamicTerminal.ts
@@ -23,9 +23,11 @@ export class DynamicTerminal extends EventEmitter<EventMap> {
     console.log('');
 
     this.interceptConsoleOutput();
-    process.stdin.resume();
-    process.stdin.setEncoding('utf8');
-    process.stdin.addListener('data', this.onStdInData);
+    if (process.stdin.isTTY === true) {
+      process.stdin.resume();
+      process.stdin.setEncoding('utf8');
+      process.stdin.addListener('data', this.onStdInData);
+    }
     this.started = true;
   }
 


### PR DESCRIPTION
## Why I did this change

- Husky was running WTR but would exit early with error level 0 before running any tests.
- Found out that process.stdin.isTTY was undefined when running with husky since it runs in a non-tty environment.
- Noticed that after doing anything with process.stdin, node would crash or exit (no error report or notice). 
- Also experienced the same problem when setting up CI in TeamCity.
 
## What I did

- add a check for isTTY to be true so that non-tty environments do not crash or exit the process with error level 0.
