### PR TITLE
Fix output format of `@web/dev-server-storybook`

### DIFF
--- a/.changeset/stale-cooks-cover.md
+++ b/.changeset/stale-cooks-cover.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server-storybook': patch
+---
+
+Fix output format of package.

--- a/packages/dev-server-storybook/src/build/build.ts
+++ b/packages/dev-server-storybook/src/build/build.ts
@@ -1,13 +1,13 @@
-import { readStorybookConfig } from '../shared/config/readStorybookConfig';
-import { validatePluginConfig } from '../shared/config/validatePluginConfig';
+import { readStorybookConfig } from '../shared/config/readStorybookConfig.js';
+import { validatePluginConfig } from '../shared/config/validatePluginConfig.js';
 
-import { createRollupConfig } from './rollup/createRollupConfig';
-import { buildAndWrite } from './rollup/buildAndWrite';
-import { createManagerHtml } from '../shared/html/createManagerHtml';
-import { createPreviewHtml } from '../shared/html/createPreviewHtml';
-import { findStories } from '../shared/stories/findStories';
-import { StorybookPluginConfig } from '../shared/config/StorybookPluginConfig';
-import { StorybookConfig } from '../shared/config/StorybookConfig';
+import { createRollupConfig } from './rollup/createRollupConfig.js';
+import { buildAndWrite } from './rollup/buildAndWrite.js';
+import { createManagerHtml } from '../shared/html/createManagerHtml.js';
+import { createPreviewHtml } from '../shared/html/createPreviewHtml.js';
+import { findStories } from '../shared/stories/findStories.js';
+import { StorybookPluginConfig } from '../shared/config/StorybookPluginConfig.js';
+import { StorybookConfig } from '../shared/config/StorybookConfig.js';
 
 interface BuildPreviewParams {
   type: string;

--- a/packages/dev-server-storybook/src/build/cli.ts
+++ b/packages/dev-server-storybook/src/build/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import commandLineArgs from 'command-line-args';
 import path from 'path';
-import { build } from './build';
+import { build } from './build.js';
 
 async function main() {
   const args = commandLineArgs([

--- a/packages/dev-server-storybook/src/build/rollup/createRollupConfig.ts
+++ b/packages/dev-server-storybook/src/build/rollup/createRollupConfig.ts
@@ -1,7 +1,7 @@
 import { Plugin, RollupOptions, RollupWarning } from 'rollup';
 
-import {nodeResolve as resolve} from '@rollup/plugin-node-resolve';
-import {babel} from '@rollup/plugin-babel';
+import { nodeResolve as resolve } from '@rollup/plugin-node-resolve';
+import { babel } from '@rollup/plugin-babel';
 // @ts-ignore
 import html from '@web/rollup-plugin-html';
 // @ts-ignore

--- a/packages/dev-server-storybook/src/build/rollup/createRollupConfig.ts
+++ b/packages/dev-server-storybook/src/build/rollup/createRollupConfig.ts
@@ -1,14 +1,16 @@
 import { Plugin, RollupOptions, RollupWarning } from 'rollup';
 
-import resolve from '@rollup/plugin-node-resolve';
+import {nodeResolve as resolve} from '@rollup/plugin-node-resolve';
 import babel from '@rollup/plugin-babel';
+// @ts-ignore
 import html from '@web/rollup-plugin-html';
+// @ts-ignore
 import polyfillsLoader from '@web/rollup-plugin-polyfills-loader';
 import { DEFAULT_EXTENSIONS } from '@babel/core';
 import terser from '@rollup/plugin-terser';
-import { mdxPlugin } from './mdxPlugin';
-import { mdjsPlugin } from './mdjsPlugin';
-import { injectExportsOrderPlugin } from './injectExportsOrderPlugin';
+import { mdxPlugin } from './mdxPlugin.js';
+import { mdjsPlugin } from './mdjsPlugin.js';
+import { injectExportsOrderPlugin } from './injectExportsOrderPlugin.js';
 
 const prebuiltDir = require
   .resolve('@web/storybook-prebuilt/package.json')

--- a/packages/dev-server-storybook/src/build/rollup/createRollupConfig.ts
+++ b/packages/dev-server-storybook/src/build/rollup/createRollupConfig.ts
@@ -1,7 +1,7 @@
 import { Plugin, RollupOptions, RollupWarning } from 'rollup';
 
 import {nodeResolve as resolve} from '@rollup/plugin-node-resolve';
-import babel from '@rollup/plugin-babel';
+import {babel} from '@rollup/plugin-babel';
 // @ts-ignore
 import html from '@web/rollup-plugin-html';
 // @ts-ignore

--- a/packages/dev-server-storybook/src/build/rollup/createRollupConfig.ts
+++ b/packages/dev-server-storybook/src/build/rollup/createRollupConfig.ts
@@ -125,6 +125,7 @@ export function createRollupConfig(params: CreateRollupConfigParams): RollupOpti
           resizeObserver: true,
         },
       }) as Plugin,
+      // @ts-ignore the provided type is wrong
       terser({ format: { comments: false } }) as Plugin,
     ],
   };

--- a/packages/dev-server-storybook/src/build/rollup/injectExportsOrderPlugin.ts
+++ b/packages/dev-server-storybook/src/build/rollup/injectExportsOrderPlugin.ts
@@ -1,5 +1,5 @@
 import { Plugin } from 'rollup';
-import { injectExportsOrder } from '../../shared/stories/injectExportsOrder';
+import { injectExportsOrder } from '../../shared/stories/injectExportsOrder.js';
 
 export function injectExportsOrderPlugin(storyFilePaths: string[]): Plugin {
   return {

--- a/packages/dev-server-storybook/src/build/rollup/mdxPlugin.ts
+++ b/packages/dev-server-storybook/src/build/rollup/mdxPlugin.ts
@@ -1,5 +1,5 @@
 import { Plugin } from 'rollup';
-import { transformMdxToCsf } from '../../shared/mdx/transformMdxToCsf';
+import { transformMdxToCsf } from '../../shared/mdx/transformMdxToCsf.js';
 
 export function mdxPlugin(): Plugin {
   return {

--- a/packages/dev-server-storybook/src/index.ts
+++ b/packages/dev-server-storybook/src/index.ts
@@ -1,1 +1,1 @@
-export { storybookPlugin } from './serve/storybookPlugin';
+export { storybookPlugin } from './serve/storybookPlugin.js';

--- a/packages/dev-server-storybook/src/serve/storybookPlugin.ts
+++ b/packages/dev-server-storybook/src/serve/storybookPlugin.ts
@@ -1,14 +1,14 @@
 import { DevServerCoreConfig, getRequestFilePath, Plugin } from '@web/dev-server-core';
 import { mdjsToCsf } from 'storybook-addon-markdown-docs';
 
-import { StorybookPluginConfig } from '../shared/config/StorybookPluginConfig';
-import { createManagerHtml } from '../shared/html/createManagerHtml';
-import { createPreviewHtml } from '../shared/html/createPreviewHtml';
-import { readStorybookConfig } from '../shared/config/readStorybookConfig';
-import { validatePluginConfig } from '../shared/config/validatePluginConfig';
-import { findStories } from '../shared/stories/findStories';
-import { transformMdxToCsf } from '../shared/mdx/transformMdxToCsf';
-import { injectExportsOrder } from '../shared/stories/injectExportsOrder';
+import { StorybookPluginConfig } from '../shared/config/StorybookPluginConfig.js';
+import { createManagerHtml } from '../shared/html/createManagerHtml.js';
+import { createPreviewHtml } from '../shared/html/createPreviewHtml.js';
+import { readStorybookConfig } from '../shared/config/readStorybookConfig.js';
+import { validatePluginConfig } from '../shared/config/validatePluginConfig.js';
+import { findStories } from '../shared/stories/findStories.js';
+import { transformMdxToCsf } from '../shared/mdx/transformMdxToCsf.js';
+import { injectExportsOrder } from '../shared/stories/injectExportsOrder.js';
 
 const regexpReplaceWebsocket = /<!-- injected by web-dev-server -->(.|\s)*<\/script>/m;
 

--- a/packages/dev-server-storybook/src/serve/storybookPlugin.ts
+++ b/packages/dev-server-storybook/src/serve/storybookPlugin.ts
@@ -1,3 +1,4 @@
+// @ts-ignore
 import { DevServerCoreConfig, getRequestFilePath, Plugin } from '@web/dev-server-core';
 import { mdjsToCsf } from 'storybook-addon-markdown-docs';
 

--- a/packages/dev-server-storybook/src/serve/storybookPlugin.ts
+++ b/packages/dev-server-storybook/src/serve/storybookPlugin.ts
@@ -31,7 +31,7 @@ export function storybookPlugin(pluginConfig: StorybookPluginConfig): Plugin {
   return {
     name: 'storybook',
 
-    serverStart(args: {config: unknown}) {
+    serverStart(args: { config: unknown }) {
       serverConfig = args.config;
     },
 

--- a/packages/dev-server-storybook/src/serve/storybookPlugin.ts
+++ b/packages/dev-server-storybook/src/serve/storybookPlugin.ts
@@ -12,6 +12,13 @@ import { injectExportsOrder } from '../shared/stories/injectExportsOrder.js';
 
 const regexpReplaceWebsocket = /<!-- injected by web-dev-server -->(.|\s)*<\/script>/m;
 
+interface Context {
+  URL: URL;
+  path: string;
+  body: unknown;
+  url: string;
+}
+
 export function storybookPlugin(pluginConfig: StorybookPluginConfig): Plugin {
   validatePluginConfig(pluginConfig);
 
@@ -23,11 +30,11 @@ export function storybookPlugin(pluginConfig: StorybookPluginConfig): Plugin {
   return {
     name: 'storybook',
 
-    serverStart(args) {
+    serverStart(args: {config: unknown}) {
       serverConfig = args.config;
     },
 
-    resolveMimeType(context) {
+    resolveMimeType(context: Context) {
       if (context.URL.searchParams.get('story') !== 'true') {
         return;
       }
@@ -37,7 +44,7 @@ export function storybookPlugin(pluginConfig: StorybookPluginConfig): Plugin {
       }
     },
 
-    async transform(context) {
+    async transform(context: Context) {
       if (typeof context.body !== 'string') {
         return;
       }
@@ -67,7 +74,7 @@ export function storybookPlugin(pluginConfig: StorybookPluginConfig): Plugin {
       }
     },
 
-    async serve(context) {
+    async serve(context: Context) {
       if (context.path === '/') {
         return { type: 'html', body: createManagerHtml(storybookConfig, serverConfig.rootDir) };
       }

--- a/packages/dev-server-storybook/src/shared/config/readStorybookConfig.ts
+++ b/packages/dev-server-storybook/src/shared/config/readStorybookConfig.ts
@@ -1,9 +1,9 @@
 import path from 'path';
 import fs from 'fs';
 
-import { StorybookPluginConfig } from './StorybookPluginConfig';
-import { createError } from '../utils';
-import { MainJs, StorybookConfig } from './StorybookConfig';
+import { StorybookPluginConfig } from './StorybookPluginConfig.js';
+import { createError } from '../utils.js';
+import { MainJs, StorybookConfig } from './StorybookConfig.js';
 
 const defaultConfigDir = path.join(process.cwd(), '.storybook');
 

--- a/packages/dev-server-storybook/src/shared/config/validatePluginConfig.ts
+++ b/packages/dev-server-storybook/src/shared/config/validatePluginConfig.ts
@@ -1,5 +1,5 @@
-import { StorybookPluginConfig } from '../config/StorybookPluginConfig';
-import { createError } from '../utils';
+import { StorybookPluginConfig } from '../config/StorybookPluginConfig.js';
+import { createError } from '../utils.js';
 
 const types = ['preact', 'web-components'];
 

--- a/packages/dev-server-storybook/src/shared/html/createManagerHtml.ts
+++ b/packages/dev-server-storybook/src/shared/html/createManagerHtml.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
-import { StorybookConfig } from '../config/StorybookConfig';
-import { createBrowserImport } from '../utils';
+import { StorybookConfig } from '../config/StorybookConfig.js';
+import { createBrowserImport } from '../utils.js';
 
 function createManagerImport(rootDir: string, managerJsPath: string) {
   if (!fs.existsSync(managerJsPath)) {

--- a/packages/dev-server-storybook/src/shared/html/createPreviewHtml.ts
+++ b/packages/dev-server-storybook/src/shared/html/createPreviewHtml.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
-import { StorybookConfig } from '../config/StorybookConfig';
+import { StorybookConfig } from '../config/StorybookConfig.js';
 
-import { StorybookPluginConfig } from '../config/StorybookPluginConfig';
-import { createBrowserImport } from '../utils';
+import { StorybookPluginConfig } from '../config/StorybookPluginConfig.js';
+import { createBrowserImport } from '../utils.js';
 
 function createPreviewImport(rootDir: string, previewJsPath: string) {
   if (!fs.existsSync(previewJsPath)) {

--- a/packages/dev-server-storybook/src/shared/mdx/transformMdxToCsf.ts
+++ b/packages/dev-server-storybook/src/shared/mdx/transformMdxToCsf.ts
@@ -1,5 +1,6 @@
 import mdx from '@mdx-js/mdx';
 import { transformAsync } from '@babel/core';
+// @ts-ignore
 import { createCompiler } from '@storybook/csf-tools/mdx';
 import { createError } from '../utils.js';
 

--- a/packages/dev-server-storybook/src/shared/mdx/transformMdxToCsf.ts
+++ b/packages/dev-server-storybook/src/shared/mdx/transformMdxToCsf.ts
@@ -1,7 +1,7 @@
 import mdx from '@mdx-js/mdx';
 import { transformAsync } from '@babel/core';
 import { createCompiler } from '@storybook/csf-tools/mdx';
-import { createError } from '../utils';
+import { createError } from '../utils.js';
 
 const compilers = [createCompiler({})];
 

--- a/packages/dev-server-storybook/src/shared/stories/findStories.ts
+++ b/packages/dev-server-storybook/src/shared/stories/findStories.ts
@@ -1,7 +1,7 @@
 import globby from 'globby';
 import path from 'path';
 
-import { createBrowserImport, createError } from '../utils';
+import { createBrowserImport, createError } from '../utils.js';
 
 export async function findStories(
   rootDir: string,

--- a/packages/dev-server-storybook/tsconfig.json
+++ b/packages/dev-server-storybook/tsconfig.json
@@ -3,7 +3,8 @@
 {
   "extends": "../../tsconfig.node-base.json",
   "compilerOptions": {
-    "module": "nodenext",
+    "module": "node16",
+    "moduleResolution": "node16",
     "outDir": "./dist",
     "rootDir": "./src",
     "composite": true,


### PR DESCRIPTION
Set `moduleResolution` to `node16` so that TypeScript will output ES Modules and changed the `module` property so that it's not a moving target.

Fixes #2405 