### PR TITLE
fix: reset coverage result converters between Chrome session runs

### DIFF
--- a/.changeset/breezy-crabs-watch.md
+++ b/.changeset/breezy-crabs-watch.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-coverage-v8': patch
+---
+
+fix: reset coverage result converters between Chrome session runs

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.16.0",
     "@rollup/plugin-node-resolve": "^15.0.1",
+    "@rollup/plugin-terser": "^0.4.1",
     "@rollup/plugin-typescript": "^11.0.0",
     "@types/chai": "^4.2.22",
     "@types/mocha": "^10.0.1",
@@ -71,7 +72,6 @@
     "prettier-plugin-package": "^1.3.0",
     "rimraf": "^4.4.1",
     "rollup": "^3.15.0",
-    "@rollup/plugin-terser": "^0.4.1",
     "ts-node": "^10.4.0",
     "typescript": "~5.0.4"
   },
@@ -111,11 +111,6 @@
       "@typescript-eslint/ban-ts-comment": "off"
     }
   },
-  "mocha": {
-    "loader": "ts-node/esm",
-    "exit": true,
-    "retries": 3
-  },
   "lint-staged": {
     "*.js": [
       "eslint --fix",
@@ -124,6 +119,11 @@
     "*.md": [
       "prettier --write --ignore-path .eslintignore"
     ]
+  },
+  "mocha": {
+    "loader": "ts-node/esm",
+    "exit": true,
+    "retries": 3
   },
   "prettier": {
     "singleQuote": true,

--- a/packages/dev-server-storybook/package.json
+++ b/packages/dev-server-storybook/package.json
@@ -59,6 +59,7 @@
     "@mdx-js/mdx": "^1.6.22",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-node-resolve": "^15.0.1",
+    "@rollup/plugin-terser": "^0.4.1",
     "@storybook/csf-tools": "^6.4.9",
     "@web/dev-server-core": "^0.5.0",
     "@web/rollup-plugin-html": "^2.0.0",
@@ -70,7 +71,6 @@
     "globby": "^11.0.1",
     "path-is-inside": "^1.0.2",
     "rollup": "^3.15.0",
-    "@rollup/plugin-terser": "^0.4.1",
     "storybook-addon-markdown-docs": "^1.0.4"
   },
   "devDependencies": {

--- a/packages/rollup-plugin-workbox/package.json
+++ b/packages/rollup-plugin-workbox/package.json
@@ -33,8 +33,8 @@
   "dependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-replace": "^5.0.2",
-    "pretty-bytes": "^5.5.0",
     "@rollup/plugin-terser": "^0.4.1",
+    "pretty-bytes": "^5.5.0",
     "workbox-build": "^6.2.4"
   },
   "contributors": [

--- a/packages/test-runner-coverage-v8/src/index.ts
+++ b/packages/test-runner-coverage-v8/src/index.ts
@@ -88,7 +88,7 @@ export async function v8ToIstanbul(
           } else {
             // When we reuse a cached converter, we need to reset it before using its `applyCoverage` function.
             // If we don't, the coverage results will be poisoned with the results of the previous uses.
-            // 
+            //
             // This "workaround" is resetting some internal variables of the `V8ToIstanbul` class: `branches` & `functions`.
             // This can break when newer versions of v8-to-istanbul are released. (variable renaming, more variables are used, ...)
             //
@@ -98,7 +98,7 @@ export async function v8ToIstanbul(
             converter.branches = {};
             // @ts-ignore
             converter.functions = {};
-          }  
+          }
 
           converter.applyCoverage(entry.functions);
           Object.assign(istanbulCoverage, converter.toIstanbul());

--- a/packages/test-runner-coverage-v8/src/index.ts
+++ b/packages/test-runner-coverage-v8/src/index.ts
@@ -85,7 +85,20 @@ export async function v8ToIstanbul(
           if (!cachedConverter) {
             await converter.load();
             cachedConverters.set(filePath, converter);
-          }
+          } else {
+            // When we reuse a cached converter, we need to reset it before using its `applyCoverage` function.
+            // If we don't, the coverage results will be poisoned with the results of the previous uses.
+            // 
+            // This "workaround" is resetting some internal variables of the `V8ToIstanbul` class: `branches` & `functions`.
+            // This can break when newer versions of v8-to-istanbul are released. (variable renaming, more variables are used, ...)
+            //
+            // TODO: use a (stable) clone technique instead when available (`structuredClone` is available in node 17)
+            //
+            // @ts-ignore
+            converter.branches = {};
+            // @ts-ignore
+            converter.functions = {};
+          }  
 
           converter.applyCoverage(entry.functions);
           Object.assign(istanbulCoverage, converter.toIstanbul());


### PR DESCRIPTION
## What I did

@web/test-runner-coverage-v8 0.6.0 introduces a performance improvement when calculating code coverage by caching coverage converters between browser sessions. (coverage converters are creating by loading the original file from disk)
Unfortunately, converters will alter their own state when applying the coverage from a specific session. This means that next sessions will be "poisoned" by previous ones.

This PR will ensure converters are reset (to their initial state of zero coverage) before applying a new one.

Ideally we would use a clone of the converter before using. But as there is no stable, ootb, way to create a clone (without also knowing the internals of the object), this workaround will just reset the internally used variables.

/cc: @43081j @koddsson 