### PR TITLE
fix: update Rollup, use moduleSideEffects flag

### DIFF
--- a/.changeset/chatty-ghosts-argue.md
+++ b/.changeset/chatty-ghosts-argue.md
@@ -1,0 +1,6 @@
+---
+'@web/dev-server-rollup': patch
+'@web/dev-server': patch
+---
+
+Update Rollup, use moduleSideEffects flag

--- a/packages/dev-server-rollup/package.json
+++ b/packages/dev-server-rollup/package.json
@@ -51,7 +51,7 @@
     "@web/dev-server-core": "^0.3.16",
     "nanocolors": "^0.2.1",
     "parse5": "^6.0.1",
-    "rollup": "^2.66.1",
+    "rollup": "^2.67.0",
     "whatwg-url": "^11.0.0"
   },
   "devDependencies": {

--- a/packages/dev-server-rollup/src/createRollupPluginContextAdapter.ts
+++ b/packages/dev-server-rollup/src/createRollupPluginContextAdapter.ts
@@ -38,6 +38,7 @@ export function createRollupPluginContextAdapter<
         isEntry: false,
         isExternal: false,
         isIncluded: false,
+        hasModuleSideEffects: false,
         moduleSideEffects: false,
         syntheticNamedExports: false,
         meta: pluginMetaPerModule.get(id) ?? {},

--- a/packages/dev-server-rollup/src/createRollupPluginContextAdapter.ts
+++ b/packages/dev-server-rollup/src/createRollupPluginContextAdapter.ts
@@ -38,7 +38,7 @@ export function createRollupPluginContextAdapter<
         isEntry: false,
         isExternal: false,
         isIncluded: false,
-        hasModuleSideEffects: false,
+        moduleSideEffects: false,
         syntheticNamedExports: false,
         meta: pluginMetaPerModule.get(id) ?? {},
       };

--- a/packages/dev-server-rollup/src/rollupAdapter.ts
+++ b/packages/dev-server-rollup/src/rollupAdapter.ts
@@ -295,7 +295,7 @@ export function rollupAdapter(
         if (typeof result === 'string') {
           return { body: result, type: 'js' };
         }
-        if (typeof result?.code === 'string') {
+        if (result != null && typeof result?.code === 'string') {
           savePluginMeta(filePath, result);
           return { body: result.code, type: 'js' };
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11213,10 +11213,10 @@ rollup-pluginutils@^2.8.2:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^2.43.1, rollup@^2.66.1:
-  version "2.66.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.66.1.tgz#366b0404de353c4331d538c3ad2963934fcb4937"
-  integrity sha512-crSgLhSkLMnKr4s9iZ/1qJCplgAgrRY+igWv8KhG/AjKOJ0YX/WpmANyn8oxrw+zenF3BXWDLa7Xl/QZISH+7w==
+rollup@^2.43.1, rollup@^2.66.1, rollup@^2.67.0:
+  version "2.75.5"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.75.5.tgz#7985c1962483235dd07966f09fdad5c5f89f16d0"
+  integrity sha512-JzNlJZDison3o2mOxVmb44Oz7t74EfSd1SQrplQk0wSaXV7uLQXtVdHbxlcT3w+8tZ1TL4r/eLfc7nAbz38BBA==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
## What I did

1. Updated `rollup` dependency range to `^2.67.0` to get latest version `2.75.5` installed
2. Added the new `moduleSideEffects` flag in addition to the the [deprecated `hasModuleSideEffects`](https://github.com/rollup/rollup/pull/4379)
3. Added the `null` check to fix ` Property 'code' does not exist on type 'void | SourceDescription'.`