### PR TITLE
Replace `rollup-plugin-terser` with `@rollup/plugin-terser`

### DIFF
--- a/.changeset/great-fans-turn.md
+++ b/.changeset/great-fans-turn.md
@@ -1,0 +1,6 @@
+---
+'rollup-plugin-workbox': patch
+'@web/dev-server-storybook': patch
+---
+
+Replace `rollup-plugin-terser` with `@rollup/plugin-terser`

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "prettier-plugin-package": "^1.3.0",
     "rimraf": "^4.4.1",
     "rollup": "^3.15.0",
-    "rollup-plugin-terser": "^7.0.2",
+    "@rollup/plugin-terser": "^0.4.1",
     "ts-node": "^10.4.0",
     "typescript": "~5.0.4"
   },

--- a/packages/dev-server-storybook/package.json
+++ b/packages/dev-server-storybook/package.json
@@ -70,7 +70,7 @@
     "globby": "^11.0.1",
     "path-is-inside": "^1.0.2",
     "rollup": "^3.15.0",
-    "rollup-plugin-terser": "^7.0.2",
+    "@rollup/plugin-terser": "^0.4.1",
     "storybook-addon-markdown-docs": "^1.0.4"
   },
   "devDependencies": {

--- a/packages/rollup-plugin-workbox/package.json
+++ b/packages/rollup-plugin-workbox/package.json
@@ -34,7 +34,7 @@
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-replace": "^5.0.2",
     "pretty-bytes": "^5.5.0",
-    "rollup-plugin-terser": "^7.0.2",
+    "@rollup/plugin-terser": "^0.4.1",
     "workbox-build": "^6.2.4"
   },
   "contributors": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2000,6 +2000,15 @@
     "@rollup/pluginutils" "^5.0.1"
     magic-string "^0.27.0"
 
+"@rollup/plugin-terser@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-terser/-/plugin-terser-0.4.1.tgz#5c323fd066355056224b6993fcb14c409d29873e"
+  integrity sha512-aKS32sw5a7hy+fEXVy+5T95aDIwjpGHCTv833HXVtyKMDoVS7pBr5K3L9hEQoNqbJFjfANPrNpIXlTQ7is00eA==
+  dependencies:
+    serialize-javascript "^6.0.0"
+    smob "^0.0.6"
+    terser "^5.15.1"
+
 "@rollup/plugin-typescript@^11.0.0":
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-11.1.0.tgz#4dd2a98475a791200d3e4dd1b8234073ad96c535"
@@ -12247,6 +12256,13 @@ serialize-javascript@^4.0.0:
   dependencies:
     randombytes "^2.1.0"
 
+serialize-javascript@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.1.tgz#b206efb27c3da0b0ab6b52f48d170b7996458e5c"
+  integrity sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==
+  dependencies:
+    randombytes "^2.1.0"
+
 serve-index@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239"
@@ -12457,6 +12473,11 @@ smartwrap@^2.0.2:
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
     yargs "^15.1.0"
+
+smob@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/smob/-/smob-0.0.6.tgz#09b268fea916158a2781c152044c6155adbb8aa1"
+  integrity sha512-V21+XeNni+tTyiST1MHsa84AQhT1aFZipzPpOFAVB8DkHzwJyjjAmt9bgwnuZiZWnIbMo2duE29wybxv/7HWUw==
 
 snake-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
[`rollup-plugin-terser`](https://www.npmjs.com/package/rollup-plugin-terser) has been deprecated.