### PR TITLE
Delete prefix requirement for appIndex redirect.

### DIFF
--- a/packages/dev-server-core/src/middleware/historyApiFallbackMiddleware.ts
+++ b/packages/dev-server-core/src/middleware/historyApiFallbackMiddleware.ts
@@ -35,10 +35,6 @@ export function historyApiFallbackMiddleware(
       return next();
     }
 
-    if (!ctx.url.startsWith(appIndexBrowserPathPrefix)) {
-      return next();
-    }
-
     // rewrite url and let static serve take it further
     logger.debug(`Rewriting ${ctx.url} to app index ${appIndexBrowserPath}`);
     ctx.url = appIndexBrowserPath;


### PR DESCRIPTION
See issue #1334 for context.

This removes the requirement that the devserver see the appIndex relative path at the beginning of the url path in order for the devserver to redirect to the index page. As a developer, I'd expect any page that does not match a URL redirect to the index.html file. This is especially helpful for monorepos where the appIndex file ends up pointing to /packages/example/dev/index.html.
