### PR TITLE
fix(dev-server-core): handle upgrade requests only for matched url

### DIFF
--- a/.changeset/popular-oranges-share.md
+++ b/.changeset/popular-oranges-share.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server-core': patch
+---
+
+Handle 'upgrade' requests only for matched url.

--- a/packages/dev-server-core/src/web-sockets/WebSocketsManager.ts
+++ b/packages/dev-server-core/src/web-sockets/WebSocketsManager.ts
@@ -48,9 +48,11 @@ export class WebSocketsManager extends EventEmitter<Events> {
     });
 
     server.on('upgrade', (request, socket, head) => {
-      this.webSocketServer.handleUpgrade(request, socket, head, ws => {
-        this.webSocketServer.emit('connection', ws, request);
-      });
+      if (request.url.match(this.webSocketServer.options.path)) {
+        this.webSocketServer.handleUpgrade(request, socket, head, ws => {
+          this.webSocketServer.emit('connection', ws, request);
+        });
+      }
     });
   }
 

--- a/packages/dev-server-core/src/web-sockets/WebSocketsManager.ts
+++ b/packages/dev-server-core/src/web-sockets/WebSocketsManager.ts
@@ -48,7 +48,7 @@ export class WebSocketsManager extends EventEmitter<Events> {
     });
 
     server.on('upgrade', (request, socket, head) => {
-      if (request.url.match(this.webSocketServer.options.path)) {
+      if (request.url === this.webSocketServer.options.path) {
         this.webSocketServer.handleUpgrade(request, socket, head, ws => {
           this.webSocketServer.emit('connection', ws, request);
         });


### PR DESCRIPTION
## Why I did this change
dev-server use websocket for reloading.
When I use other websocket connections, it failed because dev-server handle all upgrade requests regardless of url.

## What I did
1. Add if statement to handle upgrade requests only for dev-server.