### PR TITLE
Fix small typo in cli-and-configuration.md

### DIFF
--- a/docs/docs/test-runner/cli-and-configuration.md
+++ b/docs/docs/test-runner/cli-and-configuration.md
@@ -207,7 +207,7 @@ export default {
   files: [
     '**/*.spec.ts', // include `.spec.ts` files
     '!**/*.e2e.spec.ts', // exclude `.e2e.spec.ts` files
-    '!**/node_module/**/*', // exclude any node modules
+    '!**/node_modules/**/*', // exclude any node modules
   ],
 };
 ```


### PR DESCRIPTION
The example given for excluding `node_modules` has a typo in it.

## What I did

1. changed '!**/node_module/**/*' ->  '!**/node_modules/**/*' 
