### PR TITLE
fix: do not swallow tests

### DIFF
--- a/packages/test-runner/src/reporter/reportTestsErrors.ts
+++ b/packages/test-runner/src/reporter/reportTestsErrors.ts
@@ -75,15 +75,21 @@ export function reportTestsErrors(
     if (session.testResults) {
       const flattenedTests = getFlattenedTestResults(session.testResults);
       for (const test of flattenedTests) {
-        if (test.error) {
+        if (!test.passed && !test.skipped) {
           let testErrorsForBrowser = testErrorsPerBrowser.get(test.name);
           if (!testErrorsForBrowser) {
             testErrorsForBrowser = new Map<string, TestResultError>();
             testErrorsPerBrowser.set(test.name, testErrorsForBrowser);
           }
-          if (test.error) {
-            testErrorsForBrowser.set(session.browser.name, test.error);
-          }
+
+          test.error = test.error || { 
+            name: 'Unknown error', 
+            message: 'Test failed without any errors. One reason could be that you have code outside of your test.',
+            expected: "",
+            actual: "",
+            stack: "",
+          };
+          testErrorsForBrowser.set(session.browser.name, test.error);
         }
       }
     }


### PR DESCRIPTION
## What I did
Fix an issue that leads to failing tests to be potentially swallowed from the defaultReporter `import { defaultReporter } from '@web/test-runner';`

It's a very tedious issue to debug and might fail tests to fail on CI systems as well as locally.

## Reproduce
```
import { readFile } from '@web/test-runner-commands';
import { expect } from '@esm-bundle/chai';

describe('reading-time estimate', () => {
  it('supports longer articles with 2+ min read time', async () => {
    document.body.innerHTML = await readFile({ path: './mocks/just-return-empty-body.html' });
    expect(true).to.be.true;
  });

  describe('this describe fails', async () => {
    document.body.innerHTML = await readFile({ path: './mocks/just-return-empty-body-2.html' });

    it('failing test', () => {
      expect(true).to.be.true;
    });
  });
});
```

## Output before
Test fails without any logging
![Screenshot 2023-05-16 at 20 16 55](https://github.com/modernweb-dev/web/assets/39759830/2bc6556e-2dfe-4bf0-9283-d5502a721a05)

## Output after
Provide context and *which* test is failing for further debugging
![Screenshot 2023-05-16 at 20 19 03](https://github.com/modernweb-dev/web/assets/39759830/d531bb69-fab8-4ce7-b97c-f709c3a9da2c)
