### PR TITLE
Document possibility for TypeScript path resolving

### DIFF
--- a/docs/docs/dev-server/plugins/rollup.md
+++ b/docs/docs/dev-server/plugins/rollup.md
@@ -73,6 +73,7 @@ The following rollup plugins have been tested to work correctly:
 - [@rollup/plugin-node-resolve](https://github.com/rollup/plugins/tree/master/packages/node-resolve)
 - [@rollup/plugin-replace](https://github.com/rollup/plugins/tree/master/packages/replace)
 - [@rollup/plugin-sucrase](https://github.com/rollup/plugins/tree/master/packages/sucrase)
+- [rollup-plugin-typescript-paths](https://github.com/simonhaenisch/rollup-plugin-typescript-paths)
 
 The following rollup plugins don't work correctly at the moment:
 


### PR DESCRIPTION
Using rollup-plugin-typescript-paths works great for resolving custom imports; like `@interal/helpers` via TS config paths.

Example usage:
```js
import { esbuildPlugin } from '@web/dev-server-esbuild';
import { fromRollup } from '@web/dev-server-rollup';

import rollupCommonjs from '@rollup/plugin-commonjs';
import { typescriptPaths as rollupTypescriptPaths } from 'rollup-plugin-typescript-paths';

import { chromeLauncher } from '@web/test-runner';

const commonjs = fromRollup(rollupCommonjs);
const typescriptPaths = fromRollup(rollupTypescriptPaths);

export default {
  files: ['src/**/*.test.ts'],
  coverage: true,
  nodeResolve: true,
  testFramework: {
    config: {
      ui: 'bdd',
      timeout: '20000',
    },
  },
  browsers: [
    chromeLauncher({ launchOptions: { args: ['--no-sandbox'] } })
  ],
  plugins: [
    typescriptPaths({
      tsConfigPath: './tsconfig.json',
      absolute: true,
      transform: path => path.replace('.js', '.ts')
    }),
    esbuildPlugin({ ts: true, target: 'es2020', tsconfig: './tsconfig.json' })
  ],
};

```
