### PR TITLE
Move mocha options to config in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "start:build": "node packages/dev-server/dist/bin.js --root-dir _site --open",
     "test": "yarn test:node && yarn test:browser && node scripts/workspaces-scripts-bin.mjs test:ci",
     "test:browser": "node packages/test-runner/dist/bin.js \"packages/*/test-browser/**/*.test.{js,ts}\"",
-    "test:node": "mocha \"packages/*/test/**/*.test.{ts,js,mjs,cjs}\" --require ts-node/register --exit --retries 3",
+    "test:node": "mocha \"packages/*/test/**/*.test.{ts,js,mjs,cjs}\"",
     "update": "npm run update:mjs-dts-entrypoints && npm run update:tsconfigs",
     "update-dependency": "node scripts/update-dependency.js",
     "update:mjs-dts-entrypoints": "node scripts/generate-mjs-dts-entrypoints.mjs && yarn format",
@@ -110,6 +110,11 @@
       "@typescript-eslint/no-var-requires": "off",
       "@typescript-eslint/ban-ts-comment": "off"
     }
+  },
+  "mocha": {
+    "loader": "ts-node/esm",
+    "exit": true,
+    "retries": 3
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
I also moved from `--require ts-node/register` to `--loader ts-node/esm` which will make the ESM upgrade easier.