### PR TITLE
Ignore external urls from coverage

### DIFF
--- a/.changeset/cold-avocados-greet.md
+++ b/.changeset/cold-avocados-greet.md
@@ -1,0 +1,6 @@
+---
+"@web/test-runner-coverage-v8": patch
+"@web/test-runner": patch
+---
+
+Ignore external urls from coverage

--- a/packages/test-runner-coverage-v8/src/index.ts
+++ b/packages/test-runner-coverage-v8/src/index.ts
@@ -50,6 +50,9 @@ export async function v8ToIstanbul(
     if (
       // ignore non-http protocols (for exmaple webpack://)
       url.protocol.startsWith('http') &&
+      // ignore external urls
+      url.hostname === config.hostname &&
+      url.port === `${config.port}` &&
       // ignore non-files
       !!extname(path) &&
       // ignore virtual files


### PR DESCRIPTION
## What I did

1. Added a guard for external urls when collecting coverage
2. Fixed some linting errors
