### PR TITLE
chore: lint versions --fix

### DIFF
--- a/scripts/lint-versions.js
+++ b/scripts/lint-versions.js
@@ -1,4 +1,4 @@
-/* eslint-disable */
+#!/usr/bin/env node
 const { readdirSync, existsSync, readFileSync } = require('fs');
 
 const getDirectories = source =>
@@ -53,28 +53,24 @@ let currentVersions = readPackageJsonDeps('./package.json');
 let endReturn = 0;
 
 // find all versions in the monorepo
-['./packages', './demo/projects'].forEach(rootDir => {
-  getDirectories(rootDir).forEach(subPackage => {
-    const filePath = `${rootDir}/${subPackage}/package.json`;
-    currentVersions = { ...currentVersions, ...readPackageJsonNameVersion(filePath) };
-  });
-});
+for (const subPackage of getDirectories('./packages')) {
+  const filePath = `./packages/${subPackage}/package.json`;
+  currentVersions = { ...currentVersions, ...readPackageJsonNameVersion(filePath) };
+}
 
 // lint all versions in packages
-['./packages', './demo/projects'].forEach(rootDir => {
-  getDirectories(rootDir).forEach(subPackage => {
-    const filePath = `${rootDir}/${subPackage}/package.json`;
-    const subPackageVersions = readPackageJsonDeps(filePath);
-    const { output, newVersions } = compareVersions(currentVersions, subPackageVersions);
-    currentVersions = { ...newVersions };
-    if (output) {
-      console.log(`Version mismatches found in "${filePath}":`);
-      console.log(output);
-      console.log();
-      endReturn = 1;
-    }
-  });
-});
+for (const subPackage of getDirectories('./packages')) {
+  const filePath = `./packages/${subPackage}/package.json`;
+  const subPackageVersions = readPackageJsonDeps(filePath);
+  const { output, newVersions } = compareVersions(currentVersions, subPackageVersions);
+  currentVersions = { ...newVersions };
+  if (output) {
+    console.log(`Version mismatches found in "${filePath}":`);
+    console.log(output);
+    console.log();
+    endReturn = 1;
+  }
+}
 
 if (endReturn === 0) {
   console.log('All versions are aligned 💪');

--- a/scripts/lint-versions.js
+++ b/scripts/lint-versions.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const { readdirSync, existsSync, readFileSync } = require('fs');
+const { readdirSync, existsSync, readFileSync, writeFileSync } = require('fs');
 
 const getDirectories = source =>
   readdirSync(source, { withFileTypes: true })
@@ -32,11 +32,11 @@ function readPackageJsonNameVersion(filePath) {
 }
 
 function compareVersions(versionsA, versionsB) {
-  let output = '';
+  let output = {};
   const newVersions = { ...versionsA };
   Object.keys(versionsB).forEach(dep => {
     if (versionsA[dep] && versionsB[dep] && versionsA[dep] !== versionsB[dep]) {
-      output += `  - "${dep}" should be "${versionsA[dep]}" but is "${versionsB[dep]}"\n`;
+      output[dep] = [versionsA[dep], versionsB[dep]];
     }
     if (!newVersions[dep]) {
       newVersions[dep] = versionsB[dep];
@@ -58,18 +58,42 @@ for (const subPackage of getDirectories('./packages')) {
   currentVersions = { ...currentVersions, ...readPackageJsonNameVersion(filePath) };
 }
 
+const fixes = new Map();
+
 // lint all versions in packages
 for (const subPackage of getDirectories('./packages')) {
   const filePath = `./packages/${subPackage}/package.json`;
   const subPackageVersions = readPackageJsonDeps(filePath);
   const { output, newVersions } = compareVersions(currentVersions, subPackageVersions);
   currentVersions = { ...newVersions };
-  if (output) {
+  const entries = Object.entries(output);
+  if (entries.length) {
+    fixes.set(filePath, output);
     console.log(`Version mismatches found in "${filePath}":`);
-    console.log(output);
+    console.log(
+      entries.reduce(
+        (acc, [dep, [should, is]]) => `${acc}  - "${dep}" should be "${should}" but is "${is}"\n`,
+        '',
+      ),
+    );
     console.log();
     endReturn = 1;
   }
+}
+
+function fixJSON(filePath, changes) {
+  const json = JSON.parse(readFileSync(filePath, 'utf8'));
+  for (const [dep, [should]] of Object.entries(changes)) {
+    json.dependencies[dep] = should;
+  }
+  writeFileSync(filePath, JSON.stringify(json, null, 2));
+}
+
+if (fixes.size && process.argv.includes('--fix')) {
+  for (const [filePath, changes] of fixes) {
+    fixJSON(filePath, changes);
+  }
+  console.log('package.json files updated, run `yarn`');
 }
 
 if (endReturn === 0) {


### PR DESCRIPTION
## What I did

1. fix the `lint-versions.js` script
1. add a `--fix` flag to `lint-versions.js`

## Notes to Reviewers
Seems to work, but I'm not sure how to handle the `newVersions` object that's returned from `compareVersions`, so this script might not be 100% correct

Closes #2245