### PR TITLE
fix: add workaround for headless issue

### DIFF
--- a/.changeset/itchy-socks-rule.md
+++ b/.changeset/itchy-socks-rule.md
@@ -1,0 +1,7 @@
+---
+'@web/test-runner-chrome': patch
+---
+
+fix: add workaround for headless issue
+
+This will patch `window.requestAnimationFrame` and `window.requestIdleCallback` and make sure that the tab running the test code is brought back to the front.

--- a/packages/test-runner-chrome/src/ChromeLauncherPage.ts
+++ b/packages/test-runner-chrome/src/ChromeLauncherPage.ts
@@ -3,6 +3,10 @@ import { TestRunnerCoreConfig } from '@web/test-runner-core';
 import { v8ToIstanbul } from '@web/test-runner-coverage-v8';
 import { SessionResult } from '@web/test-runner-core';
 
+declare global {
+  interface Window { __bringTabToFront: Function; }
+}
+
 export class ChromeLauncherPage {
   private config: TestRunnerCoreConfig;
   private testFiles: string[];
@@ -46,13 +50,10 @@ export class ChromeLauncherPage {
         this.puppeteerPage.bringToFront(),
       );
       await this.puppeteerPage.evaluateOnNewDocument(() => {
-        // @ts-ignore
-        function patchFunction(name, fn) {
-          // @ts-ignore
-          window[name] = (...args) => {
+        function patchFunction(name: string, fn: Function) {
+          (window as any)[name] = (...args: unknown[]) => {
             fn.call(window, ...args);
             // Make sure that the tab running the test code is brought back to the front.
-            // @ts-ignore
             window.__bringTabToFront();
           };
         }

--- a/packages/test-runner-chrome/src/ChromeLauncherPage.ts
+++ b/packages/test-runner-chrome/src/ChromeLauncherPage.ts
@@ -4,7 +4,9 @@ import { v8ToIstanbul } from '@web/test-runner-coverage-v8';
 import { SessionResult } from '@web/test-runner-core';
 
 declare global {
-  interface Window { __bringTabToFront: Function; }
+  interface Window {
+    __bringTabToFront: () => void;
+  }
 }
 
 export class ChromeLauncherPage {
@@ -50,6 +52,7 @@ export class ChromeLauncherPage {
         this.puppeteerPage.bringToFront(),
       );
       await this.puppeteerPage.evaluateOnNewDocument(() => {
+        // eslint-disable-next-line @typescript-eslint/ban-types
         function patchFunction(name: string, fn: Function) {
           (window as any)[name] = (...args: unknown[]) => {
             fn.call(window, ...args);

--- a/packages/test-runner-chrome/test/chromeLauncher.test.ts
+++ b/packages/test-runner-chrome/test/chromeLauncher.test.ts
@@ -13,10 +13,7 @@ describe('test-runner-chrome', function testRunnerChrome() {
   runIntegrationTests(createConfig, {
     basic: true,
     many: true,
-    // Focus tests are failing because of a puppeteer/chrome bug.
-    // See https://github.com/puppeteer/puppeteer/issues/10350 and
-    // https://bugs.chromium.org/p/chromium/issues/detail?id=1454012
-    focus: false,
+    focus: true,
     groups: true,
     parallel: true,
     testFailure: true,

--- a/packages/test-runner-puppeteer/test/puppeteerLauncher.test.ts
+++ b/packages/test-runner-puppeteer/test/puppeteerLauncher.test.ts
@@ -13,10 +13,7 @@ describe('test-runner-puppeteer', function testRunnerPuppeteer() {
   runIntegrationTests(createConfig, {
     basic: true,
     many: true,
-    // Focus tests are failing because of a puppeteer/chrome bug.
-    // See https://github.com/puppeteer/puppeteer/issues/10350 and
-    // https://bugs.chromium.org/p/chromium/issues/detail?id=1454012
-    focus: false,
+    focus: true,
     groups: true,
     parallel: true,
     testFailure: true,


### PR DESCRIPTION
## What I did

This PR will add a workaround for an issue in the new headless mode of Puppeteer https://github.com/puppeteer/puppeteer/issues/10350.

The PR implements the proposal in the issue by patching the functions that are timing out (`window.requestIdleCallback` and `window.requestAnimationFrame`)

I'm not to sure yet what the best approach is to add tests for this.
