### PR TITLE
fix: security vulnerability make-dir

### DIFF
--- a/.changeset/small-rivers-carry.md
+++ b/.changeset/small-rivers-carry.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-core': patch
+---
+
+Fixes security vulnerability in make-dir < v4.0.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@web/dev-server-legacy": "^2.0.0",
+        "@web/dev-server-legacy": "^2.0.1",
         "@web/test-runner-core": "^0.11.2"
       },
       "devDependencies": {
@@ -30450,7 +30450,7 @@
     },
     "packages/dev-server-legacy": {
       "name": "@web/dev-server-legacy",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.12.10",
@@ -30531,7 +30531,7 @@
     },
     "packages/dev-server-storybook": {
       "name": "@web/dev-server-storybook",
-      "version": "0.7.4",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -30625,7 +30625,7 @@
     },
     "packages/mocks": {
       "name": "@web/mocks",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@web/storybook-prebuilt": "^0.1.37",
@@ -30634,7 +30634,7 @@
       },
       "devDependencies": {
         "@web/dev-server": "^0.3.0",
-        "@web/dev-server-storybook": "^0.7.4"
+        "@web/dev-server-storybook": "^1.0.0"
       }
     },
     "packages/parse5-utils": {
@@ -30939,7 +30939,7 @@
         "globby": "^11.0.1",
         "ip": "^1.1.5",
         "istanbul-lib-coverage": "^3.0.0",
-        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.0.2",
         "log-update": "^4.0.0",
         "nanocolors": "^0.2.1",
@@ -30961,6 +30961,52 @@
       "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
       "engines": {
         "node": ">= 0.6.0"
+      }
+    },
+    "packages/test-runner-core/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/test-runner-core/node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/test-runner-core/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/test-runner-core/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "packages/test-runner-coverage-v8": {
@@ -31091,7 +31137,7 @@
     },
     "packages/test-runner-visual-regression": {
       "name": "@web/test-runner-visual-regression",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@types/mkdirp": "^1.0.1",

--- a/packages/test-runner-core/package.json
+++ b/packages/test-runner-core/package.json
@@ -68,7 +68,7 @@
     "globby": "^11.0.1",
     "ip": "^1.1.5",
     "istanbul-lib-coverage": "^3.0.0",
-    "istanbul-lib-report": "^3.0.0",
+    "istanbul-lib-report": "^3.0.1",
     "istanbul-reports": "^3.0.2",
     "log-update": "^4.0.0",
     "nanocolors": "^0.2.1",


### PR DESCRIPTION
## What I did

1. make-dir 3.x.x was vulnerable (transitive dep), patched in istanbul-lib-report 3.0.1.
