### PR TITLE
fix: es-module-lexer logic in dev-server-storybook

### DIFF
--- a/packages/dev-server-storybook/package.json
+++ b/packages/dev-server-storybook/package.json
@@ -66,6 +66,7 @@
     "@web/storybook-prebuilt": "^0.1.32",
     "babel-plugin-bundled-import-meta": "^0.3.2",
     "babel-plugin-template-html-minifier": "^4.1.0",
+    "es-module-lexer": "^1.0.2",
     "globby": "^11.0.1",
     "path-is-inside": "^1.0.2",
     "rollup": "^2.66.1",

--- a/packages/dev-server-storybook/src/shared/stories/injectExportsOrder.ts
+++ b/packages/dev-server-storybook/src/shared/stories/injectExportsOrder.ts
@@ -7,8 +7,8 @@ export async function injectExportsOrder(source: string, filePath: string) {
     return null;
   }
 
-  const orderedExports = exports.filter(e => e !== 'default');
-  const exportsArray = `['${orderedExports.join("', '")}']`;
+  const orderedExports = exports.filter(e => e?.n?.toLowerCase() !== 'default');
+  const exportsArray = `['${orderedExports.map(({n}) => n) .join("', '")}']`;
 
   return `${source};\nexport const __namedExportsOrder = ${exportsArray};`;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5093,7 +5093,7 @@ es-module-lexer@^0.3.26:
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.3.26.tgz#7b507044e97d5b03b01d4392c74ffeb9c177a83b"
   integrity sha512-Va0Q/xqtrss45hWzP8CZJwzGSZJjDM5/MJRE3IXXnUCcVLElR9BRaE9F62BopysASyc4nM3uwhSW7FFB9nlWAA==
 
-es-module-lexer@^1.0.0:
+es-module-lexer@^1.0.0, es-module-lexer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.0.2.tgz#89dd1355d0e8a741b431171c69b2bfecc47d4293"
   integrity sha512-W6d+UibP+MDkF0+uUqj2sZTiyqA6v9f7/hDPqrxNYntp+NFMilA9Zr+qF9IZ7F4lcHQqw0toMlwxJxY2qm30uQ==


### PR DESCRIPTION
`es-module-lexer` previously returned a `exports` as a `string[]`, but since `^1.0.0`, `exports` is now an object.