### PR TITLE
chore: bump node ci to 16/18/19

### DIFF
--- a/.github/workflows/verify-node.yml
+++ b/.github/workflows/verify-node.yml
@@ -12,9 +12,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - '14'
           - '16'
           - '18'
+          - '19'
 
     steps:
       - uses: actions/checkout@v3

--- a/packages/dev-server-import-maps/test/resolving.test.ts
+++ b/packages/dev-server-import-maps/test/resolving.test.ts
@@ -382,7 +382,7 @@ describe('resolving imports', () => {
     expect(loggerSpies.warn.callCount).to.equal(1);
     const warning = loggerSpies.warn.getCall(0).args[0];
     expectIncludes(warning, 'Failed to parse import map in "');
-    expectIncludes(warning, `test${path.sep}index.html": Unexpected end of JSON input`);
+    expectIncludes(warning, `test${path.sep}index.html": `);
     server.stop();
   });
 


### PR DESCRIPTION
Basically move to the current stable versions of node

also had to loosen up a test just because the error text changes between node versions slightly