### PR TITLE
set node version to 18

### DIFF
--- a/.changeset/spicy-shrimps-agree.md
+++ b/.changeset/spicy-shrimps-agree.md
@@ -1,0 +1,35 @@
+---
+'@web/rollup-plugin-import-meta-assets': minor
+'@web/rollup-plugin-polyfills-loader': minor
+'@web/test-runner-visual-regression': minor
+'@web/test-runner-junit-reporter': minor
+'@web/test-runner-browserstack': minor
+'@web/test-runner-coverage-v8': minor
+'@web/dev-server-import-maps': minor
+'@web/test-runner-playwright': minor
+'@web/test-runner-puppeteer': minor
+'@web/test-runner-saucelabs': minor
+'@web/test-runner-webdriver': minor
+'@web/dev-server-storybook': minor
+'@web/test-runner-commands': minor
+'@web/test-runner-selenium': minor
+'@web/dev-server-esbuild': minor
+'@web/rollup-plugin-copy': minor
+'@web/rollup-plugin-html': minor
+'@web/test-runner-chrome': minor
+'@web/dev-server-legacy': minor
+'@web/dev-server-rollup': minor
+'@web/test-runner-mocha': minor
+'@web/polyfills-loader': minor
+'@web/test-runner-core': minor
+'@web/dev-server-core': minor
+'@web/test-runner-cli': minor
+'@web/dev-server-hmr': minor
+'@web/config-loader': minor
+'@web/browser-logs': minor
+'@web/parse5-utils': minor
+'@web/test-runner': minor
+'@web/dev-server': minor
+---
+
+Set minimum node version to 18

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "wireit": "^0.10.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "integration/test-runner": {
@@ -30272,7 +30272,7 @@
         "puppeteer": "^20.0.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/config-loader": {
@@ -30283,7 +30283,7 @@
         "semver": "^7.3.4"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/dev-server": {
@@ -30316,7 +30316,7 @@
         "puppeteer": "^20.0.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/dev-server-core": {
@@ -30355,7 +30355,7 @@
         "portfinder": "^1.0.32"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/dev-server-core/node_modules/node-fetch": {
@@ -30394,7 +30394,7 @@
         "preact": "^10.5.9"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/dev-server-esbuild/node_modules/node-fetch": {
@@ -30426,7 +30426,7 @@
         "puppeteer": "^20.0.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/dev-server-import-maps": {
@@ -30445,7 +30445,7 @@
         "@web/test-runner": "^0.17.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/dev-server-legacy": {
@@ -30477,7 +30477,7 @@
         "@types/valid-url": "^1.0.3"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/dev-server-rollup": {
@@ -30509,7 +30509,7 @@
         "rollup-plugin-postcss": "^4.0.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/dev-server-rollup/node_modules/node-fetch": {
@@ -30562,7 +30562,7 @@
         "htm": "^3.1.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/dev-server/node_modules/array-back": {
@@ -30649,7 +30649,7 @@
         "@types/html-minifier-terser": "^7.0.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/polyfills-loader": {
@@ -30683,7 +30683,7 @@
         "@types/valid-url": "^1.0.3"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/rollup-plugin-copy": {
@@ -30697,7 +30697,7 @@
         "@types/glob": "^7.1.3"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/rollup-plugin-copy/node_modules/glob": {
@@ -30734,7 +30734,7 @@
         "rollup": "^3.15.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/rollup-plugin-html/node_modules/glob": {
@@ -30766,7 +30766,7 @@
         "magic-string": "^0.30.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/rollup-plugin-import-meta-assets/node_modules/magic-string": {
@@ -30792,7 +30792,7 @@
         "rollup": "^3.15.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/rollup-plugin-workbox": {
@@ -30838,7 +30838,7 @@
         "concurrently": "^8.0.1"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/test-runner-browserstack": {
@@ -30857,7 +30857,7 @@
         "portfinder": "^1.0.32"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/test-runner-chrome": {
@@ -30876,7 +30876,7 @@
         "@web/test-runner-mocha": "^0.8.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/test-runner-cli": {
@@ -30884,7 +30884,7 @@
       "version": "0.10.0",
       "license": "MIT",
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/test-runner-commands": {
@@ -30902,7 +30902,7 @@
         "mocha": "^10.2.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/test-runner-commands/node_modules/mkdirp": {
@@ -30952,7 +30952,7 @@
         "portfinder": "^1.0.32"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/test-runner-core/node_modules/dependency-graph": {
@@ -30979,7 +30979,7 @@
         "@types/picomatch": "^2.2.1"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/test-runner-junit-reporter": {
@@ -30997,7 +30997,7 @@
         "@web/test-runner-playwright": "^0.10.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/test-runner-mocha": {
@@ -31013,7 +31013,7 @@
         "mocha": "^10.2.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/test-runner-playwright": {
@@ -31030,7 +31030,7 @@
         "portfinder": "^1.0.32"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/test-runner-puppeteer": {
@@ -31047,7 +31047,7 @@
         "puppeteer-core": "^20.0.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/test-runner-saucelabs": {
@@ -31069,7 +31069,7 @@
         "portfinder": "^1.0.32"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/test-runner-selenium": {
@@ -31086,7 +31086,7 @@
         "selenium-standalone": "^8.0.4"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/test-runner-visual-regression": {
@@ -31110,7 +31110,7 @@
         "mocha": "^10.2.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/test-runner-visual-regression/node_modules/mkdirp": {
@@ -31137,7 +31137,7 @@
         "selenium-standalone": "^8.0.4"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/test-runner/node_modules/array-back": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/modernweb-dev/web.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "rimraf --glob packages/*/tsconfig.tsbuildinfo && tsc --build",

--- a/packages/browser-logs/package.json
+++ b/packages/browser-logs/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/modernweb-dev/web/tree/master/packages/config-loader",
   "main": "src/index.js",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/dev-server-core/package.json
+++ b/packages/dev-server-core/package.json
@@ -28,7 +28,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/dev-server-esbuild/package.json
+++ b/packages/dev-server-esbuild/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/dev-server-hmr/package.json
+++ b/packages/dev-server-hmr/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/dev-server-import-maps/package.json
+++ b/packages/dev-server-import-maps/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/dev-server-legacy/package.json
+++ b/packages/dev-server-legacy/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/dev-server-rollup/package.json
+++ b/packages/dev-server-rollup/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "test": "mocha \"test/node/**/*.test.ts\" --require ts-node/register",

--- a/packages/dev-server-storybook/package.json
+++ b/packages/dev-server-storybook/package.json
@@ -24,7 +24,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build:wc": "node dist/build/cli.js -c demo/wc/.storybook",

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -25,7 +25,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "start": "npm run start:syntax",

--- a/packages/parse5-utils/package.json
+++ b/packages/parse5-utils/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/polyfills-loader/package.json
+++ b/packages/polyfills-loader/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/rollup-plugin-copy/package.json
+++ b/packages/rollup-plugin-copy/package.json
@@ -25,7 +25,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "test": "mocha test/**/*.test.js --reporter dot",

--- a/packages/rollup-plugin-html/package.json
+++ b/packages/rollup-plugin-html/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "demo:mpa": "rm -rf demo/dist && rollup -c demo/mpa/rollup.config.js --watch & npm run serve-demo",

--- a/packages/rollup-plugin-import-meta-assets/package.json
+++ b/packages/rollup-plugin-import-meta-assets/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "test": "npm run test:node",

--- a/packages/rollup-plugin-polyfills-loader/package.json
+++ b/packages/rollup-plugin-polyfills-loader/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "test": "mocha test/**/*.test.ts --require ts-node/register",

--- a/packages/test-runner-browserstack/package.json
+++ b/packages/test-runner-browserstack/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-chrome/package.json
+++ b/packages/test-runner-chrome/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-cli/package.json
+++ b/packages/test-runner-cli/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-commands/package.json
+++ b/packages/test-runner-commands/package.json
@@ -25,7 +25,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-core/package.json
+++ b/packages/test-runner-core/package.json
@@ -27,7 +27,7 @@
     "./browser/session.js": "./browser/session.js"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-coverage-v8/package.json
+++ b/packages/test-runner-coverage-v8/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc"

--- a/packages/test-runner-junit-reporter/package.json
+++ b/packages/test-runner-junit-reporter/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-mocha/package.json
+++ b/packages/test-runner-mocha/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/modernweb-dev/web/tree/master/packages/test-runner-mocha",
   "main": "dist/standalone.js",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-playwright/package.json
+++ b/packages/test-runner-playwright/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-puppeteer/package.json
+++ b/packages/test-runner-puppeteer/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-saucelabs/package.json
+++ b/packages/test-runner-saucelabs/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-selenium/package.json
+++ b/packages/test-runner-selenium/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-visual-regression/package.json
+++ b/packages/test-runner-visual-regression/package.json
@@ -26,7 +26,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-webdriver/package.json
+++ b/packages/test-runner-webdriver/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner/package.json
+++ b/packages/test-runner/package.json
@@ -31,7 +31,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## What I did

1. I set `engines.node` version to at least 18.

I figured since we aren't even testing on node16 that we don't actually support it.
