### PR TITLE
docs: update link to Playwright CI docs

### DIFF
--- a/docs/docs/test-runner/testing-in-a-ci.md
+++ b/docs/docs/test-runner/testing-in-a-ci.md
@@ -16,4 +16,4 @@ If you want to use `@web/test-runner-playwright` in a CI environment you need to
 
 For the modern web repositories, we run our tests using Github Actions with the [Github Actions plugin](https://github.com/microsoft/playwright-github-action).
 
-Check the [official documentation](https://playwright.dev/#version=master&path=docs%2Fci.md&q=) for more information on different CI environments.
+The [official documentation](https://playwright.dev/docs/next/cli#install-system-dependencies) recommends to install system dependencies in a CI environment using the Playwright CLI.

--- a/docs/docs/test-runner/testing-in-a-ci.md
+++ b/docs/docs/test-runner/testing-in-a-ci.md
@@ -14,6 +14,6 @@ Puppeteer has a [dedicated page](https://github.com/puppeteer/puppeteer/blob/mai
 
 If you want to use `@web/test-runner-playwright` in a CI environment you need to ensure the necessary native libraries are installed.
 
-For the modern web repositories, we run our tests using Github Actions with the [Github Actions plugin](https://github.com/microsoft/playwright-github-action).
+For the modern web repositories, we run our tests on GitHub Actions using the [Playwright CLI](https://playwright.dev/docs/next/cli#install-system-dependencies).
 
-The [official documentation](https://playwright.dev/docs/next/cli#install-system-dependencies) recommends to install system dependencies in a CI environment using the Playwright CLI.
+Check the [official documentation](https://playwright.dev/docs/next/ci#ci-configurations) for more information on different CI environments.


### PR DESCRIPTION
The link to the Playwright manual was broken.

The use of the `microsoft/playwright-github-action` is discouraged ([You don't need this GitHub Action](https://github.com/microsoft/playwright-github-action#%EF%B8%8F-you-dont-need-this-github-action-%EF%B8%8F)). The recommended way is to install dependencies using the Playwright CLI commands.