### PR TITLE
Upgrade TypeScript to 4.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "rollup": "^2.66.1",
     "rollup-plugin-terser": "^7.0.2",
     "ts-node": "^10.4.0",
-    "typescript": "4.1.3"
+    "typescript": "~4.7.4"
   },
   "resolutions": {
     "@mdjs/core": "^0.9.0",

--- a/packages/config-loader/src/importConfig.js
+++ b/packages/config-loader/src/importConfig.js
@@ -35,7 +35,7 @@ async function importConfig(path) {
 
     return config.default;
   } catch (e) {
-    if (CJS_ERRORS.some(msg => e.stack.includes(msg))) {
+    if (CJS_ERRORS.some(msg => /** @type {Error} */(e).stack?.includes(msg))) {
       throw new ConfigLoaderError(
         'You are using CommonJS syntax such as "require" or "module.exports" in a config loaded as es module. ' +
           'Use import/export syntax, or load the file as a CommonJS module by ' +

--- a/packages/config-loader/src/requireConfig.js
+++ b/packages/config-loader/src/requireConfig.js
@@ -14,7 +14,7 @@ function requireConfig(path) {
   try {
     return require(path);
   } catch (e) {
-    if (ESM_ERRORS.some(msg => e.stack.includes(msg))) {
+    if (ESM_ERRORS.some(msg => /** @type {Error} **/(e).stack?.includes(msg))) {
       throw new ConfigLoaderError(
         'You are using es module syntax in a config loaded as CommonJS module. ' +
           'Use require/module.exports syntax, or load the file as es module by using the .mjs ' +

--- a/packages/dev-server-core/src/middleware/pluginTransformMiddleware.ts
+++ b/packages/dev-server-core/src/middleware/pluginTransformMiddleware.ts
@@ -5,6 +5,7 @@ import { DevServerCoreConfig } from '../server/DevServerCoreConfig';
 import { PluginTransformCache } from './PluginTransformCache';
 import { getRequestFilePath, getResponseBody, RequestCancelledError } from '../utils';
 import { Logger } from '../logger/Logger';
+import { PluginSyntaxError } from '../logger/PluginSyntaxError';
 
 /**
  * Sets up a middleware which allows plugins to transform files before they are served to the browser.
@@ -84,15 +85,17 @@ export function pluginTransformMiddleware(
           cacheKey,
         );
       }
-    } catch (error) {
-      if (error instanceof RequestCancelledError) {
+    } catch (e) {
+      if (e instanceof RequestCancelledError) {
         return undefined;
       }
       context.body = 'Error while transforming file. See the terminal for more information.';
       context.status = 500;
 
+      const error = e as NodeJS.ErrnoException;
+
       if (error.name === 'PluginSyntaxError') {
-        logger.logSyntaxError(error);
+        logger.logSyntaxError(error as PluginSyntaxError);
         return;
       }
 

--- a/packages/dev-server-core/src/plugins/transformModuleImportsPlugin.ts
+++ b/packages/dev-server-core/src/plugins/transformModuleImportsPlugin.ts
@@ -117,13 +117,14 @@ export async function transformImports(
     const parseResult = await parse(code, filePath);
     imports = parseResult[0] as any as ParsedImport[];
   } catch (error) {
-    if (typeof error.idx === 'number') {
+    if (typeof (error as Error & { idx: number }).idx === 'number') {
+      const lexerError = error as Error & { idx: number };
       throw new PluginSyntaxError(
         'Syntax error',
         filePath,
         code,
-        code.slice(0, error.idx).split('\n').length,
-        error.idx - code.lastIndexOf('\n', error.idx - 1),
+        code.slice(0, lexerError.idx).split('\n').length,
+        lexerError.idx - code.lastIndexOf('\n', lexerError.idx - 1),
       );
     }
     throw error;

--- a/packages/dev-server-esbuild/src/EsbuildPlugin.ts
+++ b/packages/dev-server-esbuild/src/EsbuildPlugin.ts
@@ -6,7 +6,7 @@ import {
   DevServerCoreConfig,
   getRequestFilePath,
 } from '@web/dev-server-core';
-import type { TransformOptions } from 'esbuild';
+import type { TransformOptions, BuildFailure } from 'esbuild';
 import { Loader, Message, transform } from 'esbuild';
 import { promisify } from 'util';
 import path from 'path';
@@ -199,8 +199,8 @@ export class EsbuildPlugin implements Plugin {
 
       return transformedCode;
     } catch (e) {
-      if (Array.isArray(e.errors)) {
-        const msg = e.errors[0] as Message;
+      if (Array.isArray((e as BuildFailure).errors)) {
+        const msg = (e as BuildFailure).errors[0] as Message;
 
         if (msg.location) {
           throw new PluginSyntaxError(

--- a/packages/dev-server-esbuild/src/browser-targets.ts
+++ b/packages/dev-server-esbuild/src/browser-targets.ts
@@ -29,7 +29,9 @@ function createModernTarget() {
     ];
   } catch (error) {
     throw new Error(
-      `Error while initializing default browser targets for @web/dev-server-esbuild: ${error.message}`,
+      `Error while initializing default browser targets for @web/dev-server-esbuild: ${
+        (error as Error).message
+      }`,
     );
   }
 }

--- a/packages/dev-server-import-maps/src/importMapsPlugin.ts
+++ b/packages/dev-server-import-maps/src/importMapsPlugin.ts
@@ -148,7 +148,9 @@ export function importMapsPlugin(config: ImportMapsPluginConfig = {}): Plugin {
         } catch (error) {
           const filePath = getRequestFilePath(context.url, rootDir);
           const relativeFilePath = path.relative(process.cwd(), filePath);
-          logger.warn(`Failed to parse import map in "${relativeFilePath}": ${error.message}`);
+          logger.warn(
+            `Failed to parse import map in "${relativeFilePath}": ${(error as Error).message}`,
+          );
           return;
         }
       }

--- a/packages/dev-server/src/plugins/esbuildPlugin.ts
+++ b/packages/dev-server/src/plugins/esbuildPlugin.ts
@@ -3,7 +3,7 @@ function requirePlugin() {
     const path = require.resolve('@web/dev-server-esbuild', { paths: [__dirname, process.cwd()] });
     return require(path);
   } catch (error) {
-    if (error.code === 'MODULE_NOT_FOUND') {
+    if ((error as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND') {
       throw new Error(
         'You need to add @web/dev-server-esbuild as a dependency of your project to use the esbuild flags.',
       );

--- a/packages/polyfills-loader/src/createPolyfillsData.ts
+++ b/packages/polyfills-loader/src/createPolyfillsData.ts
@@ -13,7 +13,7 @@ export async function createPolyfillsData(cfg: PolyfillsLoaderConfig): Promise<P
     try {
       polyfillConfigs.push(polyfillConfig);
     } catch (error) {
-      if (error.code === 'MODULE_NOT_FOUND') {
+      if ((error as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND') {
         throw new Error(
           `[Polyfills loader]: Error resolving polyfill ${polyfillConfig.name}` +
             ' Are dependencies installed correctly?',

--- a/packages/test-runner-core/src/cli/terminal/DynamicTerminal.ts
+++ b/packages/test-runner-core/src/cli/terminal/DynamicTerminal.ts
@@ -11,7 +11,7 @@ interface EventMap {
 }
 
 export class DynamicTerminal extends EventEmitter<EventMap> {
-  private originalFunctions: Partial<Record<keyof Console, (...args: any[]) => any>> = {};
+  private originalFunctions: Partial<Console> = {};
   private previousDynamic: string[] = [];
   private started = false;
   private bufferedConsole = new BufferedConsole();
@@ -61,9 +61,7 @@ export class DynamicTerminal extends EventEmitter<EventMap> {
     this.flushConsoleOutput();
     logUpdate.done();
 
-    for (const [key, fn] of Object.entries(this.originalFunctions)) {
-      console[key as keyof Console] = fn;
-    }
+    Object.assign(console, this.originalFunctions);
     this.started = false;
     process.stdin.pause();
     process.stdin.removeListener('data', this.onStdInData);
@@ -109,11 +107,11 @@ export class DynamicTerminal extends EventEmitter<EventMap> {
   private interceptConsoleOutput() {
     for (const key of Object.keys(console) as (keyof Console)[]) {
       if (typeof console[key] === 'function') {
-        this.originalFunctions[key] = console[key];
+        this.originalFunctions[key] = console[key] as any;
 
         console[key] = new Proxy(console[key], {
           apply: (target, thisArg, argArray) => {
-            this.bufferedConsole.console[key](...argArray);
+            (this.bufferedConsole.console[key] as any)(...argArray);
             if (this.pendingConsoleFlush) {
               return;
             }
@@ -123,7 +121,7 @@ export class DynamicTerminal extends EventEmitter<EventMap> {
               this.flushConsoleOutput();
             }, 0);
           },
-        });
+        }) as any;
       }
     }
   }

--- a/packages/test-runner-core/src/runner/TestScheduler.ts
+++ b/packages/test-runner-core/src/runner/TestScheduler.ts
@@ -142,7 +142,8 @@ export class TestScheduler {
 
       // when the browser started, wait for session to ping back on time
       this.timeoutHandler.waitForTestsStarted(updatedSession.testRun, updatedSession.id);
-    } catch (error) {
+    } catch (e) {
+      const error = e as Error;
       if (this.timeoutHandler.isStale(updatedSession)) {
         // something else has changed the test session, such as a the browser timeout
         // or a re-run in watch mode. in that was we just log the error
@@ -179,7 +180,7 @@ export class TestScheduler {
         updatedSession.testCoverage = testCoverage;
       }
     } catch (error) {
-      sessionErrors.push(error);
+      sessionErrors.push(error as Error);
     } finally {
       if (sessionErrors.length > 0) {
         // merge with existing erors

--- a/packages/test-runner-core/src/server/plugins/api/testRunnerApiPlugin.ts
+++ b/packages/test-runner-core/src/server/plugins/api/testRunnerApiPlugin.ts
@@ -217,7 +217,9 @@ class TestRunnerApiPlugin implements TestRunnerPlugin {
         }
       } catch (error) {
         this.config.logger.error(error);
-        webSocket.send(JSON.stringify({ type: 'message-response', id, error: error.message }));
+        webSocket.send(
+          JSON.stringify({ type: 'message-response', id, error: (error as Error).message }),
+        );
         return;
       }
     }

--- a/packages/test-runner-mocha/src/standalone.ts
+++ b/packages/test-runner-mocha/src/standalone.ts
@@ -20,7 +20,7 @@ export async function runTests(testFn: () => unknown | Promise<unknown>) {
   try {
     await testFn();
   } catch (error) {
-    sessionFailed(error);
+    sessionFailed(error as Error);
     return;
   }
 

--- a/packages/test-runner/src/config/loadLauncher.ts
+++ b/packages/test-runner/src/config/loadLauncher.ts
@@ -10,7 +10,7 @@ function loadLauncher(name: string) {
     const path = require.resolve(pkg, { paths: [__dirname, process.cwd()] });
     return require(path);
   } catch (error) {
-    if (error.code === 'MODULE_NOT_FOUND') {
+    if ((error as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND') {
       throw new TestRunnerStartError(
         `You need to add ${pkg} as a dependency of your project to use the --${name} flag.`,
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2527,84 +2527,84 @@
     "@types/node" "*"
 
 "@typescript-eslint/eslint-plugin@^5.3.0":
-  version "5.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.19.0.tgz#9608a4b6d0427104bccf132f058cba629a6553c0"
-  integrity sha512-w59GpFqDYGnWFim9p6TGJz7a3qWeENJuAKCqjGSx+Hq/bwq3RZwXYqy98KIfN85yDqz9mq6QXiY5h0FjGQLyEg==
+  version "5.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.35.1.tgz#0d822bfea7469904dfc1bb8f13cabd362b967c93"
+  integrity sha512-RBZZXZlI4XCY4Wzgy64vB+0slT9+yAPQRjj/HSaRwUot33xbDjF1oN9BLwOLTewoOI0jothIltZRe9uJCHf8gg==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.19.0"
-    "@typescript-eslint/type-utils" "5.19.0"
-    "@typescript-eslint/utils" "5.19.0"
-    debug "^4.3.2"
+    "@typescript-eslint/scope-manager" "5.35.1"
+    "@typescript-eslint/type-utils" "5.35.1"
+    "@typescript-eslint/utils" "5.35.1"
+    debug "^4.3.4"
     functional-red-black-tree "^1.0.1"
-    ignore "^5.1.8"
+    ignore "^5.2.0"
     regexpp "^3.2.0"
-    semver "^7.3.5"
+    semver "^7.3.7"
     tsutils "^3.21.0"
 
 "@typescript-eslint/parser@^5.3.0":
-  version "5.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.19.0.tgz#05e587c1492868929b931afa0cb5579b0f728e75"
-  integrity sha512-yhktJjMCJX8BSBczh1F/uY8wGRYrBeyn84kH6oyqdIJwTGKmzX5Qiq49LRQ0Jh0LXnWijEziSo6BRqny8nqLVQ==
+  version "5.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.35.1.tgz#bf2ee2ebeaa0a0567213748243fb4eec2857f04f"
+  integrity sha512-XL2TBTSrh3yWAsMYpKseBYTVpvudNf69rPOWXWVBI08My2JVT5jR66eTt4IgQFHA/giiKJW5dUD4x/ZviCKyGg==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.19.0"
-    "@typescript-eslint/types" "5.19.0"
-    "@typescript-eslint/typescript-estree" "5.19.0"
-    debug "^4.3.2"
+    "@typescript-eslint/scope-manager" "5.35.1"
+    "@typescript-eslint/types" "5.35.1"
+    "@typescript-eslint/typescript-estree" "5.35.1"
+    debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@5.19.0":
-  version "5.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.19.0.tgz#97e59b0bcbcb54dbcdfba96fc103b9020bbe9cb4"
-  integrity sha512-Fz+VrjLmwq5fbQn5W7cIJZ066HxLMKvDEmf4eu1tZ8O956aoX45jAuBB76miAECMTODyUxH61AQM7q4/GOMQ5g==
+"@typescript-eslint/scope-manager@5.35.1":
+  version "5.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.35.1.tgz#ccb69d54b7fd0f2d0226a11a75a8f311f525ff9e"
+  integrity sha512-kCYRSAzIW9ByEIzmzGHE50NGAvAP3wFTaZevgWva7GpquDyFPFcmvVkFJGWJJktg/hLwmys/FZwqM9EKr2u24Q==
   dependencies:
-    "@typescript-eslint/types" "5.19.0"
-    "@typescript-eslint/visitor-keys" "5.19.0"
+    "@typescript-eslint/types" "5.35.1"
+    "@typescript-eslint/visitor-keys" "5.35.1"
 
-"@typescript-eslint/type-utils@5.19.0":
-  version "5.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.19.0.tgz#80f2125b0dfe82494bbae1ea99f1c0186d420282"
-  integrity sha512-O6XQ4RI4rQcBGshTQAYBUIGsKqrKeuIOz9v8bckXZnSeXjn/1+BDZndHLe10UplQeJLXDNbaZYrAytKNQO2T4Q==
+"@typescript-eslint/type-utils@5.35.1":
+  version "5.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.35.1.tgz#d50903b56758c5c8fc3be52b3be40569f27f9c4a"
+  integrity sha512-8xT8ljvo43Mp7BiTn1vxLXkjpw8wS4oAc00hMSB4L1/jIiYbjjnc3Qp2GAUOG/v8zsNCd1qwcqfCQ0BuishHkw==
   dependencies:
-    "@typescript-eslint/utils" "5.19.0"
-    debug "^4.3.2"
+    "@typescript-eslint/utils" "5.35.1"
+    debug "^4.3.4"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@5.19.0":
-  version "5.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.19.0.tgz#12d3d600d754259da771806ee8b2c842d3be8d12"
-  integrity sha512-zR1ithF4Iyq1wLwkDcT+qFnhs8L5VUtjgac212ftiOP/ZZUOCuuF2DeGiZZGQXGoHA50OreZqLH5NjDcDqn34w==
+"@typescript-eslint/types@5.35.1":
+  version "5.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.35.1.tgz#af355fe52a0cc88301e889bc4ada72f279b63d61"
+  integrity sha512-FDaujtsH07VHzG0gQ6NDkVVhi1+rhq0qEvzHdJAQjysN+LHDCKDKCBRlZFFE0ec0jKxiv0hN63SNfExy0KrbQQ==
 
-"@typescript-eslint/typescript-estree@5.19.0":
-  version "5.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.19.0.tgz#fc987b8f62883f9ea6a5b488bdbcd20d33c0025f"
-  integrity sha512-dRPuD4ocXdaE1BM/dNR21elSEUPKaWgowCA0bqJ6YbYkvtrPVEvZ+zqcX5a8ECYn3q5iBSSUcBBD42ubaOp0Hw==
+"@typescript-eslint/typescript-estree@5.35.1":
+  version "5.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.35.1.tgz#db878a39a0dbdc9bb133f11cdad451770bfba211"
+  integrity sha512-JUqE1+VRTGyoXlDWWjm6MdfpBYVq+hixytrv1oyjYIBEOZhBCwtpp5ZSvBt4wIA1MKWlnaC2UXl2XmYGC3BoQA==
   dependencies:
-    "@typescript-eslint/types" "5.19.0"
-    "@typescript-eslint/visitor-keys" "5.19.0"
-    debug "^4.3.2"
-    globby "^11.0.4"
+    "@typescript-eslint/types" "5.35.1"
+    "@typescript-eslint/visitor-keys" "5.35.1"
+    debug "^4.3.4"
+    globby "^11.1.0"
     is-glob "^4.0.3"
-    semver "^7.3.5"
+    semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.19.0":
-  version "5.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.19.0.tgz#fe87f1e3003d9973ec361ed10d36b4342f1ded1e"
-  integrity sha512-ZuEckdupXpXamKvFz/Ql8YnePh2ZWcwz7APICzJL985Rp5C2AYcHO62oJzIqNhAMtMK6XvrlBTZeNG8n7gS3lQ==
+"@typescript-eslint/utils@5.35.1":
+  version "5.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.35.1.tgz#ae1399afbfd6aa7d0ed1b7d941e9758d950250eb"
+  integrity sha512-v6F8JNXgeBWI4pzZn36hT2HXXzoBBBJuOYvoQiaQaEEjdi5STzux3Yj8v7ODIpx36i/5s8TdzuQ54TPc5AITQQ==
   dependencies:
     "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.19.0"
-    "@typescript-eslint/types" "5.19.0"
-    "@typescript-eslint/typescript-estree" "5.19.0"
+    "@typescript-eslint/scope-manager" "5.35.1"
+    "@typescript-eslint/types" "5.35.1"
+    "@typescript-eslint/typescript-estree" "5.35.1"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/visitor-keys@5.19.0":
-  version "5.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.19.0.tgz#c84ebc7f6c744707a361ca5ec7f7f64cd85b8af6"
-  integrity sha512-Ym7zZoMDZcAKWsULi2s7UMLREdVQdScPQ/fKWMYefarCztWlHPFVJo8racf8R0Gc8FAEJ2eD4of8As1oFtnQlQ==
+"@typescript-eslint/visitor-keys@5.35.1":
+  version "5.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.35.1.tgz#285e9e34aed7c876f16ff646a3984010035898e6"
+  integrity sha512-cEB1DvBVo1bxbW/S5axbGPE6b7FIMAbo3w+AGq6zNDA7+NYJOIkKj/sInfTv4edxd4PxJSgdN4t6/pbvgA+n5g==
   dependencies:
-    "@typescript-eslint/types" "5.19.0"
-    eslint-visitor-keys "^3.0.0"
+    "@typescript-eslint/types" "5.35.1"
+    eslint-visitor-keys "^3.3.0"
 
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
@@ -5301,7 +5301,7 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.3.0:
+eslint-visitor-keys@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
@@ -5844,7 +5844,7 @@ function-bind@^1.1.1:
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
-  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+  integrity sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==
 
 functions-have-names@^1.2.2:
   version "1.2.2"
@@ -6044,7 +6044,7 @@ globals@^13.6.0, globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
-globby@^11.0.0, globby@^11.0.1, globby@^11.0.4:
+globby@^11.0.0, globby@^11.0.1, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -6682,7 +6682,7 @@ ieee754@^1.1.13:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
-ignore@^5.0.0, ignore@^5.1.8, ignore@^5.2.0:
+ignore@^5.0.0, ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
@@ -6970,7 +6970,7 @@ is-extendable@^0.1.0:
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
-  integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
+  integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
@@ -11382,7 +11382,7 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.0.0, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
+semver@^7.0.0, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
   version "7.3.7"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
   integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
@@ -12617,10 +12617,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+typescript@^4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Also upgrades related ESLint plugins

## What I did

1. `yarn install -D typescript@latest -W`
2. Set version constraint to use `~` since TypeScript doesn't follow semver
3. Fix new errors
  a. Most were cause by catch parameters (`error`) being unknown. I cast these to specific Error types when possible.
  b. One set of errors was around very dynamic console patching that wasn't very type safe to begin with.
4. Upgrade the TypeScript ESLint parser and plugin

I'm unsure whether the upgraded `tsc` will cause .d.ts changes that are backwards incompatible. This should be checked before merging. It's possible, because I needed to upgrade TypeScript to be able to upgrade parse5, since parse5 7.0 uses `type` imports that TypeScript 4.1 can't parse.
