### PR TITLE
fix: cache sourcemap objects rather than converter instances

### DIFF
--- a/.changeset/quick-files-visit.md
+++ b/.changeset/quick-files-visit.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-coverage-v8': minor
+---
+
+Cache sourcemap resolution across v8-to-istanbul calls to avoid heavy FS reads


### PR DESCRIPTION
fixes #2258 

long story short, the object we pass into v8-to-istanbul is basically `{sources, sourceMap, originalSource?}`

if we set `originalSource`, we can avoid v8-to-istanbul loading the source file itself each time we call it

we're just moving the problem there though, so i repurposed the cache to cache these loaded files in memory with a limit of 50mb