### PR TITLE
fix(rollup-plugin-html): dont pass index.html to rollup input

### DIFF
--- a/packages/rollup-plugin-html/src/input/addRollupInput.ts
+++ b/packages/rollup-plugin-html/src/input/addRollupInput.ts
@@ -23,7 +23,10 @@ export function addRollupInput(
   if (typeof inputOptions.input === 'string') {
     return {
       ...inputOptions,
-      input: [inputOptions.input, ...inputModuleIds.map(mod => mod.importPath)],
+      input: [
+        ...(inputOptions?.input?.endsWith('.html') ? [] : [inputOptions.input]),
+        ...inputModuleIds.map(mod => mod.importPath),
+      ],
     };
   }
 


### PR DESCRIPTION
When using an `input` configuration option, it seems like the `index.html` gets passed to the actual rollup pipeline, and it causes other rollup/babel/whatever plugins to fail because they cant handle html files. 

```js
export default {
  input: 'index.html',
  output: {
    format: 'es',
    dir: 'dist',
  },
  plugins: [
    html({input: 'index.html'}), // ❌ index.html is now passed through rollup pipeline and causes errors
    html(), // ✅ no problem
  ]
}
```
