### PR TITLE
Reduce the Playwright dependency

### DIFF
--- a/.github/workflows/verify-node.yml
+++ b/.github/workflows/verify-node.yml
@@ -28,7 +28,7 @@ jobs:
           cache: yarn
 
       - name: Install Playwright dependencies
-        run: npx playwright install-deps
+        run: npx playwright-core install-deps
 
       - name: Install dependencies
         run: yarn --frozen-lockfile

--- a/.github/workflows/verify-windows.yml
+++ b/.github/workflows/verify-windows.yml
@@ -23,7 +23,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install Playwright dependencies
-        run: npx playwright install-deps
+        run: npx playwright-core install-deps
 
       - name: Install dependencies
         run: yarn --frozen-lockfile

--- a/packages/test-runner-playwright/package.json
+++ b/packages/test-runner-playwright/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@web/test-runner-core": "^0.11.0",
     "@web/test-runner-coverage-v8": "^0.6.0",
-    "playwright": "^1.22.2"
+    "playwright-core": "^1.35.0"
   },
   "devDependencies": {
     "@web/test-runner-mocha": "^0.8.0",

--- a/packages/test-runner-playwright/src/PlaywrightLauncher.ts
+++ b/packages/test-runner-playwright/src/PlaywrightLauncher.ts
@@ -1,4 +1,4 @@
-import playwright, { Browser, Page, LaunchOptions, BrowserContext } from 'playwright';
+import playwright, { Browser, Page, LaunchOptions, BrowserContext } from 'playwright-core';
 import { BrowserLauncher, TestRunnerCoreConfig, CoverageMapData } from '@web/test-runner-core';
 import { PlaywrightLauncherPage } from './PlaywrightLauncherPage';
 

--- a/packages/test-runner-playwright/src/PlaywrightLauncherPage.ts
+++ b/packages/test-runner-playwright/src/PlaywrightLauncherPage.ts
@@ -1,4 +1,4 @@
-import { Page, BrowserContext } from 'playwright';
+import { Page, BrowserContext } from 'playwright-core';
 import { TestRunnerCoreConfig } from '@web/test-runner-core';
 import { V8Coverage, v8ToIstanbul } from '@web/test-runner-coverage-v8';
 import { SessionResult } from '@web/test-runner-core';

--- a/packages/test-runner-playwright/src/index.ts
+++ b/packages/test-runner-playwright/src/index.ts
@@ -1,5 +1,5 @@
-import { LaunchOptions, devices } from 'playwright';
-import * as playwright from 'playwright';
+import { LaunchOptions, devices } from 'playwright-core';
+import * as playwright from 'playwright-core';
 import {
   PlaywrightLauncher,
   ProductType,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10607,17 +10607,10 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright-core@1.33.0:
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.33.0.tgz#269efe29a927cd6d144d05f3c2d2f72bd72447a1"
-  integrity sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==
-
-playwright@^1.22.2:
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.33.0.tgz#88df1cffe97718ab8a02303e12c9133681ec7fab"
-  integrity sha512-+zzU3V2TslRX2ETBRgQKsKytYBkJeLZ2xzUj4JohnZnxQnivoUvOvNbRBYWSYykQTO0Y4zb8NwZTYFUO+EpPBQ==
-  dependencies:
-    playwright-core "1.33.0"
+playwright-core@^1.35.0:
+  version "1.35.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.35.1.tgz#52c1e6ffaa6a8c29de1a5bdf8cce0ce290ffb81d"
+  integrity sha512-pNXb6CQ7OqmGDRspEjlxE49w+4YtR6a3X6mT1hZXeJHWmsEz7SunmvZeiG/+y1yyMZdHnnn73WKYdtV1er0Xyg==
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
I use `@playwright/test` and `@web/test-runner-playwright` in a project. They both have a pinned version of the `playwright-core` library (the latter has it through the `playwright` dependency). I end up with multiple versions of the `playwright-core` library installed whenever Dependabot tries to update the former. When I [install the browsers in my `web-test-runner` job](https://github.com/PREreview/prereview.org/blob/96927194aba4070df65223c3f8dbd086024634e0/.github/workflows/ci.yml#L247-L254) it picks up the wrong browser versions and fails (`npx playwright` running the command from `@playwright/test` rather than `playwright`).

This change reduces the dependency here to just `playwright-core`, with a relaxed constraint that should mean they use the same version.