### PR TITLE
Fix node16 module resolution.

### DIFF
--- a/.changeset/light-months-attend.md
+++ b/.changeset/light-months-attend.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-commands': patch
+---
+
+Add explicit types export to work with node16 module resolution (typescript 4.7)

--- a/packages/test-runner-commands/package.json
+++ b/packages/test-runner-commands/package.json
@@ -15,7 +15,10 @@
   "homepage": "https://github.com/modernweb-dev/web/tree/master/packages/test-runner-commands",
   "main": "browser/commands.mjs",
   "exports": {
-    ".": "./browser/commands.mjs",
+    ".": {
+      "types": "./browser/commands.d.ts",
+      "default": "./browser/commands.mjs"
+    },
     "./plugins": {
       "import": "./plugins.mjs",
       "require": "./dist/index.js"


### PR DESCRIPTION
Explicitly tell it to look for the types in `commands.d.ts`. Fixes compile error with `"moduleResolution": "node16"` in typescript 4.7.