### PR TITLE
Keep "Default" stories

### DIFF
--- a/.changeset/long-schools-wink.md
+++ b/.changeset/long-schools-wink.md
@@ -1,0 +1,6 @@
+---
+"@web/dev-server-storybook": patch
+"@web/dev-server": patch
+---
+
+Keep "Default" stories when building Storybook instance

--- a/packages/dev-server-storybook/src/shared/stories/injectExportsOrder.ts
+++ b/packages/dev-server-storybook/src/shared/stories/injectExportsOrder.ts
@@ -7,7 +7,7 @@ export async function injectExportsOrder(source: string, filePath: string) {
     return null;
   }
 
-  const orderedExports = exports.filter(e => e?.n?.toLowerCase() !== 'default');
+  const orderedExports = exports.filter(e => e?.n !== 'default');
   const exportsArray = `['${orderedExports.map(({ n }) => n).join("', '")}']`;
 
   return `${source};\nexport const __namedExportsOrder = ${exportsArray};`;


### PR DESCRIPTION
Using capital "D" `Default` is a super common pattern in Storybook creation. While we're pushing for `Regular` or similar in some of our CLI tooling, not allowing it at all is a surprising side effect for consumers of this package.

## What I did

1. Remove `toLowerCase()` from export filtering.
