### PR TITLE
feat(test-runner-commands): make snapshot file path configurable

### DIFF
--- a/packages/test-runner-commands/test/snapshot/__custom-snapshots__/custom.snap.js
+++ b/packages/test-runner-commands/test/snapshot/__custom-snapshots__/custom.snap.js
@@ -1,0 +1,9 @@
+/* @web/test-runner snapshot v1 */
+
+export const snapshots = {};
+
+snapshots['persistent-a'] = `this is snapshot A`;
+/* end snapshot persistent-a */
+
+snapshots['persistent-b'] = `this is snapshot B`;
+/* end snapshot persistent-b */

--- a/packages/test-runner-commands/test/snapshot/snapshotPlugin.test.ts
+++ b/packages/test-runner-commands/test/snapshot/snapshotPlugin.test.ts
@@ -28,4 +28,29 @@ describe('snapshotPlugin', function test() {
       plugins: [snapshotPlugin()],
     });
   });
+
+  it('passes snapshot tests with a user defined snapshot path', async () => {
+    const fileName = (testFile: string) =>
+      path.join(path.dirname(testFile), '__custom-snapshots__', 'custom');
+
+    await runTests({
+      files: [path.join(__dirname, 'browser-test.js')],
+      browsers: [
+        playwrightLauncher({ product: 'firefox' }),
+        playwrightLauncher({ product: 'chromium' }),
+        playwrightLauncher({ product: 'webkit' }),
+      ],
+      plugins: [snapshotPlugin({ fileName })],
+    });
+
+    await runTests({
+      files: [path.join(__dirname, 'src', 'nested-test.js')],
+      browsers: [
+        playwrightLauncher({ product: 'firefox' }),
+        playwrightLauncher({ product: 'chromium' }),
+        playwrightLauncher({ product: 'webkit' }),
+      ],
+      plugins: [snapshotPlugin({ fileName })],
+    });
+  });
 });

--- a/packages/test-runner-commands/test/snapshot/src/__custom-snapshots__/custom.snap.js
+++ b/packages/test-runner-commands/test/snapshot/src/__custom-snapshots__/custom.snap.js
@@ -1,0 +1,9 @@
+/* @web/test-runner snapshot v1 */
+
+export const snapshots = {};
+
+snapshots['persistent-a'] = `this is nested snapshot A`;
+/* end snapshot persistent-a */
+
+snapshots['persistent-b'] = `this is nested snapshot B`;
+/* end snapshot persistent-b */

--- a/packages/test-runner/src/config/TestRunnerConfig.ts
+++ b/packages/test-runner/src/config/TestRunnerConfig.ts
@@ -1,5 +1,6 @@
 import { TestFramework, TestRunnerCoreConfig, TestRunnerGroupConfig } from '@web/test-runner-core';
 import { RollupNodeResolveOptions } from '@web/dev-server';
+import { SnapshotPluginConfig } from '@web/test-runner-commands/plugins.js';
 
 export interface TestRunnerConfig extends Omit<TestRunnerCoreConfig, 'testFramework'> {
   groups?: string | string[] | TestRunnerGroupConfig[];
@@ -7,4 +8,5 @@ export interface TestRunnerConfig extends Omit<TestRunnerCoreConfig, 'testFramew
   preserveSymlinks?: boolean;
   esbuildTarget?: string | string[];
   testFramework?: Partial<TestFramework>;
+  snapshotConfig?: SnapshotPluginConfig;
 }

--- a/packages/test-runner/src/config/parseConfig.ts
+++ b/packages/test-runner/src/config/parseConfig.ts
@@ -166,6 +166,15 @@ export async function parseConfig(
     ...finalConfig.coverageConfig,
   };
 
+  const updateSnapshots =
+    cliArgs.updateSnapshots !== undefined
+      ? cliArgs.updateSnapshots
+      : finalConfig.snapshotConfig?.updateSnapshots;
+  finalConfig.snapshotConfig = {
+    ...finalConfig.snapshotConfig,
+    updateSnapshots,
+  };
+
   let groupConfigs = await parseConfigGroups(finalConfig, cliArgs);
   if (groupConfigs.find(g => g.name === 'default')) {
     throw new TestRunnerStartError(
@@ -254,7 +263,7 @@ export async function parseConfig(
     filePlugin(),
     sendKeysPlugin(),
     sendMousePlugin(),
-    snapshotPlugin({ updateSnapshots: !!cliArgs.updateSnapshots }),
+    snapshotPlugin(finalConfig.snapshotConfig),
   );
 
   if (finalConfig.nodeResolve) {


### PR DESCRIPTION
## What I did

1. Added configuration option to control where snapshot files are saved.

I was not totally sure if the configuration of the plugin happen somewhere other than `TestRunnerConfig`, but  could not figure a better way to configure it since the plugin seems to be added by default when the runner is started. If I understood correctly, if a user would add the `snapshotPlugin(...)` in their own configuration file, that would not override the default one, right?

I've not updated the docs yet, but can do that if the code changes otherwise look ok.