### PR TITLE
fix: avoid css modules from being preloaded as script

### DIFF
--- a/packages/rollup-plugin-polyfills-loader/src/rollupPluginPolyfillsLoader.ts
+++ b/packages/rollup-plugin-polyfills-loader/src/rollupPluginPolyfillsLoader.ts
@@ -83,11 +83,14 @@ export function polyfillsLoader(pluginOptions: RollupPluginPolyfillsLoaderConfig
         const crossorigin = type === fileTypes.MODULE ? ' crossorigin="anonymous"' : '';
         const shim = type === fileTypes.MODULESHIM;
         const rel = `${shim ? 'module' : ''}preload${shim ? '-shim' : ''}`;
-        const as = shim ? '' : ' as="script"';
+        const asScript = shim ? '' : ' as="script"';
         return htmlString.replace(
           '</head>',
           `\n${preloaded
-            .map(i => `<link rel="${rel}" href="${i}"${as}${crossorigin} />\n`)
+            .map(i => {
+              const as = i.endsWith('.css') ? ' as="style"' : asScript;
+              return `<link rel="${rel}" href="${i}"${as}${crossorigin} />\n`;
+            })
             .join('')}</head>`,
         );
       });


### PR DESCRIPTION
When using native css modules in rollup, the polyfills loader will try to add a preload link for them, e.g.:
`<link rel="preload" href="styles-78a368d53d94321d.css" as="script" crossorigin="anonymous" />`, should be preloaded as script instead