### PR TITLE
fix: update portfinder dependency to 1.0.32

### DIFF
--- a/.changeset/loud-bugs-move.md
+++ b/.changeset/loud-bugs-move.md
@@ -1,0 +1,6 @@
+---
+'@web/dev-server': patch
+'@web/test-runner': patch
+---
+
+Update portfinder dependency to 1.0.32

--- a/packages/dev-server-core/package.json
+++ b/packages/dev-server-core/package.json
@@ -84,6 +84,6 @@
     "abort-controller": "^3.0.0",
     "nanoid": "^3.1.25",
     "node-fetch": "3.0.0-beta.9",
-    "portfinder": "^1.0.28"
+    "portfinder": "^1.0.32"
   }
 }

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -68,7 +68,7 @@
     "ip": "^1.1.5",
     "nanocolors": "^0.2.1",
     "open": "^8.0.2",
-    "portfinder": "^1.0.28"
+    "portfinder": "^1.0.32"
   },
   "devDependencies": {
     "@types/command-line-usage": "^5.0.1",

--- a/packages/test-runner-browserstack/package.json
+++ b/packages/test-runner-browserstack/package.json
@@ -53,6 +53,6 @@
   "devDependencies": {
     "@types/ip": "^1.1.0",
     "@web/dev-server-legacy": "^1.0.0",
-    "portfinder": "^1.0.28"
+    "portfinder": "^1.0.32"
   }
 }

--- a/packages/test-runner-core/package.json
+++ b/packages/test-runner-core/package.json
@@ -78,6 +78,6 @@
     "source-map": "^0.7.3"
   },
   "devDependencies": {
-    "portfinder": "^1.0.28"
+    "portfinder": "^1.0.32"
   }
 }

--- a/packages/test-runner-playwright/package.json
+++ b/packages/test-runner-playwright/package.json
@@ -51,6 +51,6 @@
   },
   "devDependencies": {
     "@web/test-runner-mocha": "^0.7.4",
-    "portfinder": "^1.0.28"
+    "portfinder": "^1.0.32"
   }
 }

--- a/packages/test-runner-saucelabs/package.json
+++ b/packages/test-runner-saucelabs/package.json
@@ -56,6 +56,6 @@
     "@types/ip": "^1.1.0",
     "@web/dev-server-esbuild": "^0.3.0",
     "@web/dev-server-legacy": "^1.0.0",
-    "portfinder": "^1.0.28"
+    "portfinder": "^1.0.32"
   }
 }

--- a/packages/test-runner/package.json
+++ b/packages/test-runner/package.json
@@ -93,7 +93,7 @@
     "diff": "^5.0.0",
     "globby": "^11.0.1",
     "nanocolors": "^0.2.1",
-    "portfinder": "^1.0.28",
+    "portfinder": "^1.0.32",
     "source-map": "^0.7.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3053,7 +3053,7 @@ async@1.5.2:
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
-async@^2.6.2:
+async@^2.6.4:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
   integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
@@ -4501,7 +4501,7 @@ debug@4.3.2:
   dependencies:
     ms "2.1.2"
 
-debug@^3.1.0, debug@^3.1.1:
+debug@^3.1.0, debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -8987,7 +8987,7 @@ mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
-mkdirp@^0.5.1, mkdirp@^0.5.5:
+mkdirp@^0.5.1, mkdirp@^0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
@@ -9825,14 +9825,14 @@ pngjs@^6.0.0:
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-6.0.0.tgz#ca9e5d2aa48db0228a52c419c3308e87720da821"
   integrity sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==
 
-portfinder@^1.0.28:
-  version "1.0.28"
-  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"
-  integrity sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==
+portfinder@^1.0.32:
+  version "1.0.32"
+  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.32.tgz#2fe1b9e58389712429dc2bea5beb2146146c7f81"
+  integrity sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==
   dependencies:
-    async "^2.6.2"
-    debug "^3.1.1"
-    mkdirp "^0.5.5"
+    async "^2.6.4"
+    debug "^3.2.7"
+    mkdirp "^0.5.6"
 
 portscanner@2.1.1:
   version "2.1.1"


### PR DESCRIPTION
## What I did

Updated `portfinder` version to `^1.0.32` to ensure it gets version of `async` with a vulnerability fix.
See https://github.com/caolan/async/pull/1828#issuecomment-1098568048 and https://github.com/http-party/node-portfinder/issues/126#issuecomment-1202005607.

Fixes #1934
