### PR TITLE
fix(rollup-plugin-import-meta-assets): allow simple backticks strings

### DIFF
--- a/.changeset/thirty-planes-arrive.md
+++ b/.changeset/thirty-planes-arrive.md
@@ -1,0 +1,5 @@
+---
+'@web/rollup-plugin-import-meta-assets': patch
+---
+
+Allow import-meta-assets rollup plugin to bundle meta assets that use backticks, but do not contain any dynamic expressions inside the template literal.

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
       "license": "MIT",
       "dependencies": {
         "@web/dev-server-legacy": "^2.0.1",
-        "@web/test-runner-core": "^0.11.2"
+        "@web/test-runner-core": "^0.11.3"
       },
       "devDependencies": {
         "@esm-bundle/chai": "^4.1.5"
@@ -30531,7 +30531,7 @@
     },
     "packages/dev-server-storybook": {
       "name": "@web/dev-server-storybook",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -30918,7 +30918,7 @@
     },
     "packages/test-runner-core": {
       "name": "@web/test-runner-core",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.11",

--- a/packages/rollup-plugin-import-meta-assets/test/fixtures/backticks.js
+++ b/packages/rollup-plugin-import-meta-assets/test/fixtures/backticks.js
@@ -1,0 +1,7 @@
+const backticksImg = new URL(`./one.svg`, import.meta.url);
+const backticksImg2 = new URL(`./two.svg`, import.meta.url);
+
+const three = 'three';
+const backticksImg3 = new URL(`./${three}.svg`, import.meta.url);
+
+console.log(backticksImg, backticksImg2, backticksImg3);

--- a/packages/rollup-plugin-import-meta-assets/test/integration.test.js
+++ b/packages/rollup-plugin-import-meta-assets/test/integration.test.js
@@ -256,4 +256,20 @@ describe('rollup-plugin-import-meta-assets', () => {
       /ENOENT: no such file or directory, open '.*[/\\]missing-relative-path\.svg'/,
     );
   });
+
+  it('allows backticks in path if there are no dynamic parts included', async () => {
+    const config = {
+      input: { backticks: require.resolve('./fixtures/backticks.js') },
+      plugins: [importMetaAssets({ warnOnError: true })],
+    };
+
+    const bundle = await rollup.rollup(config);
+    const { output } = await bundle.generate(outputConfig);
+
+    expect(output.length).to.equal(3);
+    expectChunk(output, 'snapshots/backticks.js', 'backticks.js', [
+      expectAsset(output, 'snapshots/one.svg', 'one.svg', 'assets/one-824f522a.svg'),
+      expectAsset(output, 'snapshots/two.svg', 'two.svg', 'assets/two-efaa9ab3.svg'),
+    ]);
+  });
 });

--- a/packages/rollup-plugin-import-meta-assets/test/snapshots/backticks.js
+++ b/packages/rollup-plugin-import-meta-assets/test/snapshots/backticks.js
@@ -1,0 +1,7 @@
+const backticksImg = new URL(new URL('assets/one-824f522a.svg', import.meta.url).href, import.meta.url);
+const backticksImg2 = new URL(new URL('assets/two-efaa9ab3.svg', import.meta.url).href, import.meta.url);
+
+const three = 'three';
+const backticksImg3 = new URL(`./${three}.svg`, import.meta.url);
+
+console.log(backticksImg, backticksImg2, backticksImg3);


### PR DESCRIPTION
## What I did

1. allow simple backticks strings (Template Literals with 1 quasi and 0 expressions), since those are statically analyzable.