### PR TITLE
[dev-server-storybook] Load a CommonJS config if one exists

### DIFF
--- a/.changeset/wild-seas-sort.md
+++ b/.changeset/wild-seas-sort.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server-storybook': minor
+---
+
+Load CommonJS configuration file if one exists

--- a/packages/dev-server-storybook/src/shared/config/readStorybookConfig.ts
+++ b/packages/dev-server-storybook/src/shared/config/readStorybookConfig.ts
@@ -47,7 +47,10 @@ export function readStorybookConfig(pluginConfig: StorybookPluginConfig): Storyb
   let previewHead: string | undefined = undefined;
   let previewBody: string | undefined = undefined;
 
-  if (!fs.existsSync(mainJsPath) && !fs.existsSync(commonJsMainPath)) {
+  const mainJsExists = fs.existsSync(mainJsPath)
+  const commonJsMainExists = fs.existsSync(commonJsMainPath)
+
+  if (!mainJsExists && !commonJsMainExists) {
     throw createError(
       `Could not find any storybook configuration at ${mainJsPath} or ${commonJsMainPath}. You can change the storybook config directory using the configDir option.`,
     );
@@ -63,7 +66,7 @@ export function readStorybookConfig(pluginConfig: StorybookPluginConfig): Storyb
     previewBody = fs.readFileSync(previewBodyPath, 'utf-8');
   }
 
-  const mainJs = fs.existsSync(commonJsMainPath) ? 
+  const mainJs = commonJsMainExists ? 
     validateMainJs(require(commonJsMainPath)) :
     validateMainJs(require(mainJsPath));
 

--- a/packages/dev-server-storybook/src/shared/config/readStorybookConfig.ts
+++ b/packages/dev-server-storybook/src/shared/config/readStorybookConfig.ts
@@ -35,7 +35,7 @@ export function readStorybookConfig(pluginConfig: StorybookPluginConfig): Storyb
     ? path.resolve(pluginConfig.configDir)
     : defaultConfigDir;
 
-  const commonJsMainPath = path.join(configDir, 'main.cjs')
+  const commonJsMainPath = path.join(configDir, 'main.cjs');
   const mainJsPath = path.join(configDir, 'main.js');
 
   const managerJsPath = path.join(configDir, 'manager.js');
@@ -47,8 +47,8 @@ export function readStorybookConfig(pluginConfig: StorybookPluginConfig): Storyb
   let previewHead: string | undefined = undefined;
   let previewBody: string | undefined = undefined;
 
-  const mainJsExists = fs.existsSync(mainJsPath)
-  const commonJsMainExists = fs.existsSync(commonJsMainPath)
+  const mainJsExists = fs.existsSync(mainJsPath);
+  const commonJsMainExists = fs.existsSync(commonJsMainPath);
 
   if (!mainJsExists && !commonJsMainExists) {
     throw createError(
@@ -66,9 +66,9 @@ export function readStorybookConfig(pluginConfig: StorybookPluginConfig): Storyb
     previewBody = fs.readFileSync(previewBodyPath, 'utf-8');
   }
 
-  const mainJs = commonJsMainExists ? 
-    validateMainJs(require(commonJsMainPath)) :
-    validateMainJs(require(mainJsPath));
+  const mainJs = commonJsMainExists
+    ? validateMainJs(require(commonJsMainPath))
+    : validateMainJs(require(mainJsPath));
 
   return {
     mainJs,

--- a/packages/dev-server-storybook/src/shared/config/readStorybookConfig.ts
+++ b/packages/dev-server-storybook/src/shared/config/readStorybookConfig.ts
@@ -34,7 +34,10 @@ export function readStorybookConfig(pluginConfig: StorybookPluginConfig): Storyb
   const configDir = pluginConfig.configDir
     ? path.resolve(pluginConfig.configDir)
     : defaultConfigDir;
+
+  const commonJsMainPath = path.join(configDir, 'main.cjs')
   const mainJsPath = path.join(configDir, 'main.js');
+
   const managerJsPath = path.join(configDir, 'manager.js');
   const previewJsPath = path.join(configDir, 'preview.js');
   const managerHeadPath = path.join(configDir, 'manager-head.html');
@@ -44,9 +47,9 @@ export function readStorybookConfig(pluginConfig: StorybookPluginConfig): Storyb
   let previewHead: string | undefined = undefined;
   let previewBody: string | undefined = undefined;
 
-  if (!fs.existsSync(mainJsPath)) {
+  if (!fs.existsSync(mainJsPath) && !fs.existsSync(commonJsMainPath)) {
     throw createError(
-      `Could not find any storybook configuration at ${mainJsPath}. You can change the storybook config directory using the configDir option.`,
+      `Could not find any storybook configuration at ${mainJsPath} or ${commonJsMainPath}. You can change the storybook config directory using the configDir option.`,
     );
   }
 
@@ -60,7 +63,9 @@ export function readStorybookConfig(pluginConfig: StorybookPluginConfig): Storyb
     previewBody = fs.readFileSync(previewBodyPath, 'utf-8');
   }
 
-  const mainJs = validateMainJs(require(mainJsPath));
+  const mainJs = fs.existsSync(commonJsMainPath) ? 
+    validateMainJs(require(commonJsMainPath)) :
+    validateMainJs(require(mainJsPath));
 
   return {
     mainJs,


### PR DESCRIPTION
This PR checks if there's a `main.cjs` file and loads that as the storybook configuration file if it exists instead of `main.js`.

Closes https://github.com/modernweb-dev/web/issues/1832
Closes https://github.com/modernweb-dev/web/pull/1831