### PR TITLE
Convert `@wev/dev-server-storybook` to ES Module

### DIFF
--- a/.changeset/fuzzy-hornets-marry.md
+++ b/.changeset/fuzzy-hornets-marry.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server-storybook': major
+---
+
+This packages is now a ES Module by default.

--- a/packages/dev-server-storybook/package.json
+++ b/packages/dev-server-storybook/package.json
@@ -17,10 +17,12 @@
   "bin": {
     "build-storybook": "dist/build/cli.js"
   },
+  "type": "module",
   "exports": {
     ".": {
       "import": "./index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./index.d.ts"
     }
   },
   "engines": {

--- a/packages/dev-server-storybook/tsconfig.json
+++ b/packages/dev-server-storybook/tsconfig.json
@@ -3,7 +3,7 @@
 {
   "extends": "../../tsconfig.node-base.json",
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "nodenext",
     "outDir": "./dist",
     "rootDir": "./src",
     "composite": true,


### PR DESCRIPTION
## What I did

1. Added `"type": "module"` to the package.json of `dev-server-storybook`.
2. Changed `"module"` to `"nodenext"` in the `tsconfig.json`.
3. Made sure to add the `types` field in the exports field.
