### PR TITLE
fix(dev-server-rollup): fix rollup adapter resolution for virtual modules on Windows

### DIFF
--- a/.changeset/two-ants-explode.md
+++ b/.changeset/two-ants-explode.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server-rollup': patch
+---
+
+fix rollup adapter resolution for virtual modules on Windows

--- a/packages/dev-server-rollup/src/rollupAdapter.ts
+++ b/packages/dev-server-rollup/src/rollupAdapter.ts
@@ -113,7 +113,13 @@ export function rollupAdapter(
         return;
       }
 
-      if (!injectedFilePath && !path.isAbsolute(source) && whatwgUrl.parseURL(source) != null) {
+      const isVirtualModule = source.startsWith('\0');
+      if (
+        !injectedFilePath &&
+        !path.isAbsolute(source) &&
+        whatwgUrl.parseURL(source) != null &&
+        !isVirtualModule
+      ) {
         // don't resolve relative and valid urls
         return source;
       }


### PR DESCRIPTION

This is a second attempt to close #2078 (with #2079 being the first attempt).

The issue is that an absolute Windows path prefixed with a null byte is not a valid absolute file path, but it is (apparently) a valid URL (the null byte gets eaten as white space, and then the `C:` is interpreted as the URL scheme). However, in the context of processing Rollup plugins, the null byte is a signal that this path should be treated in a special way.

This fix explicitly checks for the null byte to avoid this issue, as discussed with @giamir and @43081j.
