### PR TITLE
feat(dev-server-core): support middleware mode

### DIFF
--- a/.changeset/fluffy-snails-share.md
+++ b/.changeset/fluffy-snails-share.md
@@ -7,4 +7,4 @@ support middleware mode
 BREAKING CHANGE
 
 Theoretically it's a breaking change for Plugin API since now `serverStart` hook might not have a param `server`.
-It won't impact the codebase immediately since you need to first activate `middlewareMode` to actually break stuff if any plugin depends on `server` existence, but type wise it might break compilation of such plugins right away. We decided to take an easy path and not create a SemVer mess with a minor update as the impact of this is too small and the risk is acceptable.
+The breaking change shouldnt impact your codebase immediately since you need to first activate `middlewareMode` to actually break stuff if any plugin depends on the existence of the `server` arg that gets passed to the plugin, but type wise it might break compilation of such plugins right away. Considering that `@web/dev-server` is still on semver 0.x.x, and since the impact of this breaking change should be very minimal, we decided to make the breaking change in this patch version.

--- a/.changeset/fluffy-snails-share.md
+++ b/.changeset/fluffy-snails-share.md
@@ -1,0 +1,10 @@
+---
+'@web/dev-server-core': patch
+---
+
+support middleware mode
+
+BREAKING CHANGE
+
+Theoretically it's a breaking change for Plugin API since now `serverStart` hook might not have a param `server`.
+It won't impact the codebase immediately since you need to first activate `middlewareMode` to actually break stuff if any plugin depends on `server` existence, but type wise it might break compilation of such plugins right away. We decided to take an easy path and not create a SemVer mess with a minor update as the impact of this is too small and the risk is acceptable.

--- a/docs/docs/dev-server/node-api.md
+++ b/docs/docs/dev-server/node-api.md
@@ -152,6 +152,29 @@ wss.on('connection', ws => {
 });
 ```
 
+## Middleware mode
+
+If you need to connect to an existing running web server with a compatible node middleware API (e.g. `express`), you can use `@web/dev-server` in middleware mode.
+
+```js
+import { startDevServer } from '@web/dev-server';
+
+async function main() {
+  const expressApp = express();
+  expressApp.listen(1234);
+  const { koaApp } = await startDevServer({
+    config: {
+      middlewareMode: true,
+    },
+  });
+  expressApp.use(koaApp.callback());
+}
+
+main();
+```
+
+In this mode it will not start a new HTTP server, but rather allow you to use it's callback `koaApp.callback()` as a middleware in a parent server.
+
 ## Advanced
 
 If you need more control than what `startDevServer` gives you, you can also use the individual pieces that make up the dev server directly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7619,6 +7619,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "dev": true
+    },
     "node_modules/array-iterate": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-1.1.4.tgz",
@@ -8085,6 +8091,122 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "dev": true,
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.11.0",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "node_modules/body-parser/node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "dev": true,
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/body-parser/node_modules/raw-body": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "dev": true,
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/body-parser/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/boolbase": {
@@ -9920,6 +10042,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "dev": true
     },
     "node_modules/cookies": {
       "version": "0.8.0",
@@ -12328,6 +12456,215 @@
         "node": ">=6"
       }
     },
+    "node_modules/express": {
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "dev": true,
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.1",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.5.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.2.0",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.11.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/express/node_modules/finalhandler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "node_modules/express/node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+      "dev": true
+    },
+    "node_modules/express/node_modules/qs": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "dev": true,
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/express/node_modules/send": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express/node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/express/node_modules/serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "dev": true,
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.18.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/ext-list": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
@@ -12850,6 +13187,15 @@
       },
       "engines": {
         "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/fresh": {
@@ -14607,6 +14953,15 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
       "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg=="
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/is-absolute": {
       "version": "1.0.0",
@@ -17646,6 +18001,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
+      "dev": true
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -17657,6 +18018,15 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/micromark": {
@@ -21353,6 +21723,19 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -29347,6 +29730,7 @@
         "@types/koa-static": "^4.0.1",
         "@types/parse5": "^6.0.1",
         "abort-controller": "^3.0.0",
+        "express": "^4.18.2",
         "nanoid": "^3.1.25",
         "node-fetch": "3.0.0-beta.9",
         "portfinder": "^1.0.32"
@@ -29479,7 +29863,7 @@
     },
     "packages/dev-server-rollup": {
       "name": "@web/dev-server-rollup",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-node-resolve": "^15.0.1",
@@ -29869,7 +30253,7 @@
     },
     "packages/test-runner-chrome": {
       "name": "@web/test-runner-chrome",
-      "version": "0.13.2",
+      "version": "0.13.3",
       "license": "MIT",
       "dependencies": {
         "@web/test-runner-core": "^0.11.2",

--- a/packages/dev-server-core/package.json
+++ b/packages/dev-server-core/package.json
@@ -81,6 +81,7 @@
     "@types/koa-static": "^4.0.1",
     "@types/parse5": "^6.0.1",
     "abort-controller": "^3.0.0",
+    "express": "^4.18.2",
     "nanoid": "^3.1.25",
     "node-fetch": "3.0.0-beta.9",
     "portfinder": "^1.0.32"

--- a/packages/dev-server-core/src/plugins/Plugin.ts
+++ b/packages/dev-server-core/src/plugins/Plugin.ts
@@ -20,7 +20,7 @@ export type ResolveMimeTypeResult = void | string | { type?: string };
 export interface ServerStartParams {
   config: DevServerCoreConfig;
   app: Koa;
-  server: Server;
+  server?: Server;
   fileWatcher: FSWatcher;
   logger: Logger;
   webSockets?: WebSocketsManager;

--- a/packages/dev-server-core/src/server/DevServerCoreConfig.ts
+++ b/packages/dev-server-core/src/server/DevServerCoreConfig.ts
@@ -7,7 +7,7 @@ export interface DevServerCoreConfig {
   /**
    * The port to run the server on.
    */
-  port: number;
+  port?: number;
   /**
    * Root directory to serve files from. All served files must be accessible with
    * this directory. If you are in a monorepository, you may need to set the to
@@ -17,7 +17,11 @@ export interface DevServerCoreConfig {
   /**
    * Hostname to bind the server to.
    */
-  hostname: string;
+  hostname?: string;
+  /**
+   * Whether to run server or not and allow to use as a middleware connected to another server.
+   */
+  middlewareMode?: boolean;
   basePath?: string;
   /**
    * The app's index.html file. When set, serves the index.html for non-file requests. Use this to enable SPA routing

--- a/packages/dev-server-core/src/server/createServer.ts
+++ b/packages/dev-server-core/src/server/createServer.ts
@@ -25,7 +25,12 @@ function httpsRedirect(req: IncomingMessage, res: ServerResponse) {
  * Creates a koa server with middlewares, but does not start it. Returns the koa app and
  * http server instances.
  */
-export function createServer(logger: Logger, cfg: DevServerCoreConfig, fileWatcher: FSWatcher) {
+export function createServer(
+  logger: Logger,
+  cfg: DevServerCoreConfig,
+  fileWatcher: FSWatcher,
+  middlewareMode = false,
+) {
   const app = new Koa();
   app.silent = true;
   app.on('error', error => {
@@ -53,6 +58,10 @@ export function createServer(logger: Logger, cfg: DevServerCoreConfig, fileWatch
   const middleware = createMiddleware(cfg, logger, fileWatcher);
   for (const m of middleware) {
     app.use(m);
+  }
+
+  if (middlewareMode) {
+    return { app };
   }
 
   let server: Server;

--- a/packages/dev-server-core/test/web-sockets/WebSocketsManager.test.ts
+++ b/packages/dev-server-core/test/web-sockets/WebSocketsManager.test.ts
@@ -61,7 +61,7 @@ describe('WebSocketManager', () => {
         });
       }, 'expected a message event');
 
-      server.webSockets.send('hello world');
+      server.webSockets!.send('hello world');
       await waitForMessage;
     } finally {
       server.stop();
@@ -102,7 +102,7 @@ describe('WebSocketManager', () => {
         });
       }, 'expected message');
 
-      server.webSockets.send('hello world');
+      server.webSockets!.send('hello world');
       await Promise.all([waitForMessage1, waitForMessage2]);
     } finally {
       server.stop();
@@ -125,7 +125,7 @@ describe('WebSocketManager', () => {
       }, 'expected web socket to open');
 
       const waitForMessage = waitFor(resolve => {
-        server.webSockets.on('message', ({ webSocket, data }) => {
+        server.webSockets!.on('message', ({ webSocket, data }) => {
           expect(webSocket).to.be.an.instanceOf(WebSocket);
           expect(data).to.eql({ type: 'foo' });
           resolve();
@@ -167,7 +167,7 @@ describe('WebSocketManager', () => {
         });
       }, 'expected a message event');
 
-      server.webSockets.sendConsoleLog('hello world');
+      server.webSockets!.sendConsoleLog('hello world');
       await waitForMessage;
     } finally {
       server.stop();
@@ -202,7 +202,7 @@ describe('WebSocketManager', () => {
         });
       }, 'expected a message event');
 
-      server.webSockets.sendImport('/foo.js');
+      server.webSockets!.sendImport('/foo.js');
       await waitForMessage;
     } finally {
       server.stop();

--- a/packages/dev-server-hmr/test/HmrPlugin.test.ts
+++ b/packages/dev-server-hmr/test/HmrPlugin.test.ts
@@ -27,7 +27,7 @@ describe('HmrPlugin', () => {
       ],
     });
     const { fileWatcher, webSockets } = server;
-    const stub = stubMethod(webSockets, 'send');
+    const stub = stubMethod(webSockets!, 'send');
     try {
       await fetch(`${host}/foo.js`);
       fileWatcher.emit('change', pathUtil.join(__dirname, '/foo.js'));
@@ -56,7 +56,7 @@ describe('HmrPlugin', () => {
       ],
     });
     const { fileWatcher, webSockets } = server;
-    const stub = stubMethod(webSockets, 'send');
+    const stub = stubMethod(webSockets!, 'send');
     try {
       await fetch(`${host}/foo.js`);
       await fetch(`${host}/bar.js`);
@@ -83,7 +83,7 @@ describe('HmrPlugin', () => {
       ],
     });
     const { fileWatcher, webSockets } = server;
-    const stub = stubMethod(webSockets, 'send');
+    const stub = stubMethod(webSockets!, 'send');
     try {
       await fetch(`${host}/foo.js`);
       await fetch(`${host}/bar.js`);
@@ -111,7 +111,7 @@ describe('HmrPlugin', () => {
       ],
     });
     const { fileWatcher, webSockets } = server;
-    const stub = stubMethod(webSockets, 'send');
+    const stub = stubMethod(webSockets!, 'send');
     try {
       await fetch(`${host}/foo.js`);
       await fetch(`${host}/bar.js`);
@@ -141,7 +141,7 @@ describe('HmrPlugin', () => {
       ],
     });
     const { fileWatcher, webSockets } = server;
-    const stub = stubMethod(webSockets, 'send');
+    const stub = stubMethod(webSockets!, 'send');
     try {
       await fetch(`${host}/root/foo.js`);
       await fetch(`${host}/root/bar.js`);
@@ -171,7 +171,7 @@ describe('HmrPlugin', () => {
       ],
     });
     const { fileWatcher, webSockets } = server;
-    const stub = stubMethod(webSockets, 'send');
+    const stub = stubMethod(webSockets!, 'send');
     try {
       await fetch(`${host}/foo.js`);
       await fetch(`${host}/bar.js`);
@@ -291,7 +291,7 @@ describe('HmrPlugin', () => {
       ],
     });
     const { fileWatcher, webSockets } = server;
-    const stub = stubMethod(webSockets, 'send');
+    const stub = stubMethod(webSockets!, 'send');
     try {
       await fetch(`${host}/foo.js`);
       await fetch(`${host}/bar.js`);
@@ -322,7 +322,7 @@ describe('HmrPlugin', () => {
       ],
     });
     const { fileWatcher, webSockets } = server;
-    const stub = stubMethod(webSockets, 'send');
+    const stub = stubMethod(webSockets!, 'send');
     try {
       await fetch(`${host}/foo.js`);
       fileWatcher.emit('change', pathUtil.join(__dirname, '/foo.js'));

--- a/packages/dev-server-hmr/test/browser.test.ts
+++ b/packages/dev-server-hmr/test/browser.test.ts
@@ -46,7 +46,7 @@ describe('browser tests', function () {
       ],
     });
     const { fileWatcher, webSockets } = server;
-    const stub = stubMethod(webSockets, 'send');
+    const stub = stubMethod(webSockets!, 'send');
     const page = await browser.newPage();
     try {
       await page.goto(`${host}/foo.html`, { waitUntil: 'networkidle0' });


### PR DESCRIPTION
## What I did

1. add `middlewareMode` option to dev server config, make `hostname` and `port` optional in types
2. implement middleware mode to prevent starting an actual HTTP/S server
3. make `server` optional on `DevServer` which also has an impact on Plugin API
4. add test and docs

## Breaking change

Theoretically it's a breaking change for Plugin API since now `serverStart` hook might not have a param `server`.
It won't impact the codebase immediately since you need to first activate `middlewareMode` to actually break stuff if any plugin depends on `server` existence, but type wise it might break compilation of such plugins right away.

As agreed with @thepassle we decided to take an easy path and not create a SemVer mess with a minor update as the impact of this is too small.