### PR TITLE
feat(test-runner-core): allow http2/ssl opts in config

### DIFF
--- a/.changeset/unlucky-radios-peel.md
+++ b/.changeset/unlucky-radios-peel.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-core': patch
+---
+
+Allow http2/ssl options to be set in WTR config

--- a/packages/test-runner-core/src/config/TestRunnerCoreConfig.ts
+++ b/packages/test-runner-core/src/config/TestRunnerCoreConfig.ts
@@ -33,6 +33,10 @@ export interface TestRunnerCoreConfig {
   hostname: string;
   port: number;
 
+  http2?: boolean;
+  sslKey?: string;
+  sslCert?: string;
+
   browsers: BrowserLauncher[];
   testFramework?: TestFramework;
   logger: Logger;

--- a/packages/test-runner-core/src/server/TestRunnerServer.ts
+++ b/packages/test-runner-core/src/server/TestRunnerServer.ts
@@ -40,6 +40,10 @@ export class TestRunnerServer {
       rootDir,
       injectWebSocket: true,
 
+      http2: config.http2,
+      sslKey: config.sslKey,
+      sslCert: config.sslCert,
+
       mimeTypes: config.mimeTypes,
       middleware: [
         watchFilesMiddleware({ runSessions, sessions, rootDir, fileWatcher: this.fileWatcher }),


### PR DESCRIPTION
## What I did

1. Passed http2/ssl configuration options from WTR into the underlying DevServer instance to allow tests served over HTTPS
