### PR TITLE
Remove not supported statement

### DIFF
--- a/docs/docs/test-runner/commands.md
+++ b/docs/docs/test-runner/commands.md
@@ -49,7 +49,7 @@ describe('my component', () => {
 
 The `emulateMedia` command allows changing browser media queries. The function is async and should be awaited.
 
-`emulateMedia` is supported in `@web/test-runner-chrome`, `-puppeteer` and `-playwright`. The `reducedMotion` option is not supported by playwright.
+`emulateMedia` is supported in `@web/test-runner-chrome`, `-puppeteer` and `-playwright`.
 
 <details>
 <summary>View example</summary>


### PR DESCRIPTION
Playwright added support for `emulateMedia` in this PR https://github.com/microsoft/playwright/pull/6646

## What I did

1. Removed statement about `emulateMedia` about Playwright support
