### PR TITLE
Add CHANGELOG to publish output

### DIFF
--- a/packages/dev-server-storybook/package.json
+++ b/packages/dev-server-storybook/package.json
@@ -39,7 +39,8 @@
     "*.js",
     "*.mjs",
     "dist",
-    "src"
+    "src",
+    "CHANGELOG.md"
   ],
   "keywords": [
     "web",


### PR DESCRIPTION
The changelog is not added by NPM as a default: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#files
The file is quite handy to have though for quick reference when updating dependencies to check what has changed.