### PR TITLE
fix(rollup-plugin-import-meta-assets): completely overwrite import.meta.url

### DIFF
--- a/.changeset/tall-oranges-fetch.md
+++ b/.changeset/tall-oranges-fetch.md
@@ -1,0 +1,5 @@
+---
+'@web/rollup-plugin-import-meta-assets': minor
+---
+
+Change output to avoid import.meta.url in non-ESM builds

--- a/packages/rollup-plugin-import-meta-assets/src/rollup-plugin-import-meta-assets.js
+++ b/packages/rollup-plugin-import-meta-assets/src/rollup-plugin-import-meta-assets.js
@@ -90,7 +90,7 @@ function importMetaAssets({ include, exclude, warnOnError, transform } = {}) {
               });
               magicString.overwrite(
                 node.arguments[0].start,
-                node.arguments[0].end,
+                node.arguments[1].end,
                 `import.meta.ROLLUP_FILE_URL_${ref}`,
               );
               modifiedCode = true;

--- a/packages/rollup-plugin-import-meta-assets/test/snapshots/different-asset-levels-bundle.js
+++ b/packages/rollup-plugin-import-meta-assets/test/snapshots/different-asset-levels-bundle.js
@@ -1,14 +1,14 @@
 const nameOne = 'one-name';
-const imageOne = new URL(new URL('assets/one-deep-d40c1b4b.svg', import.meta.url).href, import.meta.url).href;
+const imageOne = new URL(new URL('assets/one-deep-d40c1b4b.svg', import.meta.url).href).href;
 
 const nameTwo = 'two-name';
-const imageTwo = new URL(new URL('assets/two-deep-e73b0d96.svg', import.meta.url).href, import.meta.url).href;
+const imageTwo = new URL(new URL('assets/two-deep-e73b0d96.svg', import.meta.url).href).href;
 
 const nameThree = 'three-name';
-const imageThree = new URL(new URL('assets/three-deep-801763e8.svg', import.meta.url).href, import.meta.url).href;
+const imageThree = new URL(new URL('assets/three-deep-801763e8.svg', import.meta.url).href).href;
 
 const nameFour = 'four-name';
-const imageFour = new URL(new URL('assets/four-deep-c65478aa.svg', import.meta.url).href, import.meta.url).href;
+const imageFour = new URL(new URL('assets/four-deep-c65478aa.svg', import.meta.url).href).href;
 
 console.log({
   [nameOne]: imageOne,

--- a/packages/rollup-plugin-import-meta-assets/test/snapshots/four-bundle.js
+++ b/packages/rollup-plugin-import-meta-assets/test/snapshots/four-bundle.js
@@ -1,4 +1,4 @@
 const nameFour = 'four-name';
-const imageFour = new URL(new URL('assets/four-b40404a7.svg', import.meta.url).href, import.meta.url).href;
+const imageFour = new URL(new URL('assets/four-b40404a7.svg', import.meta.url).href).href;
 
 export { imageFour, nameFour };

--- a/packages/rollup-plugin-import-meta-assets/test/snapshots/multi-level-bundle.js
+++ b/packages/rollup-plugin-import-meta-assets/test/snapshots/multi-level-bundle.js
@@ -1,14 +1,14 @@
 const nameOne = 'one-name';
-const imageOne = new URL(new URL('assets/one-134aaf72.svg', import.meta.url).href, import.meta.url).href;
+const imageOne = new URL(new URL('assets/one-134aaf72.svg', import.meta.url).href).href;
 
 const nameTwo = 'two-name';
-const imageTwo = new URL(new URL('assets/two-e4de930c.svg', import.meta.url).href, import.meta.url).href;
+const imageTwo = new URL(new URL('assets/two-e4de930c.svg', import.meta.url).href).href;
 
 const nameThree = 'three-name';
-const imageThree = new URL(new URL('assets/three-3f2c16b3.svg', import.meta.url).href, import.meta.url).href;
+const imageThree = new URL(new URL('assets/three-3f2c16b3.svg', import.meta.url).href).href;
 
 const nameFour = 'four-name';
-const imageFour = new URL(new URL('assets/four-b40404a7.svg', import.meta.url).href, import.meta.url).href;
+const imageFour = new URL(new URL('assets/four-b40404a7.svg', import.meta.url).href).href;
 
 console.log({
   [nameOne]: imageOne,

--- a/packages/rollup-plugin-import-meta-assets/test/snapshots/simple-bundle.js
+++ b/packages/rollup-plugin-import-meta-assets/test/snapshots/simple-bundle.js
@@ -1,7 +1,7 @@
-const justUrlObject = new URL(new URL('assets/one-134aaf72.svg', import.meta.url).href, import.meta.url);
-const href = new URL(new URL('assets/two-e4de930c.svg', import.meta.url).href, import.meta.url).href;
-const pathname = new URL(new URL('assets/three-3f2c16b3.svg', import.meta.url).href, import.meta.url).pathname;
-const searchParams = new URL(new URL('assets/four-b40404a7.svg', import.meta.url).href, import.meta.url).searchParams;
+const justUrlObject = new URL(new URL('assets/one-134aaf72.svg', import.meta.url).href);
+const href = new URL(new URL('assets/two-e4de930c.svg', import.meta.url).href).href;
+const pathname = new URL(new URL('assets/three-3f2c16b3.svg', import.meta.url).href).pathname;
+const searchParams = new URL(new URL('assets/four-b40404a7.svg', import.meta.url).href).searchParams;
 
 console.log({
   justUrlObject,

--- a/packages/rollup-plugin-import-meta-assets/test/snapshots/three-bundle.js
+++ b/packages/rollup-plugin-import-meta-assets/test/snapshots/three-bundle.js
@@ -1,4 +1,4 @@
 const nameThree = 'three-name';
-const imageThree = new URL(new URL('assets/three-3f2c16b3.svg', import.meta.url).href, import.meta.url).href;
+const imageThree = new URL(new URL('assets/three-3f2c16b3.svg', import.meta.url).href).href;
 
 export { imageThree, nameThree };

--- a/packages/rollup-plugin-import-meta-assets/test/snapshots/transform-bundle-ignored.js
+++ b/packages/rollup-plugin-import-meta-assets/test/snapshots/transform-bundle-ignored.js
@@ -1,7 +1,7 @@
-const justUrlObject = new URL(new URL('assets/one-d81655b9.svg', import.meta.url).href, import.meta.url);
-const href = new URL(new URL('assets/two-00516e7a.svg', import.meta.url).href, import.meta.url).href;
-const pathname = new URL(new URL('assets/three-0ba6692d.svg', import.meta.url).href, import.meta.url).pathname;
-const searchParams = new URL(new URL('assets/four-a00e2e1d.svg', import.meta.url).href, import.meta.url).searchParams;
+const justUrlObject = new URL(new URL('assets/one-d81655b9.svg', import.meta.url).href);
+const href = new URL(new URL('assets/two-00516e7a.svg', import.meta.url).href).href;
+const pathname = new URL(new URL('assets/three-0ba6692d.svg', import.meta.url).href).pathname;
+const searchParams = new URL(new URL('assets/four-a00e2e1d.svg', import.meta.url).href).searchParams;
 const someJpg = new URL('./image.jpg', import.meta.url);
 
 console.log({

--- a/packages/rollup-plugin-import-meta-assets/test/snapshots/transform-bundle.js
+++ b/packages/rollup-plugin-import-meta-assets/test/snapshots/transform-bundle.js
@@ -1,8 +1,8 @@
-const justUrlObject = new URL(new URL('assets/one-d81655b9.svg', import.meta.url).href, import.meta.url);
-const href = new URL(new URL('assets/two-00516e7a.svg', import.meta.url).href, import.meta.url).href;
-const pathname = new URL(new URL('assets/three-0ba6692d.svg', import.meta.url).href, import.meta.url).pathname;
-const searchParams = new URL(new URL('assets/four-a00e2e1d.svg', import.meta.url).href, import.meta.url).searchParams;
-const someJpg = new URL(new URL('assets/image-d6eb190c.jpg', import.meta.url).href, import.meta.url);
+const justUrlObject = new URL(new URL('assets/one-d81655b9.svg', import.meta.url).href);
+const href = new URL(new URL('assets/two-00516e7a.svg', import.meta.url).href).href;
+const pathname = new URL(new URL('assets/three-0ba6692d.svg', import.meta.url).href).pathname;
+const searchParams = new URL(new URL('assets/four-a00e2e1d.svg', import.meta.url).href).searchParams;
+const someJpg = new URL(new URL('assets/image-d6eb190c.jpg', import.meta.url).href);
 
 console.log({
   justUrlObject,


### PR DESCRIPTION
This removes the duplicated `import.meta.url` in the output, like this:

```diff
 // Pre-bundling code
 new URL("./some-internal-path.png", import.meta.url)
 
 // Bundled code in ESM output 
-new URL(new URL("asset/bundled-asset.png", import.meta.url).href, import.meta.url) 
+new URL(new URL("asset/bundled-asset.png", import.meta.url).href) 

 // Bundled code in CJS output 
 new URL(
   "undefined" == typeof document
     ? new (require("url").URL)(
         "file:" + __dirname + "/assets/InterLatin-b0e9bc2a.woff2"
       ).href
     : new URL(
         "assets/InterLatin-b0e9bc2a.woff2",
         (document.currentScript && document.currentScript.src) ||
           document.baseURI
       ).href
-, import.meta.url); // Uncaught SyntaxError: Cannot use 'import.meta' outside a module
+);
```

## Why

This way, it should work exactly the same (Rollup makes sure we have `import.meta.url` or something similar to base our URL on); but the second `import.meta` gets eliminated, which reduces size, repetition, and most of all, doesn't trigger an error in Common JS modules.

## What I did

1. Updated the overwrite function

   ```js
   // Before
   new URL("myFile.tx", import.meta.url)
   //      |---------|
   //      Only this part was overwritten

   // After
   new URL("myFile.tx", import.meta.url)
   //      |--------------------------|
   //      Now everything is overwritten
   ```

2. Updated tests

> I made it a `minor` change as it should supposedly not modify the functionality of the plugin, but maybe it should be a `major` as it modifies its output?