### PR TITLE
fix(rollup-plugin-workbox): revert back to non-ESM version of pretty-bytes

### DIFF
--- a/.changeset/smooth-zoos-provide.md
+++ b/.changeset/smooth-zoos-provide.md
@@ -1,0 +1,5 @@
+---
+'rollup-plugin-workbox': patch
+---
+
+Revert back to non-ESM version of `pretty-bytes`

--- a/packages/rollup-plugin-workbox/package.json
+++ b/packages/rollup-plugin-workbox/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@rollup/plugin-node-resolve": "^11.0.1",
     "@rollup/plugin-replace": "^5.0.2",
-    "pretty-bytes": "^6.1.0",
+    "pretty-bytes": "^5.5.0",
     "rollup-plugin-terser": "^7.0.2",
     "workbox-build": "^6.2.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10649,15 +10649,10 @@ prettier@^2.4.1, prettier@^2.7.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
-pretty-bytes@^5.3.0:
+pretty-bytes@^5.3.0, pretty-bytes@^5.5.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
   integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
-
-pretty-bytes@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-6.1.0.tgz#1d1cc9aae1939012c74180b679da6684616bf804"
-  integrity sha512-Rk753HI8f4uivXi4ZCIYdhmG1V+WKzvRMg/X+M42a6t7D07RcmopXJMDNk6N++7Bl75URRGsb40ruvg7Hcp2wQ==
 
 pretty-ms@^0.2.1:
   version "0.2.2"


### PR DESCRIPTION
As raised in #2212, this reverts #2208, which upgraded `pretty-bytes` from 5.6.0 to 6.1.0.

In that major version bump, `pretty-bytes` became an ESM-only package. Based on [their description](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c), this package would also need to convert to ESM in order to adopt it, hence the revert.

Dependabot will likely attempt to upgrade this again, so not sure if you'd like me to add this to its ignore list?