### PR TITLE
fix(test-runner-chrome): add mutex when bringing tabs to front

### DIFF
--- a/.changeset/orange-ducks-change.md
+++ b/.changeset/orange-ducks-change.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-chrome': patch
+---
+
+fix(test-runner-chrome): add mutex when bringing tabs to front

--- a/package-lock.json
+++ b/package-lock.json
@@ -6323,11 +6323,6 @@
       "resolved": "packages/rollup-plugin-polyfills-loader",
       "link": true
     },
-    "node_modules/@web/storybook-prebuilt": {
-      "version": "0.1.37",
-      "resolved": "https://registry.npmjs.org/@web/storybook-prebuilt/-/storybook-prebuilt-0.1.37.tgz",
-      "integrity": "sha512-je4BAbOJiEjQOkeFJfw+fnezKpU3fQW+5ZTiY24UGB1xPaZfU7ZMrC9tW6699vy/QRVJhiJyQrcIQ35OVSlCQA=="
-    },
     "node_modules/@web/test-runner": {
       "resolved": "packages/test-runner",
       "link": true
@@ -7712,6 +7707,14 @@
       "integrity": "sha512-p4jj6Fws4Iy2m0iCmI2am2ZNZCgbdgE+P8F/8csmn2vx7ixXrO2zGcuNsD46X5uZSVecmkEy/M06X2vG8KD6dQ==",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
+      "integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/asynckit": {
@@ -29283,7 +29286,7 @@
     },
     "packages/dev-server": {
       "name": "@web/dev-server",
-      "version": "0.2.3",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.11",
@@ -29525,7 +29528,7 @@
     },
     "packages/dev-server-storybook": {
       "name": "@web/dev-server-storybook",
-      "version": "0.7.2",
+      "version": "0.7.4",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -29552,7 +29555,7 @@
       },
       "devDependencies": {
         "@types/path-is-inside": "^1.0.0",
-        "@web/dev-server": "^0.2.2",
+        "@web/dev-server": "^0.2.5",
         "htm": "^3.1.0"
       },
       "engines": {
@@ -29624,7 +29627,7 @@
     },
     "packages/mocks": {
       "name": "@web/mocks",
-      "version": "0.1.1",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@web/storybook-prebuilt": "^0.1.37",
@@ -29632,8 +29635,8 @@
         "msw": "0.0.0-fetch.rc-15"
       },
       "devDependencies": {
-        "@web/dev-server": "^0.2.3",
-        "@web/dev-server-storybook": "^0.7.2"
+        "@web/dev-server": "^0.2.5",
+        "@web/dev-server-storybook": "^0.7.4"
       }
     },
     "packages/mocks/node_modules/@web/storybook-prebuilt": {
@@ -29871,6 +29874,7 @@
       "dependencies": {
         "@web/test-runner-core": "^0.11.2",
         "@web/test-runner-coverage-v8": "^0.7.0",
+        "async-mutex": "0.4.0",
         "chrome-launcher": "^0.15.0",
         "puppeteer-core": "^19.8.1"
       },

--- a/packages/test-runner-chrome/package.json
+++ b/packages/test-runner-chrome/package.json
@@ -48,7 +48,8 @@
     "@web/test-runner-core": "^0.11.2",
     "@web/test-runner-coverage-v8": "^0.7.0",
     "chrome-launcher": "^0.15.0",
-    "puppeteer-core": "^19.8.1"
+    "puppeteer-core": "^19.8.1",
+    "async-mutex": "0.4.0"
   },
   "devDependencies": {
     "@types/istanbul-reports": "^3.0.0",


### PR DESCRIPTION
## What I did

This is a potential fix for the timeout issues when running test code in parallel that is requiring to be run in an active tab.
