### PR TITLE
Replace navigations to `data:,` with `about:blank`.

### DIFF
--- a/.changeset/tough-bikes-study.md
+++ b/.changeset/tough-bikes-study.md
@@ -1,0 +1,6 @@
+---
+'@web/test-runner-selenium': patch
+'@web/test-runner-webdriver': patch
+---
+
+Navigations to blank pages now use `about:blank` instead of `data:,`.

--- a/packages/test-runner-selenium/src/IFrameManager.ts
+++ b/packages/test-runner-selenium/src/IFrameManager.ts
@@ -139,7 +139,7 @@ export class IFrameManager {
       }
 
       // set src after retreiving values to avoid the iframe from navigating away
-      iframe.src = "data:,";
+      iframe.src = "about:blank";
       return { testCoverage: testCoverage };
     `);
 

--- a/packages/test-runner-webdriver/src/IFrameManager.ts
+++ b/packages/test-runner-webdriver/src/IFrameManager.ts
@@ -134,7 +134,7 @@ export class IFrameManager {
       iframe.addEventListener('load', loaded);
       iframe.addEventListener('error', loaded);
       // set src after retrieving values to avoid the iframe from navigating away
-      iframe.src = "data:,";
+      iframe.src = "about:blank";
     `);
 
     if (!validateBrowserResult(returnValue)) {

--- a/packages/test-runner-webdriver/src/SessionManager.ts
+++ b/packages/test-runner-webdriver/src/SessionManager.ts
@@ -73,7 +73,7 @@ export class SessionManager {
     const { testCoverage } = returnValue;
 
     // navigate to an empty page to kill any running code on the page
-    await this.driver.navigateTo('data:,');
+    await this.driver.navigateTo('about:blank');
 
     this.urlMap.delete(id);
 


### PR DESCRIPTION
This PR replaces navigations to `data:,` with `about:blank`. This lets the Safari extension installed by the version of Selenium used in Saucelabs' Safari 9 and 10 environments [recognize that it should not run](https://github.com/SeleniumHQ/selenium/blob/selenium-2.48.0/javascript/safari-driver/inject/tab.js#L234).

(Fixes #1986)