### PR TITLE
Export the `formatError` function from test-runner

### DIFF
--- a/.changeset/seven-avocados-try.md
+++ b/.changeset/seven-avocados-try.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner': patch
+---
+
+Export formatError from `@web/test-runner`

--- a/packages/test-runner/src/index.ts
+++ b/packages/test-runner/src/index.ts
@@ -7,5 +7,5 @@ export { startTestRunner } from './startTestRunner';
 export { defaultReporter } from './reporter/defaultReporter';
 export { summaryReporter } from './reporter/summaryReporter';
 export { dotReporter } from './reporter/dotReporter';
-export {formatError} from './reporter/reportTestsErrors';
+export { formatError } from './reporter/reportTestsErrors';
 export type TestRunnerConfig = Partial<FullTestRunnerConfig>;

--- a/packages/test-runner/src/index.ts
+++ b/packages/test-runner/src/index.ts
@@ -7,4 +7,5 @@ export { startTestRunner } from './startTestRunner';
 export { defaultReporter } from './reporter/defaultReporter';
 export { summaryReporter } from './reporter/summaryReporter';
 export { dotReporter } from './reporter/dotReporter';
+export {formatError} from './reporter/reportTestsErrors';
 export type TestRunnerConfig = Partial<FullTestRunnerConfig>;


### PR DESCRIPTION
## What I did

I cherry-picked the commit from https://github.com/modernweb-dev/web/pull/2113 since we need to land that before we can import the function in `browser-logs`
