### PR TITLE
fix(all): add types to exports for node16/nodenext module resolution

### DIFF
--- a/.changeset/tasty-waves-allow.md
+++ b/.changeset/tasty-waves-allow.md
@@ -1,0 +1,34 @@
+---
+'@web/browser-logs': patch
+'@web/config-loader': patch
+'@web/dev-server': patch
+'@web/dev-server-core': patch
+'@web/dev-server-esbuild': patch
+'@web/dev-server-hmr': patch
+'@web/dev-server-import-maps': patch
+'@web/dev-server-legacy': patch
+'@web/dev-server-rollup': patch
+'@web/dev-server-storybook': patch
+'@web/parse5-utils': patch
+'@web/polyfills-loader': patch
+'@web/rollup-plugin-copy': patch
+'@web/rollup-plugin-html': patch
+'@web/rollup-plugin-import-meta-assets': patch
+'@web/rollup-plugin-polyfills-loader': patch
+'rollup-plugin-workbox': patch
+'@web/test-runner-browserstack': patch
+'@web/test-runner-chrome': patch
+'@web/test-runner-cli': patch
+'@web/test-runner-commands': patch
+'@web/test-runner-core': patch
+'@web/test-runner-coverage-v8': patch
+'@web/test-runner-junit-reporter': patch
+'@web/test-runner-playwright': patch
+'@web/test-runner-puppeteer': patch
+'@web/test-runner-saucelabs': patch
+'@web/test-runner-selenium': patch
+'@web/test-runner-visual-regression': patch
+'@web/test-runner-webdriver': patch
+---
+
+Add explicit types export to work with node16 module resolution (typescript ≥ 4.7)

--- a/packages/browser-logs/package.json
+++ b/packages/browser-logs/package.json
@@ -16,8 +16,14 @@
   "main": "dist/index.js",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -44,8 +44,14 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./src/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./src/index.d.ts",
+        "default": "./src/index.js"
+      }
     }
   }
 }

--- a/packages/dev-server-core/package.json
+++ b/packages/dev-server-core/package.json
@@ -16,15 +16,30 @@
   "main": "dist/index.js",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     },
     "./dist/dom5": {
-      "require": "./dist/dom5/index.js"
+      "require": {
+        "types": "./dist/dom5/index.d.ts",
+        "default": "./dist/dom5/index.js"
+      }
     },
     "./test-helpers": {
-      "import": "./test-helpers.mjs",
-      "require": "./dist/test-helpers.js"
+      "import": {
+        "types": "./test-helpers.d.ts",
+        "default": "./test-helpers.mjs"
+      },
+      "require": {
+        "types": "./dist/test-helpers.d.ts",
+        "default": "./dist/test-helpers.js"
+      }
     }
   },
   "engines": {

--- a/packages/dev-server-esbuild/package.json
+++ b/packages/dev-server-esbuild/package.json
@@ -16,8 +16,14 @@
   "main": "dist/index.js",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/dev-server-hmr/package.json
+++ b/packages/dev-server-hmr/package.json
@@ -16,8 +16,14 @@
   "main": "dist/index.js",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/dev-server-import-maps/package.json
+++ b/packages/dev-server-import-maps/package.json
@@ -16,8 +16,14 @@
   "main": "dist/index.js",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/dev-server-legacy/package.json
+++ b/packages/dev-server-legacy/package.json
@@ -16,8 +16,14 @@
   "main": "dist/index.js",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/dev-server-rollup/package.json
+++ b/packages/dev-server-rollup/package.json
@@ -16,8 +16,14 @@
   "main": "dist/index.js",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/dev-server-storybook/package.json
+++ b/packages/dev-server-storybook/package.json
@@ -19,8 +19,14 @@
   },
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -20,8 +20,14 @@
   },
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/parse5-utils/package.json
+++ b/packages/parse5-utils/package.json
@@ -16,8 +16,14 @@
   "main": "src/index.js",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./src/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./src/index.d.ts",
+        "default": "./src/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/polyfills-loader/package.json
+++ b/packages/polyfills-loader/package.json
@@ -16,8 +16,14 @@
   "main": "dist/index.js",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/rollup-plugin-copy/package.json
+++ b/packages/rollup-plugin-copy/package.json
@@ -20,8 +20,14 @@
   "module": "index.mjs",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./src/copy.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./src/copy.d.ts",
+        "default": "./src/copy.js"
+      }
     }
   },
   "engines": {

--- a/packages/rollup-plugin-html/package.json
+++ b/packages/rollup-plugin-html/package.json
@@ -16,8 +16,14 @@
   "main": "dist/index.js",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/rollup-plugin-import-meta-assets/package.json
+++ b/packages/rollup-plugin-import-meta-assets/package.json
@@ -16,8 +16,14 @@
   "main": "src/index.js",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./src/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./src/index.d.ts",
+        "default": "./src/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/rollup-plugin-polyfills-loader/package.json
+++ b/packages/rollup-plugin-polyfills-loader/package.json
@@ -16,8 +16,14 @@
   "main": "dist/index.js",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/rollup-plugin-workbox/package.json
+++ b/packages/rollup-plugin-workbox/package.json
@@ -17,8 +17,14 @@
   "module": "index.mjs",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "scripts": {

--- a/packages/test-runner-browserstack/package.json
+++ b/packages/test-runner-browserstack/package.json
@@ -16,8 +16,14 @@
   "main": "dist/index.js",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/test-runner-chrome/package.json
+++ b/packages/test-runner-chrome/package.json
@@ -16,8 +16,14 @@
   "main": "dist/index.js",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/test-runner-cli/package.json
+++ b/packages/test-runner-cli/package.json
@@ -16,8 +16,14 @@
   "main": "dist/index.js",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/test-runner-commands/package.json
+++ b/packages/test-runner-commands/package.json
@@ -20,8 +20,14 @@
       "default": "./browser/commands.mjs"
     },
     "./plugins": {
-      "import": "./plugins.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./plugins.d.ts",
+        "default": "./plugins.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/test-runner-core/package.json
+++ b/packages/test-runner-core/package.json
@@ -17,14 +17,29 @@
   "module": "./index.mjs",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     },
     "./test-helpers": {
-      "import": "./test-helpers.mjs",
-      "require": "./dist/test-helpers.js"
+      "import": {
+        "types": "./test-helpers.d.ts",
+        "default": "./test-helpers.mjs"
+      },
+      "require": {
+        "types": "./dist/test-helpers.d.ts",
+        "default": "./dist/test-helpers.js"
+      }
     },
-    "./browser/session.js": "./browser/session.js"
+    "./browser/session.js": {
+      "types": "./browser/session.d.ts",
+      "default": "./browser/session.js"
+    }
   },
   "engines": {
     "node": ">=12.0.0"

--- a/packages/test-runner-coverage-v8/package.json
+++ b/packages/test-runner-coverage-v8/package.json
@@ -16,8 +16,14 @@
   "main": "dist/index.js",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/test-runner-junit-reporter/package.json
+++ b/packages/test-runner-junit-reporter/package.json
@@ -16,8 +16,14 @@
   "main": "dist/index.js",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/test-runner-playwright/package.json
+++ b/packages/test-runner-playwright/package.json
@@ -16,8 +16,14 @@
   "main": "dist/index.js",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/test-runner-puppeteer/package.json
+++ b/packages/test-runner-puppeteer/package.json
@@ -16,8 +16,14 @@
   "main": "dist/index.js",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/test-runner-saucelabs/package.json
+++ b/packages/test-runner-saucelabs/package.json
@@ -16,8 +16,14 @@
   "main": "dist/index.js",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/test-runner-selenium/package.json
+++ b/packages/test-runner-selenium/package.json
@@ -16,8 +16,14 @@
   "main": "dist/index.js",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/test-runner-visual-regression/package.json
+++ b/packages/test-runner-visual-regression/package.json
@@ -15,10 +15,19 @@
   "homepage": "https://github.com/modernweb-dev/web/tree/master/packages/test-runner-visual-regression",
   "main": "browser/commands.mjs",
   "exports": {
-    ".": "./browser/commands.mjs",
+    ".": {
+      "types": "./browser/commands.d.ts",
+      "default": "./browser/commands.mjs"
+    },
     "./plugin": {
-      "import": "./plugin.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./plugin.d.ts",
+        "default": "./plugin.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {

--- a/packages/test-runner-webdriver/package.json
+++ b/packages/test-runner-webdriver/package.json
@@ -16,8 +16,14 @@
   "main": "dist/index.js",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "engines": {


### PR DESCRIPTION
Add types to exports for typescript's node16 module resolution.

Two packages were already fixed in #1973 and #1981, this PR fixes the rest.

I automated this change using [`jq`](https://stedolan.github.io/jq/) to prevent typos or other small mistakes in this repetitive task.

<details>
<summary>jq script</summary>

```jq
#!/usr/bin/env -S jq -f

def type_path:
	sub("\\.[mc]?js$"; ".d.ts")
	;

def add_types_to_export:
	if type == "string" then
		{ types: type_path, default: . }
	elif .types != null then
		.
	else
		map_values(add_types_to_export)
	end
	;

def add_types_to_exports:
	if keys[0] | startswith(".") then
		map_values(add_types_to_export)
	else
		add_types_to_export
	end
	;

if .exports != null then
	.exports |= add_types_to_exports
else
	.
end
```

</details>
