### PR TITLE
Add selectOption command in test-runner-commands

### DIFF
--- a/.changeset/proud-apples-give.md
+++ b/.changeset/proud-apples-give.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-commands': patch
+---
+
+Add selectOption command to select options by value, label, or multiple values and automatically emit native change/input events

--- a/docs/docs/test-runner/commands.md
+++ b/docs/docs/test-runner/commands.md
@@ -332,6 +332,84 @@ it('natively holds and then releases a key', async () => {
 
 </details>
 
+### Select option
+
+The `selectOption` command allows you to select an option in a `<select>` tag by either a single value, a label string or as multiple values, depending on the specific implementations of the browser laucher you're using. Once selected, the native `change` and `input` events are dispatched automatically. The `selectOption` command needs the CSS selector to locate the `<select>` by and the value, label, or values to select. The function is async and should be awaited.
+
+The three major launchers all have different support for selecting options, and the `selectOption` takes this into account.Attempting to select an option via a method that is not implemented in the provided launcher will produce errors. Each supported launcher's option selection support is documented below.
+
+- Playwright
+  - Supports selecting options by `label`, `value`, and `multiple values`
+- Puppeteer
+  - Supports selection options by `value`, and `multiple values` only. Selecting options by label is not implemented
+- WebDriver
+  - [No support for selecting options in JS](https://www.selenium.dev/documentation/webdriver/elements/select_lists/)
+
+<details>
+<summary>View example</summary>
+
+```js
+import { selectOption } from '@web/test-runner-commands';
+
+// Assuming the document.body has a select like:
+// <select id="testSelect">
+//   <option value="first">first option</option>
+//   <option value="second">second option</option>
+//   <option value="third">third option</option>
+// </select>
+
+it('natively selects an option by value', async () => {
+  const valueToSelect = 'first';
+  const select = document.querySelector('#testSelect');
+
+  await selectOption({ selector: '#testSelect', value: valueToSelect });
+
+  expect(select.value).to.equal(valueToSelect);
+});
+
+// PLAYWRIGHT ONLY
+it('natively selects an option by label', async () => {
+  const labelToSelect = 'second option';
+  const select = document.querySelector('#testSelect');
+
+  await selectOption({ selector: '#testSelect', label: labelToSelect });
+
+  const expectedSelectedOption = Array.from(document.querySelectorAll('option')).filter(
+    option => option.textContent === labelToSelect,
+  )[0];
+
+  expect(select.value).to.equal(expectedSelectedOption.value);
+});
+
+it('natively selects an option with multiple values', async () => {
+  const valuesToSelect = ['second', 'third'];
+
+  const select = document.querySelector('#testSelect');
+  select.multiple = true;
+
+  await selectOption({ selector: '#testSelect', values: valuesToSelect });
+
+  const selectedValues = Array.from(select.selectedOptions, option => option.value);
+  expect(selectedValues).to.deep.equal(valuesToSelect);
+});
+
+it('change and input events are fired after option is selected', async () => {
+  let changeEventFired, inputEventFired;
+  const valueToSelect = 'first';
+
+  const select = document.querySelector('#testSelect');
+
+  select.addEventListener('change', () => (changeEventFired = true));
+  select.addEventListener('input', () => (inputEventFired = true));
+  await selectOption({ selector: '#testSelect', value: valueToSelect });
+
+  expect(changeEventFired).to.equal(true);
+  expect(inputEventFired).to.equal(true);
+});
+```
+
+</details>
+
 ### Set user agent
 
 The `setUserAgent` command changes the browser's user agent. The function is async and should be awaited.

--- a/packages/test-runner-commands/browser/commands.mjs
+++ b/packages/test-runner-commands/browser/commands.mjs
@@ -69,6 +69,10 @@ export function sendKeys(options) {
   return executeServerCommand('send-keys', options);
 }
 
+export function selectOption(options) {
+  return executeServerCommand('select-option', options);
+}
+
 export function sendMouse(options) {
   return executeServerCommand('send-mouse', options);
 }

--- a/packages/test-runner-commands/src/selectOptionPlugin.ts
+++ b/packages/test-runner-commands/src/selectOptionPlugin.ts
@@ -2,11 +2,14 @@ import { TestRunnerPlugin } from '@web/test-runner-core';
 import type { ChromeLauncher } from '@web/test-runner-chrome';
 import type { PlaywrightLauncher } from '@web/test-runner-playwright';
 
-type SelectByValuePayload = { selector: string, value: string };
-type SelectByLabelPayload = { selector: string, label: string };
-type SelectMultipleValuesPayload = { selector: string, values: string[] };
+type SelectByValuePayload = { selector: string; value: string };
+type SelectByLabelPayload = { selector: string; label: string };
+type SelectMultipleValuesPayload = { selector: string; values: string[] };
 
-export type SelectOptionPayload = SelectByLabelPayload | SelectByValuePayload | SelectMultipleValuesPayload;
+export type SelectOptionPayload =
+  | SelectByLabelPayload
+  | SelectByValuePayload
+  | SelectMultipleValuesPayload;
 
 function isObject(payload: unknown): payload is Record<string, unknown> {
   return payload != null && typeof payload === 'object';
@@ -17,14 +20,16 @@ function isSelectOptionPayload(payload: unknown): boolean {
 
   if (!isObject(payload)) throw new Error('You must provide a `SelectOptionPayload` object');
 
-  if(!payload.selector || typeof payload.selector !== 'string') {
+  if (!payload.selector || typeof payload.selector !== 'string') {
     throw new Error(`You must provide a selector representing the select you wish to locate`);
   }
 
   const numberOfValidOptions = Object.keys(payload).filter(key =>
     validOptions.includes(key),
   ).length;
-  const unknownOptions = Object.keys(payload).filter(key => ![...validOptions, 'selector'].includes(key));
+  const unknownOptions = Object.keys(payload).filter(
+    key => ![...validOptions, 'selector'].includes(key),
+  );
 
   if (numberOfValidOptions === 0)
     throw new Error(
@@ -43,13 +48,12 @@ function isValuePayload(payload: SelectOptionPayload): payload is SelectByValueP
 }
 
 function isLabelPayload(payload: SelectOptionPayload): payload is SelectByLabelPayload {
-    return 'selector' in payload && 'label' in payload;
+  return 'selector' in payload && 'label' in payload;
 }
 
 function isMultiplePayload(payload: SelectOptionPayload): payload is SelectMultipleValuesPayload {
-    return 'selector' in payload && 'values' in payload;
+  return 'selector' in payload && 'values' in payload;
 }
-
 
 export function selectOptionPlugin(): TestRunnerPlugin<SelectOptionPayload> {
   return {
@@ -72,7 +76,7 @@ export function selectOptionPlugin(): TestRunnerPlugin<SelectOptionPayload> {
             return true;
           } else if (isMultiplePayload(payload)) {
             const { selector, values } = payload;
-            await page.locator(selector).selectOption([ ...values ]);
+            await page.locator(selector).selectOption([...values]);
             return true;
           }
         }
@@ -91,13 +95,13 @@ export function selectOptionPlugin(): TestRunnerPlugin<SelectOptionPayload> {
           } else {
             throw new Error(`Puppeteer only supports selection of an option by its value(s):
             https://pptr.dev/next/api/puppeteer.page.select#parameters
-            `)
+            `);
           }
         }
 
         // handle specific behavior for webdriver
-        if (session.browser.type === 'webdriver') {      
-            throw new Error(`Selecting an option via a browser driver command is not currently implemented in WebDriver yet.
+        if (session.browser.type === 'webdriver') {
+          throw new Error(`Selecting an option via a browser driver command is not currently implemented in WebDriver yet.
             https://www.selenium.dev/documentation/webdriver/elements/select_lists/
             
             When using WebDriver, the current recommended (September 2022) approach is to:
@@ -109,7 +113,9 @@ export function selectOptionPlugin(): TestRunnerPlugin<SelectOptionPayload> {
         }
 
         // you might not be able to support all browser launchers
-        throw new Error(`Selection of select element options is not supported for browser type ${session.browser.type}.`);
+        throw new Error(
+          `Selection of select element options is not supported for browser type ${session.browser.type}.`,
+        );
       }
     },
   };

--- a/packages/test-runner-commands/src/selectOptionPlugin.ts
+++ b/packages/test-runner-commands/src/selectOptionPlugin.ts
@@ -1,0 +1,117 @@
+import { TestRunnerPlugin } from '@web/test-runner-core';
+import type { ChromeLauncher, puppeteerCore } from '@web/test-runner-chrome';
+import type { PlaywrightLauncher } from '@web/test-runner-playwright';
+import type { WebdriverLauncher } from '@web/test-runner-webdriver';
+
+type SelectByValuePayload = { selector: string, value: string };
+type SelectByLabelPayload = { selector: string, label: string };
+type SelectMultipleValuesPayload = { selector: string, values: string[] };
+
+export type SelectOptionPayload = SelectByLabelPayload | SelectByValuePayload | SelectMultipleValuesPayload;
+
+function isObject(payload: unknown): payload is Record<string, unknown> {
+  return payload != null && typeof payload === 'object';
+}
+
+function isSelectOptionPayload(payload: unknown): boolean {
+  const validOptions = ['value', 'label', 'values'];
+
+  if (!isObject(payload)) throw new Error('You must provide a `SelectOptionPayload` object');
+
+  if(!payload.selector || typeof payload.selector !== 'string') {
+    throw new Error(`You must provide a selector representing the select you wish to locate`);
+  }
+
+  const numberOfValidOptions = Object.keys(payload).filter(key =>
+    validOptions.includes(key),
+  ).length;
+  const unknownOptions = Object.keys(payload).filter(key => ![...validOptions, 'selector'].includes(key));
+
+  if (numberOfValidOptions === 0)
+    throw new Error(
+      `You must provide one of the following properties to pass to the browser runner: ${validOptions.join(
+        ', ',
+      )}.`,
+    );
+  if (unknownOptions.length > 0) {
+    throw new Error('Unknown options `' + unknownOptions.join(', ') + '` present.');
+  }
+  return true;
+}
+
+function isValuePayload(payload: SelectOptionPayload): payload is SelectByValuePayload {
+  return 'selector' in payload && 'value' in payload;
+}
+
+function isLabelPayload(payload: SelectOptionPayload): payload is SelectByLabelPayload {
+    return 'selector' in payload && 'label' in payload;
+}
+
+function isMultiplePayload(payload: SelectOptionPayload): payload is SelectMultipleValuesPayload {
+    return 'selector' in payload && 'values' in payload;
+}
+
+
+export function selectOptionPlugin(): TestRunnerPlugin<SelectOptionPayload> {
+  return {
+    name: 'select-option-command',
+    async executeCommand({ command, payload, session }): Promise<any> {
+      if (command === 'select-option') {
+        if (!isSelectOptionPayload(payload) || !payload) {
+          throw new Error('You must provide a `SelectOptionPayload` object');
+        }
+        // handle specific behavior for playwright
+        if (session.browser.type === 'playwright') {
+          const page = (session.browser as PlaywrightLauncher).getPage(session.id);
+          if (isValuePayload(payload)) {
+            const { selector, value } = payload;
+            await page.locator(selector).selectOption(value);
+            return true;
+          } else if (isLabelPayload(payload)) {
+            const { selector, label } = payload;
+            await page.locator(selector).selectOption({ label });
+            return true;
+          } else if (isMultiplePayload(payload)) {
+            const { selector, values } = payload;
+            await page.locator(selector).selectOption([ ...values ]);
+            return true;
+          }
+        }
+
+        // handle specific behavior for puppeteer
+        if (session.browser.type === 'puppeteer') {
+          const page = (session.browser as ChromeLauncher).getPage(session.id);
+          if (isValuePayload(payload)) {
+            const { selector, value } = payload;
+            await page.select(selector, value);
+            return true;
+          } else if (isMultiplePayload(payload)) {
+            const { selector, values } = payload;
+            await page.select(selector, ...values);
+            return true;
+          } else {
+            throw new Error(`Puppeteer only supports selection of an option by its value(s):
+            https://pptr.dev/next/api/puppeteer.page.select#parameters
+            `)
+          }
+        }
+
+        // handle specific behavior for webdriver
+        if (session.browser.type === 'webdriver') {      
+            throw new Error(`Selecting an option via a browser driver command is not currently implemented in WebDriver yet.
+            https://www.selenium.dev/documentation/webdriver/elements/select_lists/
+            
+            When using WebDriver, the current recommended (September 2022) approach is to:
+            - locate your select element (via querySelector or querySelectorAll)
+            - focus the element
+            - use sendKeys() to type the label of the option you wish to select
+            - use select.dispatchEvent(new Event('change')) to trigger a change event on the select.
+            `);
+        }
+
+        // you might not be able to support all browser launchers
+        throw new Error(`Selection of select element options is not supported for browser type ${session.browser.type}.`);
+      }
+    },
+  };
+}

--- a/packages/test-runner-commands/src/selectOptionPlugin.ts
+++ b/packages/test-runner-commands/src/selectOptionPlugin.ts
@@ -1,7 +1,6 @@
 import { TestRunnerPlugin } from '@web/test-runner-core';
-import type { ChromeLauncher, puppeteerCore } from '@web/test-runner-chrome';
+import type { ChromeLauncher } from '@web/test-runner-chrome';
 import type { PlaywrightLauncher } from '@web/test-runner-playwright';
-import type { WebdriverLauncher } from '@web/test-runner-webdriver';
 
 type SelectByValuePayload = { selector: string, value: string };
 type SelectByLabelPayload = { selector: string, label: string };

--- a/packages/test-runner-commands/test/select-option/playwright-test.js
+++ b/packages/test-runner-commands/test/select-option/playwright-test.js
@@ -1,0 +1,55 @@
+import { selectOption } from '../../browser/commands.mjs';
+import { expect } from '../chai.js';
+
+const selectTemplate = `<select id="testSelect">
+  <option value="first">first option</option>
+  <option value="second">second option</option>
+  <option value="third">third option</option>
+</select>`;
+
+it('natively selects an option by value', async () => {
+  const valueToSelect = 'first';
+  document.body.innerHTML = selectTemplate;
+  const select = document.querySelector('#testSelect');
+  await selectOption({ selector: '#testSelect', value: valueToSelect });
+
+  expect(select.value).to.equal(valueToSelect);
+});
+
+it('natively selects an option by label', async () => {
+  const labelToSelect = 'second option';
+  document.body.innerHTML = selectTemplate;
+
+  const select = document.querySelector('#testSelect');
+  await selectOption({ selector: '#testSelect', label: labelToSelect });
+
+  const expectedSelectedOption = Array.from(document.querySelectorAll('option')).filter(
+    option => option.textContent === labelToSelect,
+  )[0];
+
+  expect(select.value).to.equal(expectedSelectedOption.value);
+});
+
+it('natively selects an option with multiple values', async () => {
+  const valuesToSelect = ['second', 'third'];
+  document.body.innerHTML = selectTemplate;
+  const select = document.querySelector('#testSelect');
+  select.multiple = true;
+  await selectOption({ selector: '#testSelect', values: valuesToSelect });
+  const selectedValues = Array.from(select.selectedOptions, option => option.value);
+  expect(selectedValues).to.deep.equal(valuesToSelect);
+});
+
+it('change and input events are fired after option is selected', async () => {
+  let changeEventFired, inputEventFired;
+  const valueToSelect = 'first';
+  document.body.innerHTML = selectTemplate;
+  const select = document.querySelector('#testSelect');
+
+  select.addEventListener('change', () => (changeEventFired = true));
+  select.addEventListener('input', () => (inputEventFired = true));
+  await selectOption({ selector: '#testSelect', value: valueToSelect });
+
+  expect(changeEventFired).to.equal(true);
+  expect(inputEventFired).to.equal(true);
+});

--- a/packages/test-runner-commands/test/select-option/puppeteer-test.js
+++ b/packages/test-runner-commands/test/select-option/puppeteer-test.js
@@ -1,0 +1,41 @@
+import { selectOption } from '../../browser/commands.mjs';
+import { expect } from '../chai.js';
+
+const selectTemplate = `<select id="testSelect">
+  <option value="first">first option</option>
+  <option value="second">second option</option>
+  <option value="third">third option</option>
+</select>`;
+
+it('natively selects an option by value', async () => {
+  const valueToSelect = 'first';
+  document.body.innerHTML = selectTemplate;
+  const select = document.querySelector('#testSelect');
+  await selectOption({ selector: '#testSelect', value: valueToSelect });
+
+  expect(select.value).to.equal(valueToSelect);
+});
+
+it('natively selects an option with multiple values', async () => {
+  const valuesToSelect = ['second', 'third'];
+  document.body.innerHTML = selectTemplate;
+  const select = document.querySelector('#testSelect');
+  select.multiple = true;
+  await selectOption({ selector: '#testSelect', values: valuesToSelect });
+  const selectedValues = Array.from(select.selectedOptions, option => option.value);
+  expect(selectedValues).to.deep.equal(valuesToSelect);
+});
+
+it('change and input events are fired after option is selected', async () => {
+  let changeEventFired, inputEventFired;
+  const valueToSelect = 'first';
+  document.body.innerHTML = selectTemplate;
+  const select = document.querySelector('#testSelect');
+
+  select.addEventListener('change', () => (changeEventFired = true));
+  select.addEventListener('input', () => (inputEventFired = true));
+  await selectOption({ selector: '#testSelect', value: valueToSelect });
+
+  expect(changeEventFired).to.equal(true);
+  expect(inputEventFired).to.equal(true);
+});

--- a/packages/test-runner-commands/test/select-option/selectOptionPlugin.test.ts
+++ b/packages/test-runner-commands/test/select-option/selectOptionPlugin.test.ts
@@ -1,0 +1,30 @@
+import path from 'path';
+import { runTests } from '@web/test-runner-core/test-helpers';
+import { chromeLauncher } from '@web/test-runner-chrome';
+import { playwrightLauncher } from '@web/test-runner-playwright';
+
+import { selectOptionPlugin } from '../../src/selectOptionPlugin';
+
+describe('selectOptionPlugin', function test() {
+  this.timeout(20000);
+
+  it('can send keys on puppeteer', async () => {
+    await runTests({
+      files: [path.join(__dirname, 'puppeteer-test.js')],
+      browsers: [chromeLauncher()],
+      plugins: [selectOptionPlugin()],
+    });
+  });
+
+  it('can send keys on playwright', async () => {
+    await runTests({
+      files: [path.join(__dirname, 'playwright-test.js')],
+      browsers: [
+        playwrightLauncher({ product: 'chromium' }),
+        playwrightLauncher({ product: 'firefox' }),
+        playwrightLauncher({ product: 'webkit' }),
+      ],
+      plugins: [selectOptionPlugin()],
+    });
+  });
+});


### PR DESCRIPTION
## What I did

**Background**
Having written a few tests where selecting an option in a `<select>` was necessary, I've always found that the "normal" method of setting a select's value then programmatically triggering the events with `dispatchEvent` kinda breaks the testing paradigm of "interact like a user would" in the case of e2e tests. Using a driver based "select option" command, imo, better fits the model of interacting like a user, since the test code doesn't manually emit events then test if they fired. Tests can just call the `selectOption` command, and the browser will act as if the user clicked an option on the page.

Playwright and Puppeteer both implement a browser driver command for option selection that automatically emits native `change` and `input` events. This PR adds those commands as a `test-runner-commands` plugin.

1. Added a `selectOption` command plugin with tests and documentation such that options can be selected via labels, values, or multiple values, depending on the support available in supported launchers. (unfortunately, selecting options doesn't seem to be implemented in WebDriver for JS)
