### PR TITLE
Increase flaky test timeout

### DIFF
--- a/packages/test-runner-core/test/src/runner/TestScheduler.test.ts
+++ b/packages/test-runner-core/test/src/runner/TestScheduler.test.ts
@@ -276,7 +276,7 @@ describe('TestScheduler', () => {
       const [scheduler, sessions, [session1]] = createTestFixture('1');
       scheduler.schedule(1, [session1]);
 
-      await timeout(8);
+      await timeout(20);
 
       const finalSession1 = sessions.get(session1.id)!;
       expect(finalSession1.status).to.equal(SESSION_STATUS.FINISHED);


### PR DESCRIPTION
This test keeps failing on `master`. I'm either gonna increase the timeout or skip it since in its current state it isn't providing any value.