### PR TITLE
fix (dev-server-rollup): support child plugins in resolution algorithm

### DIFF
--- a/packages/dev-server-core/src/index.ts
+++ b/packages/dev-server-core/src/index.ts
@@ -6,7 +6,7 @@ import WebSocket from 'ws';
 export { WebSocket };
 
 export { DevServer } from './server/DevServer';
-export { Plugin, ServerStartParams } from './plugins/Plugin';
+export { Plugin, ServerStartParams, ResolveOptions } from './plugins/Plugin';
 export { DevServerCoreConfig, MimeTypeMappings } from './server/DevServerCoreConfig';
 export { WebSocketsManager, WebSocketData } from './web-sockets/WebSocketsManager';
 export {

--- a/packages/dev-server-core/src/plugins/Plugin.ts
+++ b/packages/dev-server-core/src/plugins/Plugin.ts
@@ -26,6 +26,12 @@ export interface ServerStartParams {
   webSockets?: WebSocketsManager;
 }
 
+export interface ResolveOptions {
+  isEntry?: boolean;
+  skipSelf?: boolean;
+  [key: string]: unknown;
+}
+
 export interface Plugin {
   name: string;
   injectWebSocket?: boolean;
@@ -40,11 +46,7 @@ export interface Plugin {
     code?: string;
     column?: number;
     line?: number;
-    resolveOptions?: {
-      custom?: Record<string, unknown>;
-      isEntry?: boolean;
-      skipSelf?: boolean;
-    };
+    resolveOptions?: ResolveOptions;
   }): ResolveResult | Promise<ResolveResult>;
   resolveImportSkip?(context: Context, source: string, importer: string): void;
   transformImport?(args: {

--- a/packages/dev-server-core/src/plugins/Plugin.ts
+++ b/packages/dev-server-core/src/plugins/Plugin.ts
@@ -46,6 +46,7 @@ export interface Plugin {
       skipSelf?: boolean;
     };
   }): ResolveResult | Promise<ResolveResult>;
+  resolveImportSkip?(context: Context, source: string, importer: string): void;
   transformImport?(args: {
     source: string;
     context: Context;

--- a/packages/dev-server-core/src/plugins/Plugin.ts
+++ b/packages/dev-server-core/src/plugins/Plugin.ts
@@ -40,7 +40,11 @@ export interface Plugin {
     code?: string;
     column?: number;
     line?: number;
-    resolveOptions?: Record<string, unknown>;
+    resolveOptions?: {
+      custom?: Record<string, unknown>;
+      isEntry?: boolean;
+      skipSelf?: boolean;
+    };
   }): ResolveResult | Promise<ResolveResult>;
   transformImport?(args: {
     source: string;

--- a/packages/dev-server-core/src/plugins/Plugin.ts
+++ b/packages/dev-server-core/src/plugins/Plugin.ts
@@ -40,6 +40,7 @@ export interface Plugin {
     code?: string;
     column?: number;
     line?: number;
+    resolveOptions?: Record<string, unknown>;
   }): ResolveResult | Promise<ResolveResult>;
   transformImport?(args: {
     source: string;

--- a/packages/dev-server-rollup/src/createRollupPluginContextAdapter.ts
+++ b/packages/dev-server-rollup/src/createRollupPluginContextAdapter.ts
@@ -74,11 +74,12 @@ export function createRollupPluginContextAdapter<
       if (!context) throw new Error('Context is required.');
 
       for (const pl of config.plugins ?? []) {
-        if (
-          pl.resolveImport &&
-          (!options.skipSelf || pl.resolveImport !== wdsPlugin.resolveImport)
-        ) {
-          const result = await pl.resolveImport({ source, context });
+        if (pl.resolveImport && (!options.skipSelf || pl !== wdsPlugin)) {
+          const result = await pl.resolveImport({
+            source,
+            context,
+            resolveOptions: options,
+          });
           let resolvedId: string | undefined;
           if (typeof result === 'string') {
             resolvedId = result;

--- a/packages/dev-server-rollup/src/createRollupPluginContextAdapter.ts
+++ b/packages/dev-server-rollup/src/createRollupPluginContextAdapter.ts
@@ -1,5 +1,11 @@
 import path from 'path';
-import { DevServerCoreConfig, FSWatcher, Plugin as WdsPlugin, Context } from '@web/dev-server-core';
+import {
+  DevServerCoreConfig,
+  FSWatcher,
+  Plugin as WdsPlugin,
+  Context,
+  ResolveOptions,
+} from '@web/dev-server-core';
 import {
   PluginContext,
   MinimalPluginContext,
@@ -7,11 +13,6 @@ import {
   CustomPluginOptions,
   ModuleInfo,
 } from 'rollup';
-
-interface ResolveOptions {
-  skipSelf?: boolean;
-  [key: string]: unknown;
-}
 
 export function createRollupPluginContextAdapter<
   T extends PluginContext | MinimalPluginContext | TransformPluginContext,

--- a/packages/dev-server-rollup/src/rollupAdapter.ts
+++ b/packages/dev-server-rollup/src/rollupAdapter.ts
@@ -129,7 +129,7 @@ export function rollupAdapter(
       resolverCache.set(context, resolverCacheForContext);
       const resolverCacheForPlugin = resolverCacheForContext.get(wdsPlugin) ?? new Set<string>();
       resolverCacheForContext.set(wdsPlugin, resolverCacheForPlugin);
-      
+
       resolverCacheForPlugin.add(`${source}:${importer}`);
     },
 


### PR DESCRIPTION
It is possible a rollup plug injects its own child plugins by hooking into the rollup `options` hook and mutating the options to have extra plugs.

This change introduces a check for such plugins and calls them before the host plugin in case they successfully resolve a path first.

Similarly, the `resolve` method of plugins receives an options object to hold state for the resolution plugins. We currently lose this object when calling through to `resolveImport`, which can confuse third-party plugins/resolvers heavily.

To fix this, `resolveImport` now also accepts a `resolverOptions` so we can pass it on when calling child plugins.

cc @lucaelin as discussed in #1700

this was an incredibly deep rabbit hole of spaghetti code (outside modernweb), thanks a lot to lucaelin for figuring a bunch of it out too.

its possible we still need to fix rollup upstream as it has some weird import/export mismatch lucaelin is aware of (and already opened an issue for?). weirdly my local copy passes fine now but its possible in the week ive had this up on bricks, i just fixed it in node_modules and forgot about it (to get it working).

## WIP for now

as im ~pretty sure~ certain there's _still_ another infinite loop floating around...