### PR TITLE
docs: Instructions for enabling a11snapshot

### DIFF
--- a/docs/docs/test-runner/commands.md
+++ b/docs/docs/test-runner/commands.md
@@ -434,6 +434,18 @@ The `a11ySnapshot` command requests a snapshot of the accessibility tree built i
 
 `a11ySnapshot` is supported in `@web/test-runner-chrome`, `-puppeteer` and `-playwright`.
 
+The `a11ySnapshot` plugin is not loaded by the Web Test Runner's default configuration, make sure to enable it in your configuration:
+
+```js
+import { a11ySnapshotPlugin } from '@web/test-runner-commands/plugins';
+
+export default {
+  plugins: [
+    a11ySnapshotPlugin()
+  ]
+}
+```
+
 <details>
 <summary>View example</summary>
 

--- a/docs/docs/test-runner/commands.md
+++ b/docs/docs/test-runner/commands.md
@@ -440,10 +440,8 @@ The `a11ySnapshot` plugin is not loaded by the Web Test Runner's default configu
 import { a11ySnapshotPlugin } from '@web/test-runner-commands/plugins';
 
 export default {
-  plugins: [
-    a11ySnapshotPlugin()
-  ]
-}
+  plugins: [a11ySnapshotPlugin()],
+};
 ```
 
 <details>


### PR DESCRIPTION
Some browser commands are availble by default, but a11ysnapshot is not.

The error message reads: `Error: Error while executing command a11y-snapshot: Unknown command a11y-snapshot. Did you install a plugin to handle this command?` This is OK for someone who is familiar with Web Test Runner, but users getting started with testing could perhaps use a little bit more assistance. That's why I am proposing to add this section to the documentation.

## What I did

1.
