### PR TITLE
Update createRollupConfig.ts

### DIFF
--- a/.changeset/dirty-roses-compare.md
+++ b/.changeset/dirty-roses-compare.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server-storybook': patch
+---
+
+Fix console logging due to source mapping issues.

--- a/packages/dev-server-storybook/src/build/rollup/createRollupConfig.ts
+++ b/packages/dev-server-storybook/src/build/rollup/createRollupConfig.ts
@@ -54,6 +54,8 @@ export function createRollupConfig(params: CreateRollupConfigParams): RollupOpti
         configFile: false,
         extensions: [...DEFAULT_EXTENSIONS, 'md', 'mdx'],
         exclude: `${prebuiltDir}/**`,
+        sourceMaps: true,
+        inputSourceMap: false,
         presets: [
           [
             require.resolve('@babel/preset-env'),

--- a/packages/dev-server-storybook/src/build/rollup/createRollupConfig.ts
+++ b/packages/dev-server-storybook/src/build/rollup/createRollupConfig.ts
@@ -55,6 +55,7 @@ export function createRollupConfig(params: CreateRollupConfigParams): RollupOpti
         extensions: [...DEFAULT_EXTENSIONS, 'md', 'mdx'],
         exclude: `${prebuiltDir}/**`,
         sourceMaps: true,
+        // @ts-ignore The provided types are wrong. See https://babeljs.io/docs/options#inputsourcemap
         inputSourceMap: false,
         presets: [
           [


### PR DESCRIPTION
I might be able to create a reproduction if we want, but I'm getting a console message when building storybook in an internal project. The message is:

```
Error when using sourcemap for reporting an error: Can't resolve original location of error.
```

I found a [Rollup issue](https://github.com/rollup/rollup/issues/3457) which suggest setting the babel option`inputSourceMap` to `false`. Setting that option makes the error go away, but I'm unsure if I'm changing something significantly.

The [Babel docs for this option](https://babeljs.io/docs/options#source-map-options) don't really clear it up to me, but I figure the tests are running green, so this should be fine to change?