### PR TITLE
fix: esbuild options shouldnt override swsrc and swdest

### DIFF
--- a/.changeset/tasty-timers-think.md
+++ b/.changeset/tasty-timers-think.md
@@ -1,0 +1,5 @@
+---
+"rollup-plugin-workbox": patch
+---
+
+fix: esbuild options shouldnt override swsrc and swdest

--- a/packages/rollup-plugin-workbox/src/index.ts
+++ b/packages/rollup-plugin-workbox/src/index.ts
@@ -64,12 +64,12 @@ export function injectManifest(
     name,
     async writeBundle() {
       await esbuild.build({
-        entryPoints: [swSrc],
-        outfile: swDest,
         bundle: true,
         minify: true,
         format: 'iife',
         ...esbuildOptions,
+        entryPoints: [swSrc],
+        outfile: swDest,
       });
 
       injectManifestConfig.swSrc = swDest;


### PR DESCRIPTION
Because the input of esbuild should always be the output of workbox, and the output of esbuild should be as configured via workbox
