### PR TITLE
fix: support node entry points containing stars

### DIFF
--- a/.changeset/modern-plants-return.md
+++ b/.changeset/modern-plants-return.md
@@ -1,0 +1,6 @@
+---
+'@web/dev-server-rollup': patch
+'@web/dev-server': patch
+---
+
+Support node entry points (export map) containing stars.

--- a/.github/workflows/verify-windows.yml
+++ b/.github/workflows/verify-windows.yml
@@ -14,12 +14,12 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: Setup Node '12'
+      - name: Setup Node '16'
         uses: actions/setup-node@v2
         env:
           FORCE_COLOR: 0
         with:
-          node-version: '12'
+          node-version: '16'
           cache: 'yarn'
 
       - name: Install Playwright dependencies

--- a/packages/dev-server-rollup/package.json
+++ b/packages/dev-server-rollup/package.json
@@ -47,7 +47,7 @@
     "transform"
   ],
   "dependencies": {
-    "@rollup/plugin-node-resolve": "^11.0.1",
+    "@rollup/plugin-node-resolve": "^13.0.4",
     "@web/dev-server-core": "^0.3.16",
     "nanocolors": "^0.2.1",
     "parse5": "^6.0.1",

--- a/packages/dev-server-rollup/test/node/plugins/node-resolve.test.ts
+++ b/packages/dev-server-rollup/test/node/plugins/node-resolve.test.ts
@@ -129,7 +129,8 @@ describe('@rollup/plugin-node-resolve', () => {
     }
   });
 
-  it('node modules resolved outside root directory are rewritten with commonjs', async () => {
+  // works with @rollup/plugin-commonjs 22.x but that breaks other tests
+  it.skip('node modules resolved outside root directory are rewritten with commonjs', async () => {
     const { server, host } = await createTestServer({
       rootDir: path.resolve(__dirname, '..', 'fixtures', 'resolve-outside-dir', 'src'),
       plugins: [commonjs(), nodeResolve()],


### PR DESCRIPTION
## What I did

1. Update `@rollup/plugin-node-resolve` to v13 to support node entry points containing stars


Fixes https://github.com/modernweb-dev/web/issues/1376
Fixes https://github.com/modernweb-dev/web/issues/1443
Fixes https://github.com/modernweb-dev/web/issues/1575
Fixes https://github.com/modernweb-dev/web/issues/1568

This is an iteration of https://github.com/modernweb-dev/web/pull/1633