### PR TITLE
fix(@web/test-runner-coverage-v8): ensure the size of source files is calculcated correctly when caching them

### DIFF
--- a/.changeset/silent-hats-invite.md
+++ b/.changeset/silent-hats-invite.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-coverage-v8': patch
+---
+
+fix: ensure the size of source files is calculcated correctly when caching them

--- a/packages/test-runner-coverage-v8/src/index.ts
+++ b/packages/test-runner-coverage-v8/src/index.ts
@@ -19,6 +19,7 @@ const cachedMatchers = new Map<string, Matcher>();
 // them from disk per call
 const cachedSources = new LruCache<string, IstanbulSource>({
   maxSize: 1024 * 1024 * 50,
+  sizeCalculation: n => n.source.length,
 });
 
 // coverage base dir must be separated with "/"


### PR DESCRIPTION
Fixes #2302 