### PR TITLE
fix: always load EMS for config option 'always'

### DIFF
--- a/.changeset/chilled-tables-obey.md
+++ b/.changeset/chilled-tables-obey.md
@@ -1,0 +1,5 @@
+---
+"@web/polyfills-loader": patch
+---
+
+fix: always load EMS for config option 'always'

--- a/packages/polyfills-loader/src/createPolyfillsData.ts
+++ b/packages/polyfills-loader/src/createPolyfillsData.ts
@@ -35,7 +35,7 @@ export async function createPolyfillsData(cfg: PolyfillsLoaderConfig): Promise<P
   if (polyfills.esModuleShims) {
     addPolyfillConfig({
       name: 'es-module-shims',
-      test: polyfills.regeneratorRuntime !== 'always' ? noModuleSupportTest : undefined,
+      test: polyfills.regeneratorRuntime !== 'always' ? '1' : undefined,
       path: require.resolve('es-module-shims'),
     });
   }

--- a/packages/polyfills-loader/test/createPolyfillsData.test.ts
+++ b/packages/polyfills-loader/test/createPolyfillsData.test.ts
@@ -54,7 +54,7 @@ describe('polyfills', () => {
         content: '',
         name: 'es-module-shims',
         path: 'polyfills/es-module-shims.js',
-        test: "1",
+        test: '1',
         type: 'script',
       },
       {

--- a/packages/polyfills-loader/test/createPolyfillsData.test.ts
+++ b/packages/polyfills-loader/test/createPolyfillsData.test.ts
@@ -54,7 +54,7 @@ describe('polyfills', () => {
         content: '',
         name: 'es-module-shims',
         path: 'polyfills/es-module-shims.js',
-        test: "!('noModule' in HTMLScriptElement.prototype)",
+        test: "1",
         type: 'script',
       },
       {


### PR DESCRIPTION
## What I did

1. actually always load es-module-shims if the `'always'` configuration option is used
