### PR TITLE
Optional support .cjs extension when package.json contains {"type": "module"}

### DIFF
--- a/packages/dev-server-storybook/src/build/build.ts
+++ b/packages/dev-server-storybook/src/build/build.ts
@@ -62,6 +62,7 @@ async function buildManager(params: BuildmanagerParams) {
 
 export interface BuildParams {
   type: 'web-components' | 'preact';
+  mainExt: 'cjs' | 'js';
   outputDir: string;
   configDir: string;
 }

--- a/packages/dev-server-storybook/src/build/cli.ts
+++ b/packages/dev-server-storybook/src/build/cli.ts
@@ -23,12 +23,18 @@ async function main() {
       type: String,
       defaultValue: 'web-components',
     },
+    {
+      name: 'ext',
+      alias: 'e',
+      type: String,
+      defaultValue: 'js',
+    },
   ]);
 
   const configDir = path.resolve(args['config-dir']);
   const outputDir = path.resolve(args['output-dir']);
 
-  await build({ type: args.type, configDir, outputDir });
+  await build({ type: args.type, mainExt: args.ext, configDir, outputDir });
 }
 
 main();

--- a/packages/dev-server-storybook/src/shared/config/StorybookPluginConfig.ts
+++ b/packages/dev-server-storybook/src/shared/config/StorybookPluginConfig.ts
@@ -1,4 +1,5 @@
 export interface StorybookPluginConfig {
+  mainExt: 'cjs' | 'js';
   type: 'web-components' | 'preact';
   configDir?: string;
 }

--- a/packages/dev-server-storybook/src/shared/config/readStorybookConfig.ts
+++ b/packages/dev-server-storybook/src/shared/config/readStorybookConfig.ts
@@ -34,7 +34,8 @@ export function readStorybookConfig(pluginConfig: StorybookPluginConfig): Storyb
   const configDir = pluginConfig.configDir
     ? path.resolve(pluginConfig.configDir)
     : defaultConfigDir;
-  const mainJsPath = path.join(configDir, 'main.js');
+  const mainExt = pluginConfig.mainExt ? pluginConfig.mainExt : 'js';
+  const mainJsPath = path.join(configDir, 'main.' + mainExt);
   const managerJsPath = path.join(configDir, 'manager.js');
   const previewJsPath = path.join(configDir, 'preview.js');
   const managerHeadPath = path.join(configDir, 'manager-head.html');


### PR DESCRIPTION
Compatible way to resolve CommonJS loading for ESM (Modern 🙂) projects, solves:
- [ ] #1832
- [ ] #1831