### PR TITLE
Allow test-runner to run tests without adding files to the watcher

### DIFF
--- a/.changeset/mighty-yaks-develop.md
+++ b/.changeset/mighty-yaks-develop.md
@@ -1,0 +1,6 @@
+---
+'@web/dev-server-core': minor
+'@web/test-runner-core': patch
+---
+
+Add option to disable the fileWatcher in the dev server, to allow the test-runner to run once without files added to the watcher.

--- a/docs/docs/dev-server/cli-and-configuration.md
+++ b/docs/docs/dev-server/cli-and-configuration.md
@@ -86,7 +86,7 @@ interface DevServerConfig {
   open?: 'string' | boolean;
   // index HTML to use for SPA routing / history API fallback
   appIndex?: string;
-  // run in watch mode, reloading when files change
+  // reload the brower on file changes.
   watch?: boolean;
   // resolve bare module imports
   nodeResolve?: boolean | RollupNodeResolveOptions;

--- a/docs/docs/dev-server/cli-and-configuration.md
+++ b/docs/docs/dev-server/cli-and-configuration.md
@@ -124,6 +124,10 @@ interface DevServerConfig {
   sslKey?: string;
   // path to SSL certificate
   sslCert?: string;
+
+  // Whether to watch and rebuild served files.
+  // Useful when you want more control over when files are build (e.g. when doing a test run using @web/test-runner).
+  disableFileWatcher?: boolean;
 }
 ```
 

--- a/packages/dev-server-core/src/server/DevServerCoreConfig.ts
+++ b/packages/dev-server-core/src/server/DevServerCoreConfig.ts
@@ -56,4 +56,10 @@ export interface DevServerCoreConfig {
    * by the dev server. Defaults to true.
    */
   injectWebSocket?: boolean;
+  
+  /**
+   * Whether to watch and rebuild served files.
+   * Useful when you want more control over when files are build (e.g. when doing a test run using @web/test-runner).
+   */
+  disableFileWatcher?: boolean;
 }

--- a/packages/dev-server-core/src/server/createMiddleware.ts
+++ b/packages/dev-server-core/src/server/createMiddleware.ts
@@ -41,8 +41,10 @@ export function createMiddleware(
     middlewares.push(m);
   }
 
-  // watch files that are served
-  middlewares.push(watchServedFilesMiddleware(fileWatcher, config.rootDir));
+  if (!config.disableFileWatcher) {
+    // watch files that are served
+    middlewares.push(watchServedFilesMiddleware(fileWatcher, config.rootDir));
+  }
 
   // serves 304 responses if resource hasn't changed
   middlewares.push(etagCacheMiddleware());

--- a/packages/dev-server-core/test/server/DevServer.test.ts
+++ b/packages/dev-server-core/test/server/DevServer.test.ts
@@ -3,6 +3,7 @@ import { Server } from 'net';
 import { FSWatcher } from 'chokidar';
 import { expect } from 'chai';
 import fetch from 'node-fetch';
+import { Stub, stubMethod } from 'hanbi';
 import { ServerStartParams } from '../../src/plugins/Plugin';
 import { DevServer } from '../../src/server/DevServer';
 import { createTestServer } from '../helpers';
@@ -179,4 +180,49 @@ it('waits on server start hooks before starting', async () => {
   expect(aFinished).to.be.true;
   expect(bFinished).to.be.true;
   server.stop();
+});
+
+describe('disableFileWatcher', () => {
+  /**
+   * Extracted setup to ensure `fileWatcher.add` is called when
+   * `disableFileWatch = false`. Only then there is confidence that the
+   * `disableFileWatch = true` actually works.
+   * */
+  const setupDisableFileWatch = async (config: { disableFileWatcher: boolean }) => {
+    let fileWatchStub: Stub<FSWatcher['add']>;
+    const { host, server } = await createTestServer({
+      disableFileWatcher: config.disableFileWatcher,
+      plugins: [
+        {
+          name: 'watcher-stub',
+          serverStart({ fileWatcher }) {
+            fileWatchStub = stubMethod(fileWatcher, 'add');
+          },
+        },
+      ],
+    });
+    // @ts-ignore
+    if (!fileWatchStub) {
+      throw new Error('Something went wrong with stubbing the file watcher');
+    }
+
+    // Ensure something is fetched to trigger all the middlewares
+    await fetch(`${host}/index.html`);
+
+    return { fileWatchStub, host, server };
+  };
+
+  it('disables file watch when true', async () => {
+    const { fileWatchStub, server } = await setupDisableFileWatch({ disableFileWatcher: true })
+
+    expect(fileWatchStub.callCount).to.equal(0);
+    server.stop();
+  });
+  
+  it('leaves file watch in tact when false', async () => {
+    const { fileWatchStub, server } = await setupDisableFileWatch({ disableFileWatcher: false });
+
+    expect(fileWatchStub.callCount).to.gt(0);
+    server.stop();
+  });
 });

--- a/packages/test-runner-core/src/server/TestRunnerServer.ts
+++ b/packages/test-runner-core/src/server/TestRunnerServer.ts
@@ -45,6 +45,9 @@ export class TestRunnerServer {
       sslCert: config.sslCert,
 
       mimeTypes: config.mimeTypes,
+
+      disableFileWatcher: !config.watch,
+
       middleware: [
         watchFilesMiddleware({ runSessions, sessions, rootDir, fileWatcher: this.fileWatcher }),
         cacheMiddleware(CACHED_PATTERNS, config.watch),


### PR DESCRIPTION
## What I did

1. Added a `disableFileWatcher` as a flag to the config of the dev-server.
2. Pass `disableFileWatcher` from the test-runner to the dev-server depending on the watch mode of the test-runner.

## Why?

While using the `@web/test-runner` in a Gitlab CI, it was noticed that the test was sometimes failing due to the browser (Playwright) being killed. This was due the a file watch limit in the CI. Due to the flakyness I am not able to give a clear reproduction on this issue. It also does not help that this is a private Gitlab, but I can provide the error:
`2022-10-17T08:06:58.884Z pw:browser [pid=155][err] [1017/080658.883851:ERROR:file_path_watcher_inotify.cc(333)] inotify_init() failed: Too many open files (24)`

It is possible to fix this via a plugin, but I hope to also solve future issues by doing a proper fix. The plugin would look like this if anyone is interested:
``` TypeScript
const unwatchPlugin = (unwatch) => ({
	name: 'unwatch',
	serverStart: ({ fileWatcher }) => {
		if (unwatch) {
			fileWatcher.add = () => {};
		}
	},
});
```
Using the plugin I was able to verify that the watcher had to do with the issue. I am aware that the watcher should not trigger problems in the CI, but I think the simpler a test run is in the CI, the better.


