### PR TITLE
Feat/external loader script

### DIFF
--- a/.changeset/cool-teachers-brush.md
+++ b/.changeset/cool-teachers-brush.md
@@ -1,0 +1,6 @@
+---
+'@web/polyfills-loader': minor
+'@web/rollup-plugin-polyfills-loader': minor
+---
+
+Add option to externalize polyfills loader script

--- a/docs/docs/building/polyfills-loader.md
+++ b/docs/docs/building/polyfills-loader.md
@@ -80,6 +80,7 @@ const config = {
     resizeObserver: true,
   },
   minify: true,
+  externalLoaderScript: false,
 };
 ```
 
@@ -313,6 +314,10 @@ const config = {
 ```
 
 </details>
+
+#### externalLoaderScript
+
+When true, creates a separate loader script instead of inlining it into the HTML.
 
 ## Usage
 

--- a/docs/docs/building/rollup-plugin-polyfills-loader.md
+++ b/docs/docs/building/rollup-plugin-polyfills-loader.md
@@ -71,3 +71,27 @@ export default {
   ],
 };
 ```
+
+### External loader script
+
+By default the polyfills loader scriped is inlined into the HTML. You can configure the plugin to create an external script:
+
+```js
+import html from '@web/rollup-plugin-html';
+import polyfillsLoader from '@web/rollup-plugin-polyfills-loader';
+
+export default {
+  output: { dir: 'dist' },
+  plugins: [
+    html({ input: 'index.html' }),
+    polyfillsLoader({
+      polyfills: {
+        coreJs: true,
+        fetch: true,
+        webcomponents: true,
+      },
+      externalLoaderScript: false,
+    }),
+  ],
+};
+```

--- a/docs/docs/building/rollup-plugin-polyfills-loader.md
+++ b/docs/docs/building/rollup-plugin-polyfills-loader.md
@@ -74,7 +74,7 @@ export default {
 
 ### External loader script
 
-By default the polyfills loader scriped is inlined into the HTML. You can configure the plugin to create an external script:
+By default the polyfills loader script is inlined into the HTML. You can configure the plugin to create an external script:
 
 ```js
 import html from '@web/rollup-plugin-html';
@@ -90,7 +90,7 @@ export default {
         fetch: true,
         webcomponents: true,
       },
-      externalLoaderScript: false,
+      externalLoaderScript: true,
     }),
   ],
 };

--- a/packages/polyfills-loader/src/createPolyfillsLoader.ts
+++ b/packages/polyfills-loader/src/createPolyfillsLoader.ts
@@ -253,7 +253,7 @@ export async function createPolyfillsLoader(
   }
 
   if (cfg.externalLoaderScript) {
-    generatedFiles.push({ type:'script', path: 'loader.js', content: code });
+    generatedFiles.push({ type: 'script', path: 'loader.js', content: code });
   }
 
   return { code, polyfillFiles: generatedFiles };

--- a/packages/polyfills-loader/src/createPolyfillsLoader.ts
+++ b/packages/polyfills-loader/src/createPolyfillsLoader.ts
@@ -252,5 +252,9 @@ export async function createPolyfillsLoader(
     ({ code } = output);
   }
 
+  if (cfg.externalLoaderScript) {
+    generatedFiles.push({ type:'script', path: 'loader.js', content: code });
+  }
+
   return { code, polyfillFiles: generatedFiles };
 }

--- a/packages/polyfills-loader/src/injectPolyfillsLoader.ts
+++ b/packages/polyfills-loader/src/injectPolyfillsLoader.ts
@@ -12,7 +12,7 @@ import {
   Element,
 } from '@web/parse5-utils';
 
-import { PolyfillsLoaderConfig, PolyfillsLoader, GeneratedFile, PolyfillFile } from './types';
+import { PolyfillsLoaderConfig, PolyfillsLoader, GeneratedFile } from './types';
 import { createPolyfillsLoader } from './createPolyfillsLoader';
 import { hasFileOfType, fileTypes } from './utils';
 

--- a/packages/polyfills-loader/src/types.ts
+++ b/packages/polyfills-loader/src/types.ts
@@ -22,6 +22,8 @@ export interface PolyfillsLoaderConfig {
   // whether to preload the modern entrypoint, best for performance
   // defaults to true
   preload?: boolean;
+  // whether to inject the loader as an external script instead of inline
+  externalLoaderScript?: boolean;
 }
 
 export interface PolyfillsConfig {

--- a/packages/polyfills-loader/test/injectPolyfillsLoader.test.ts
+++ b/packages/polyfills-loader/test/injectPolyfillsLoader.test.ts
@@ -230,4 +230,23 @@ describe('injectPolyfillsLoader', () => {
       ],
     });
   });
+
+  it('can injects a loader externally', async () => {
+    const html = `
+      <div>before</div>
+      <script type="module" src="./app.js"></script>
+      <div>after</div>
+    `;
+
+    await testSnapshot('external-loader', html, {
+      ...defaultConfig,
+      polyfills: {
+        hash: false,
+        webcomponents: true,
+        fetch: true,
+        intersectionObserver: true,
+      },
+      externalScript: true,
+    });
+  });
 });

--- a/packages/polyfills-loader/test/injectPolyfillsLoader.test.ts
+++ b/packages/polyfills-loader/test/injectPolyfillsLoader.test.ts
@@ -246,7 +246,7 @@ describe('injectPolyfillsLoader', () => {
         fetch: true,
         intersectionObserver: true,
       },
-      externalScript: true,
+      externalLoaderScript: true,
     });
   });
 });

--- a/packages/polyfills-loader/test/snapshots/injectPolyfillsLoader/external-loader.html
+++ b/packages/polyfills-loader/test/snapshots/injectPolyfillsLoader/external-loader.html
@@ -1,0 +1,4 @@
+<html><head></head><body><div>before</div>
+      <script type="module" src="./app.js"></script>
+      <div>after</div>
+    <script src="loader.js"></script></body></html>

--- a/packages/rollup-plugin-polyfills-loader/src/createPolyfillsLoaderConfig.ts
+++ b/packages/rollup-plugin-polyfills-loader/src/createPolyfillsLoaderConfig.ts
@@ -86,5 +86,5 @@ export function createPolyfillsLoaderConfig(
     }
   }
 
-  return { modern, legacy, polyfills };
+  return { modern, legacy, polyfills, externalLoaderScript: pluginOptions.externalLoaderScript };
 }

--- a/packages/rollup-plugin-polyfills-loader/src/types.d.ts
+++ b/packages/rollup-plugin-polyfills-loader/src/types.d.ts
@@ -14,4 +14,5 @@ export interface RollupPluginPolyfillsLoaderConfig {
   legacyOutput?: LegacyOutputConfig | LegacyOutputConfig[];
   polyfills?: PolyfillsConfig;
   polyfillsDir?: string;
+  externalLoaderScript?: boolean;
 }

--- a/packages/rollup-plugin-polyfills-loader/test/snapshots/external-script.html
+++ b/packages/rollup-plugin-polyfills-loader/test/snapshots/external-script.html
@@ -1,0 +1,3 @@
+<html><head>
+<link rel="preload" href="./entrypoint-a.js" as="script" crossorigin="anonymous" />
+</head><body><script src="loader.js"></script></body></html>

--- a/packages/rollup-plugin-polyfills-loader/test/src/createPolyfillsLoaderConfig.test.ts
+++ b/packages/rollup-plugin-polyfills-loader/test/src/createPolyfillsLoaderConfig.test.ts
@@ -16,6 +16,7 @@ describe('createPolyfillsLoaderConfig()', () => {
       legacy: undefined,
       modern: { files: [{ path: 'app.js', type: 'module', attributes: [] }] },
       polyfills: undefined,
+      externalLoaderScript: undefined,
     });
   });
 
@@ -41,6 +42,7 @@ describe('createPolyfillsLoaderConfig()', () => {
         ],
       },
       polyfills: undefined,
+      externalLoaderScript: undefined,
     });
   });
 
@@ -61,6 +63,7 @@ describe('createPolyfillsLoaderConfig()', () => {
       legacy: undefined,
       modern: { files: [{ path: 'app.js', type: 'systemjs', attributes: [] }] },
       polyfills: undefined,
+      externalLoaderScript: undefined,
     });
   });
 
@@ -92,6 +95,7 @@ describe('createPolyfillsLoaderConfig()', () => {
         },
       ],
       polyfills: undefined,
+      externalLoaderScript: undefined,
     });
   });
 
@@ -134,6 +138,7 @@ describe('createPolyfillsLoaderConfig()', () => {
         },
       ],
       polyfills: undefined,
+      externalLoaderScript: undefined,
     });
   });
 
@@ -169,6 +174,7 @@ describe('createPolyfillsLoaderConfig()', () => {
         },
       ],
       polyfills: undefined,
+      externalLoaderScript: undefined,
     });
   });
 
@@ -188,6 +194,7 @@ describe('createPolyfillsLoaderConfig()', () => {
       legacy: undefined,
       modern: { files: [{ path: 'app.js', type: 'module', attributes: [] }] },
       polyfills: { fetch: true, webcomponents: true },
+      externalLoaderScript: undefined,
     });
   });
 

--- a/packages/rollup-plugin-polyfills-loader/test/src/rollupPluginPolyfillsLoader.test.ts
+++ b/packages/rollup-plugin-polyfills-loader/test/src/rollupPluginPolyfillsLoader.test.ts
@@ -37,7 +37,7 @@ async function testSnapshot({ name, fileName, inputOptions, outputOptions }: Sna
 
   const file = getAsset(output, fileName);
   if (!file) throw new Error(`Build did not output ${fileName}`);
-
+console.log(output)
   if (updateSnapshots) {
     fs.writeFileSync(snapshotPath, file.source, 'utf-8');
   } else {
@@ -380,6 +380,29 @@ describe('rollup-plugin-polyfills-loader', function describe() {
 
     await testSnapshot({
       name: 'no-polyfills-retain-attributes',
+      fileName: 'index.html',
+      inputOptions,
+      outputOptions: defaultOutputOptions,
+    });
+  });
+
+  it.only('can inject a polyfills loader as an external script', async () => {
+    const inputOptions: RollupOptions = {
+      plugins: [
+        html({
+          input: {
+            html: `<script type="module" src="${relativeUrl}/fixtures/entrypoint-a.js"></script>`,
+          },
+        }),
+        polyfillsLoader({
+          polyfills: { hash: false, fetch: true },
+          externalLoaderScript: true,
+        }),
+      ],
+    };
+
+    await testSnapshot({
+      name: 'external-script',
       fileName: 'index.html',
       inputOptions,
       outputOptions: defaultOutputOptions,

--- a/packages/rollup-plugin-polyfills-loader/test/src/rollupPluginPolyfillsLoader.test.ts
+++ b/packages/rollup-plugin-polyfills-loader/test/src/rollupPluginPolyfillsLoader.test.ts
@@ -37,7 +37,7 @@ async function testSnapshot({ name, fileName, inputOptions, outputOptions }: Sna
 
   const file = getAsset(output, fileName);
   if (!file) throw new Error(`Build did not output ${fileName}`);
-console.log(output)
+
   if (updateSnapshots) {
     fs.writeFileSync(snapshotPath, file.source, 'utf-8');
   } else {
@@ -386,7 +386,7 @@ describe('rollup-plugin-polyfills-loader', function describe() {
     });
   });
 
-  it.only('can inject a polyfills loader as an external script', async () => {
+  it('can inject a polyfills loader as an external script', async () => {
     const inputOptions: RollupOptions = {
       plugins: [
         html({

--- a/packages/test-runner-commands/test/send-mouse/sendMousePlugin.test.ts
+++ b/packages/test-runner-commands/test/send-mouse/sendMousePlugin.test.ts
@@ -46,10 +46,10 @@ describe('sendMousePlugin', function test() {
       }
     });
 
-  /**
-   * TODO: Test is skipped because webdriver requires Chrome v100 which is not available in
-   * CI. Unskip later when it is supported.
-   */
+    /**
+     * TODO: Test is skipped because webdriver requires Chrome v100 which is not available in
+     * CI. Unskip later when it is supported.
+     */
     it.skip('can send mouse on webdriver', async () => {
       await runTests({
         files: [path.join(__dirname, 'browser-test.js')],


### PR DESCRIPTION
## What I did

Added the option to create the polyfills loader as an external script, instead of inlining it into the HTML. This enables setting strict CSP rules without requiring setting up a nonce hash for the inline script.
