### PR TITLE
fix(dev-server-rollup): fix rollup adapter virtual modules resolution for windows environments

### DIFF
--- a/.changeset/fair-geese-bathe.md
+++ b/.changeset/fair-geese-bathe.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server-rollup': patch
+---
+
+fix rollup adapter virtual modules resolution for windows environments

--- a/packages/dev-server-rollup/src/rollupAdapter.ts
+++ b/packages/dev-server-rollup/src/rollupAdapter.ts
@@ -113,7 +113,11 @@ export function rollupAdapter(
         return;
       }
 
-      if (!injectedFilePath && !path.isAbsolute(source) && whatwgUrl.parseURL(source) != null) {
+      if (
+        !injectedFilePath &&
+        !path.isAbsolute(source.replace('\0', '')) &&
+        whatwgUrl.parseURL(source) != null
+      ) {
         // don't resolve relative and valid urls
         return source;
       }


### PR DESCRIPTION
Please refer to https://github.com/modernweb-dev/web/issues/2078 for full context.