### PR TITLE
fix(parse5-utils): add support for templates

### DIFF
--- a/.changeset/soft-meals-smash.md
+++ b/.changeset/soft-meals-smash.md
@@ -1,0 +1,5 @@
+---
+'@web/parse5-utils': patch
+---
+
+Adds support for traversing <template> elements

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@web/dev-server-legacy": "^2.0.0",
+        "@web/dev-server-legacy": "^2.0.1",
         "@web/test-runner-core": "^0.11.2"
       },
       "devDependencies": {
@@ -30450,7 +30450,7 @@
     },
     "packages/dev-server-legacy": {
       "name": "@web/dev-server-legacy",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.12.10",
@@ -31091,7 +31091,7 @@
     },
     "packages/test-runner-visual-regression": {
       "name": "@web/test-runner-visual-regression",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@types/mkdirp": "^1.0.1",

--- a/packages/parse5-utils/src/index.js
+++ b/packages/parse5-utils/src/index.js
@@ -215,7 +215,19 @@ function findNodes(nodes, test) {
     if (test(node)) {
       found.push(node);
     }
-    const children = adapter.getChildNodes(/** @type {ParentNode} */ (node));
+
+    /** @type {Node[]} */
+    let children = [];
+
+    if (adapter.isElementNode(node) && adapter.getTagName(node) === 'template') {
+      const content = adapter.getTemplateContent(node);
+      if (content) {
+        children = adapter.getChildNodes(content);
+      }
+    } else {
+      children = adapter.getChildNodes(/** @type {ParentNode} */ (node));
+    }
+
     if (Array.isArray(children)) {
       n.unshift(...children);
     }

--- a/packages/parse5-utils/test/index.test.js
+++ b/packages/parse5-utils/test/index.test.js
@@ -288,6 +288,21 @@ describe('parse5-utils', () => {
       const found = utils.findElements(doc, el => utils.hasAttribute(el, 'non-existing'));
       expect(found.length).to.equal(0);
     });
+
+    it('returns child elements within template elements', () => {
+      const doc = parse(`
+      <html>
+        <body>
+          <template>
+            <img src="foo.png" />
+          </template>
+        </body>
+      </html>
+    `);
+
+      const found = utils.findElements(doc, el => utils.hasAttribute(el, 'src'));
+      expect(found.length).to.equal(1);
+    });
   });
 
   describe('prependToDocument', () => {


### PR DESCRIPTION
Proposed fix for https://github.com/modernweb-dev/web/issues/2397

parse5-utils does not currently handle tags within a `<template>` tag, this prevents `rollup-plugin-html` from extracting assets that are within a template.

## What I did

1. Add a condition to `findNodes` that will get child nodes of a `<template>` tag
2. Add a test to ensure the change functions as expected

