### PR TITLE
feat (test-runner-chrome): use built in puppeteer coverage

### DIFF
--- a/.changeset/tasty-candles-juggle.md
+++ b/.changeset/tasty-candles-juggle.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-chrome': patch
+---
+
+Acquire raw v8 coverage via puppeteer API rather than CDP calls


### PR DESCRIPTION
Fixes #2223 

puppeteer comes with an option to retrieve raw v8 coverage entries now, so we no longer need to do cdp calls ourselves