### PR TITLE
fix: add types field to package.json exports

### DIFF
--- a/.changeset/slimy-scissors-learn.md
+++ b/.changeset/slimy-scissors-learn.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner': patch
+---
+
+Add types field to package.json exports map

--- a/packages/test-runner/package.json
+++ b/packages/test-runner/package.json
@@ -21,7 +21,7 @@
   "exports": {
     ".": {
       "import": {
-        "types":"./index.d.ts",
+        "types": "./index.d.ts",
         "default": "./index.mjs"
       },
       "require": {

--- a/packages/test-runner/package.json
+++ b/packages/test-runner/package.json
@@ -20,8 +20,14 @@
   },
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types":"./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {


### PR DESCRIPTION
## What I did

1. Added types in exports map

This allows types to be imported when using "moduleResolution": "Node16" in TypeScript.
