### PR TITLE
Test on stable targeting Node releases

### DIFF
--- a/.github/workflows/verify-node.yml
+++ b/.github/workflows/verify-node.yml
@@ -14,7 +14,7 @@ jobs:
         node-version:
           - '16'
           - '18'
-          - '19'
+          - '20'
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## What I did

1. @43081j v20 is fully available, so it seemed like the right thing to move off of 19.
