### PR TITLE
fix(test-runner-chrome): fix debug mode

### DIFF
--- a/.changeset/large-hairs-count.md
+++ b/.changeset/large-hairs-count.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-chrome': patch
+---
+
+Fix debug mode

--- a/packages/test-runner-chrome/src/ChromeLauncher.ts
+++ b/packages/test-runner-chrome/src/ChromeLauncher.ts
@@ -155,7 +155,7 @@ export class ChromeLauncher implements BrowserLauncher {
 
   async startDebugSession(sessionId: string, url: string) {
     if (!this.debugBrowser || !this.debugBrowserContext) {
-      this.debugBrowser = await this.launchBrowser({ devtools: true });
+      this.debugBrowser = await this.launchBrowser({ devtools: true, headless: false });
       this.debugBrowserContext = await this.createBrowserContextFn({
         config: this.config!,
         browser: this.debugBrowser,


### PR DESCRIPTION
## What I did

1. Fix debug mode by passing `headless: false`

This most likely was broken by upgrading to puppeteer 20.

My OS:
Ubuntu 22

To reproduce:
1. Run a test using the ChromeLauncher
2. Press `D` in the terminal

Actual:
No browser window opened

Expected:
Browser window to open
