### PR TITLE
Convert some rollup plugins to esm

### DIFF
--- a/.changeset/late-icons-provide.md
+++ b/.changeset/late-icons-provide.md
@@ -1,0 +1,10 @@
+---
+'@web/rollup-plugin-import-meta-assets': major
+'@web/test-runner-visual-regression': major
+'rollup-plugin-workbox': major
+'@web/dev-server-storybook': major
+'@web/rollup-plugin-copy': major
+'@web/dev-server-legacy': major
+---
+
+Convert project to be a ES Module.

--- a/packages/rollup-plugin-copy/package.json
+++ b/packages/rollup-plugin-copy/package.json
@@ -18,6 +18,7 @@
   },
   "main": "src/copy.js",
   "module": "index.mjs",
+  "type": "module",
   "exports": {
     ".": {
       "import": "./index.mjs",

--- a/packages/rollup-plugin-copy/src/copy.js
+++ b/packages/rollup-plugin-copy/src/copy.js
@@ -1,6 +1,6 @@
-const fs = require('fs');
-const path = require('path');
-const { patternsToFiles } = require('./patternsToFiles.js');
+import fs from 'fs';
+import path from 'path';
+import { patternsToFiles } from './patternsToFiles.js';
 
 /**
  * Copies all files from the given patterns retaining relative paths relative to the root directory.
@@ -21,7 +21,7 @@ const { patternsToFiles } = require('./patternsToFiles.js');
  * @param {string} [options.rootDir] Defaults to current working directory
  * @return {import('rollup').Plugin} A Rollup Plugin
  */
-function copy({ patterns = [], rootDir = process.cwd(), exclude }) {
+export function copy({ patterns = [], rootDir = process.cwd(), exclude }) {
   const resolvedRootDir = path.resolve(rootDir);
   /** @type {string[]} */
   let filesToCopy = [];
@@ -45,5 +45,3 @@ function copy({ patterns = [], rootDir = process.cwd(), exclude }) {
     },
   };
 }
-
-module.exports = { copy };

--- a/packages/rollup-plugin-copy/src/listFiles.js
+++ b/packages/rollup-plugin-copy/src/listFiles.js
@@ -1,6 +1,6 @@
-const glob = require('glob');
-const fs = require('fs');
-const path = require('path');
+import glob from 'glob';
+import fs from 'fs';
+import path from 'path';
 
 /**
  * Lists all files using the specified glob, starting from the given root directory.
@@ -11,7 +11,7 @@ const path = require('path');
  * @param {string} rootDir
  * @param {string|string[]} [ignore]
  */
-function listFiles(fromGlob, rootDir, ignore) {
+export function listFiles(fromGlob, rootDir, ignore) {
   return new Promise(resolve => {
     glob(fromGlob, { cwd: rootDir, dot: true, ignore }, (er, files) => {
       // remember, each filepath returned is relative to rootDir
@@ -25,5 +25,3 @@ function listFiles(fromGlob, rootDir, ignore) {
     });
   });
 }
-
-module.exports = { listFiles };

--- a/packages/rollup-plugin-copy/src/patternsToFiles.js
+++ b/packages/rollup-plugin-copy/src/patternsToFiles.js
@@ -1,4 +1,4 @@
-const { listFiles } = require('./listFiles.js');
+import { listFiles } from './listFiles.js';
 
 /**
  *
@@ -6,7 +6,7 @@ const { listFiles } = require('./listFiles.js');
  * @param {string} rootDir
  * @param {string|string[]} [exclude]
  */
-async function patternsToFiles(inPatterns, rootDir, exclude) {
+export async function patternsToFiles(inPatterns, rootDir, exclude) {
   const patterns = typeof inPatterns === 'string' ? [inPatterns] : inPatterns;
   const listFilesPromises = patterns.map(pattern => listFiles(pattern, rootDir, exclude));
   const arrayOfFilesArrays = await Promise.all(listFilesPromises);
@@ -20,5 +20,3 @@ async function patternsToFiles(inPatterns, rootDir, exclude) {
 
   return files;
 }
-
-module.exports = { patternsToFiles };

--- a/packages/rollup-plugin-copy/test/integration.test.js
+++ b/packages/rollup-plugin-copy/test/integration.test.js
@@ -1,8 +1,8 @@
-const path = require('path');
-const { expect } = require('chai');
-const rollup = require('rollup');
+import path from 'path';
+import { expect } from 'chai';
+import { rollup } from 'rollup';
 
-const { copy } = require('../src/copy.js');
+import { copy } from '../src/copy.js';
 
 describe('rollup-plugin-copy', () => {
   it('adds files to rollup', async () => {

--- a/packages/rollup-plugin-copy/test/integration.test.js
+++ b/packages/rollup-plugin-copy/test/integration.test.js
@@ -1,12 +1,15 @@
 import path from 'path';
 import { expect } from 'chai';
 import { rollup } from 'rollup';
+import { fileURLToPath } from 'url';
 
 import { copy } from '../src/copy.js';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 describe('rollup-plugin-copy', () => {
   it('adds files to rollup', async () => {
-    const bundle = await rollup.rollup({
+    const bundle = await rollup({
       input: path.resolve(__dirname, './fixture/index.js'),
       plugins: [copy({ patterns: '**/*.svg', rootDir: path.resolve(__dirname, './fixture/') })],
     });

--- a/packages/rollup-plugin-copy/test/listFiles.test.js
+++ b/packages/rollup-plugin-copy/test/listFiles.test.js
@@ -1,7 +1,7 @@
-const path = require('path');
-const { expect } = require('chai');
+import path from 'path';
+import { expect } from 'chai';
 
-const { listFiles } = require('../src/listFiles.js');
+import { listFiles } from '../src/listFiles.js';
 
 describe('listFiles', () => {
   it('gives a list of files', async () => {

--- a/packages/rollup-plugin-copy/test/listFiles.test.js
+++ b/packages/rollup-plugin-copy/test/listFiles.test.js
@@ -3,6 +3,9 @@ import { expect } from 'chai';
 
 import { listFiles } from '../src/listFiles.js';
 
+import { fileURLToPath } from 'url';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 describe('listFiles', () => {
   it('gives a list of files', async () => {
     const files = await listFiles('*.svg', path.resolve(__dirname, './fixture/'));

--- a/packages/rollup-plugin-copy/test/patternsToFiles.test.js
+++ b/packages/rollup-plugin-copy/test/patternsToFiles.test.js
@@ -1,7 +1,7 @@
-const path = require('path');
-const { expect } = require('chai');
+import path from 'path';
+import { expect } from 'chai';
 
-const { patternsToFiles } = require('../src/patternsToFiles.js');
+import { patternsToFiles } from '../src/patternsToFiles.js';
 
 describe('patternsToFiles', () => {
   it('works with a string', async () => {

--- a/packages/rollup-plugin-copy/test/patternsToFiles.test.js
+++ b/packages/rollup-plugin-copy/test/patternsToFiles.test.js
@@ -1,5 +1,8 @@
 import path from 'path';
 import { expect } from 'chai';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 import { patternsToFiles } from '../src/patternsToFiles.js';
 

--- a/packages/rollup-plugin-import-meta-assets/package.json
+++ b/packages/rollup-plugin-import-meta-assets/package.json
@@ -14,6 +14,7 @@
   "author": "modern-web",
   "homepage": "https://github.com/modernweb-dev/web/tree/master/packages/rollup-plugin-import-meta-assets",
   "main": "src/index.js",
+  "type": "module",
   "exports": {
     ".": {
       "import": "./index.mjs",

--- a/packages/rollup-plugin-import-meta-assets/src/rollup-plugin-import-meta-assets.js
+++ b/packages/rollup-plugin-import-meta-assets/src/rollup-plugin-import-meta-assets.js
@@ -1,12 +1,11 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
-'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const { createFilter } = require('@rollup/pluginutils');
-const { asyncWalk } = require('estree-walker');
-const MagicString = require('magic-string');
+import fs from 'fs';
+import path from 'path';
+import { createFilter } from '@rollup/pluginutils';
+import { asyncWalk } from 'estree-walker';
+import MagicString from 'magic-string';
 
 /**
  * Extract the relative path from an AST node representing this kind of expression `new URL('./path/to/asset.ext', import.meta.url)`.
@@ -51,7 +50,7 @@ function isNewUrlImportMetaUrl(node) {
  * @param {function} [options.transform] A function to transform assets.
  * @return {import('rollup').Plugin} A Rollup Plugin
  */
-function importMetaAssets({ include, exclude, warnOnError, transform } = {}) {
+export function importMetaAssets({ include, exclude, warnOnError, transform } = {}) {
   const filter = createFilter(include, exclude);
 
   return {
@@ -112,5 +111,3 @@ function importMetaAssets({ include, exclude, warnOnError, transform } = {}) {
     },
   };
 }
-
-module.exports = { importMetaAssets };

--- a/packages/rollup-plugin-import-meta-assets/test/integration.test.js
+++ b/packages/rollup-plugin-import-meta-assets/test/integration.test.js
@@ -51,7 +51,7 @@ describe('rollup-plugin-import-meta-assets', () => {
       plugins: [importMetaAssets()],
     };
 
-    const bundle = await rollup.rollup(config);
+    const bundle = await rollup(config);
     const { output } = await bundle.generate(outputConfig);
 
     expect(output.length).to.equal(5);
@@ -79,7 +79,7 @@ describe('rollup-plugin-import-meta-assets', () => {
       ],
     };
 
-    const bundle = await rollup.rollup(config);
+    const bundle = await rollup(config);
     const { output } = await bundle.generate(outputConfig);
 
     expect(output.length).to.equal(6);
@@ -108,7 +108,7 @@ describe('rollup-plugin-import-meta-assets', () => {
       ],
     };
 
-    const bundle = await rollup.rollup(config);
+    const bundle = await rollup(config);
     const { output } = await bundle.generate(outputConfig);
 
     expect(output.length).to.equal(5);
@@ -126,7 +126,7 @@ describe('rollup-plugin-import-meta-assets', () => {
       plugins: [importMetaAssets()],
     };
 
-    const bundle = await rollup.rollup(config);
+    const bundle = await rollup(config);
     const { output } = await bundle.generate(outputConfig);
 
     expect(output.length).to.equal(5);
@@ -148,7 +148,7 @@ describe('rollup-plugin-import-meta-assets', () => {
       plugins: [importMetaAssets()],
     };
 
-    const bundle = await rollup.rollup(config);
+    const bundle = await rollup(config);
     const { output } = await bundle.generate(outputConfig);
 
     expect(output.length).to.equal(5);
@@ -170,7 +170,7 @@ describe('rollup-plugin-import-meta-assets', () => {
       plugins: [importMetaAssets()],
     };
 
-    const bundle = await rollup.rollup(config);
+    const bundle = await rollup(config);
     const { output } = await bundle.generate(outputConfig);
 
     expect(output.length).to.equal(5);
@@ -211,7 +211,7 @@ describe('rollup-plugin-import-meta-assets', () => {
       ],
     };
 
-    const bundle = await rollup.rollup(config);
+    const bundle = await rollup(config);
     const { output } = await bundle.generate(outputConfig);
 
     // 4 ES modules + 2 assets
@@ -235,7 +235,7 @@ describe('rollup-plugin-import-meta-assets', () => {
     let error;
 
     try {
-      const bundle = await rollup.rollup(config);
+      const bundle = await rollup(config);
       await bundle.generate(outputConfig);
     } catch (e) {
       error = e;
@@ -250,7 +250,7 @@ describe('rollup-plugin-import-meta-assets', () => {
       plugins: [importMetaAssets({ warnOnError: true })],
     };
 
-    const bundle = await rollup.rollup(config);
+    const bundle = await rollup(config);
     await bundle.generate(outputConfig);
 
     expect(consoleStub.callCount).to.equal(2);

--- a/packages/rollup-plugin-import-meta-assets/test/integration.test.js
+++ b/packages/rollup-plugin-import-meta-assets/test/integration.test.js
@@ -1,10 +1,10 @@
-const fs = require('fs');
-const path = require('path');
-const rollup = require('rollup');
-const { expect } = require('chai');
-const hanbi = require('hanbi');
+import fs from 'fs';
+import path from 'path';
+import { rollup } from 'rollup';
+import { expect } from 'chai';
+import * as hanbi from 'hanbi';
 
-const { importMetaAssets } = require('../src/rollup-plugin-import-meta-assets.js');
+import { importMetaAssets } from '../src/rollup-plugin-import-meta-assets.js';
 
 const outputConfig = {
   format: 'es',

--- a/packages/rollup-plugin-import-meta-assets/test/integration.test.js
+++ b/packages/rollup-plugin-import-meta-assets/test/integration.test.js
@@ -7,6 +7,8 @@ import * as hanbi from 'hanbi';
 import { importMetaAssets } from '../src/rollup-plugin-import-meta-assets.js';
 
 import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const outputConfig = {

--- a/packages/rollup-plugin-import-meta-assets/test/integration.test.js
+++ b/packages/rollup-plugin-import-meta-assets/test/integration.test.js
@@ -6,6 +6,9 @@ import * as hanbi from 'hanbi';
 
 import { importMetaAssets } from '../src/rollup-plugin-import-meta-assets.js';
 
+import { fileURLToPath } from 'url';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 const outputConfig = {
   format: 'es',
   dir: 'dist',

--- a/packages/rollup-plugin-workbox/package.json
+++ b/packages/rollup-plugin-workbox/package.json
@@ -15,6 +15,7 @@
   },
   "main": "dist/index.js",
   "module": "index.mjs",
+  "type": "module",
   "exports": {
     ".": {
       "import": "./index.mjs",

--- a/scripts/generate-mjs-dts-entrypoints.mjs
+++ b/scripts/generate-mjs-dts-entrypoints.mjs
@@ -1,9 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 import { createRequire } from 'module';
-import { packages } from '../workspace-packages.mjs';
-
 const require = createRequire(import.meta.url);
+import { packages } from '../workspace-packages.mjs';
 
 for (const pkg of packages) {
   if (pkg.type === 'ts' && pkg.environment === 'node') {


### PR DESCRIPTION
## What I did

1. Added `"type": "module"` to the `package.json` of these rollup plugins.
2. Changed `"module"` to `"nodenext"` in the `tsconfig.json`.
3. Made sure to add the types field in the exports field.

_This is a stacked PR and is waiting for #2391 to land before we can land this one._