### PR TITLE
fix(dev-server): Enable the development export condition by default

### DIFF
--- a/.changeset/brown-lies-repeat.md
+++ b/.changeset/brown-lies-repeat.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server': patch
+---
+
+Enable the "development" export condition by default

--- a/packages/dev-server/demo/node-resolve/index.html
+++ b/packages/dev-server/demo/node-resolve/index.html
@@ -26,6 +26,8 @@
         nodeResolve: window.__nodeResolve || false,
         noExtension: window.__noExtension || false,
         extensionPriority: window.__extensionPriority || false,
+        // lit-html only adds this global in development mode
+        developmentExportCondition: window.litIssuedWarnings || false,
       };
       document.getElementById('test').innerHTML = `<pre>${JSON.stringify(
         window.__tests,

--- a/packages/dev-server/src/plugins/nodeResolvePlugin.ts
+++ b/packages/dev-server/src/plugins/nodeResolvePlugin.ts
@@ -15,6 +15,7 @@ export function nodeResolvePlugin(
       moduleDirectories: ['node_modules', 'web_modules'],
       // allow resolving polyfills for nodejs libs
       preferBuiltins: false,
+      exportConditions: ['development'],
     },
     userOptionsObject,
   );

--- a/packages/dev-server/test/integration.test.mjs
+++ b/packages/dev-server/test/integration.test.mjs
@@ -17,7 +17,7 @@ const testCases = [
   },
   {
     name: 'node-resolve',
-    tests: ['inlineNodeResolve', 'nodeResolve', 'noExtension', 'extensionPriority'],
+    tests: ['developmentExportCondition', 'inlineNodeResolve', 'nodeResolve', 'noExtension', 'extensionPriority'],
   },
   {
     name: 'static',


### PR DESCRIPTION
Partial fix for https://github.com/modernweb-dev/web/issues/1950

This adds the "development" export condition _when_ node resolution is already enabled, which at least removes the need for a config file when using the `--node-resolve` flag or `nodeResolve: true` config option.

I still think the flag should be enabled by default as it's used in basically every invocation of wds that I've ever seen.

## What I did

1. Added `exportConditions: ['development']` to the default config options in the nodeResolvePlugin
2. Added a test that checks for a global that lit-html only sets in the development build.
