### PR TITLE
fix(dev-server-rollup): fix rootDir test for packages with common names

### DIFF
--- a/.changeset/ninety-eyes-attack.md
+++ b/.changeset/ninety-eyes-attack.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server-rollup': patch
+---
+
+Fixed a bug causing packages with common root names to not resolve in monorepos as outside the root dir.

--- a/packages/dev-server-rollup/src/rollupAdapter.ts
+++ b/packages/dev-server-rollup/src/rollupAdapter.ts
@@ -214,7 +214,12 @@ export function rollupAdapter(
         }
 
         const normalizedPath = path.normalize(resolvedImportPath);
-        if (!normalizedPath.startsWith(rootDir)) {
+
+        // append a path separator to rootDir so we are actually testing containment
+        // of the normalized path within the rootDir folder
+        const checkRootDir = rootDir.endsWith(path.sep) ? rootDir : rootDir + path.sep;
+
+        if (!normalizedPath.startsWith(checkRootDir)) {
           const relativePath = path.relative(rootDir, normalizedPath);
           const dirUp = `..${path.sep}`;
           const lastDirUpIndex = relativePath.lastIndexOf(dirUp) + 3;

--- a/packages/dev-server-rollup/test/node/fixtures/resolve-outside-dir-foo/index.js
+++ b/packages/dev-server-rollup/test/node/fixtures/resolve-outside-dir-foo/index.js
@@ -1,0 +1,1 @@
+export default 'resolveOutsideDirFoo';

--- a/packages/dev-server-rollup/test/node/fixtures/resolve-outside-dir-foo/package.json
+++ b/packages/dev-server-rollup/test/node/fixtures/resolve-outside-dir-foo/package.json
@@ -1,0 +1,3 @@
+{
+    "name": "resolve-outside-dir-foo"
+}

--- a/packages/dev-server-rollup/test/node/fixtures/resolve-outside-dir-foo/resolve-outside-dir-foo
+++ b/packages/dev-server-rollup/test/node/fixtures/resolve-outside-dir-foo/resolve-outside-dir-foo
@@ -1,0 +1,1 @@
+resolve-outside-dir-foo

--- a/packages/dev-server-rollup/test/node/fixtures/resolve-outside-dir/node_modules/resolve-outside-dir-foo
+++ b/packages/dev-server-rollup/test/node/fixtures/resolve-outside-dir/node_modules/resolve-outside-dir-foo
@@ -1,0 +1,1 @@
+../../resolve-outside-dir-foo

--- a/packages/dev-server-rollup/test/node/fixtures/resolve-outside-dir/src/app.js
+++ b/packages/dev-server-rollup/test/node/fixtures/resolve-outside-dir/src/app.js
@@ -1,3 +1,5 @@
 import moduleA from 'module-a';
+import moduleB from 'resolve-outside-dir-foo';
 
 console.log(moduleA);
+console.log(moduleB);

--- a/packages/dev-server-rollup/test/node/plugins/node-resolve.test.ts
+++ b/packages/dev-server-rollup/test/node/plugins/node-resolve.test.ts
@@ -112,6 +112,23 @@ describe('@rollup/plugin-node-resolve', () => {
     }
   });
 
+  it('node modules resolved outside root directory with matching basename via symlink are rewritten', async () => {
+    const { server, host } = await createTestServer({
+      rootDir: path.resolve(__dirname, '..', 'fixtures', 'resolve-outside-dir'),
+      plugins: [nodeResolve()],
+    });
+
+    try {
+      const responseText = await fetchText(`${host}/src/app.js`);
+      expectIncludes(
+        responseText,
+        "import moduleB from '/__wds-outside-root__/1/resolve-outside-dir-foo/index.js'",
+      );
+    } finally {
+      server.stop();
+    }
+  });
+
   it('node modules resolved outside root directory are rewritten', async () => {
     const { server, host } = await createTestServer({
       rootDir: path.resolve(__dirname, '..', 'fixtures', 'resolve-outside-dir', 'src'),


### PR DESCRIPTION
Appends a path separator to the rootDir to ensure we are actually testing that the resolved import path is inside the directory of the current rootDir. This then allows packages with common name prefixes to work properly.

NOTE: to test this I have committed a symlink that links the `node_modules/resolve-outside-dir-foo` package into the fixture for the test. This is necessary so that the node_module resolution happens, and so that the resolved file is a sibling folder of the rootDir.

fixes https://github.com/modernweb-dev/web/issues/1944