### PR TITLE
fix(test-runner-core): destroy consumer after usage to prevent a leak

### DIFF
--- a/.changeset/strong-fans-invent.md
+++ b/.changeset/strong-fans-invent.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-core': patch
+---
+
+Destroy consumer when it is used and refactor the caching code for readability

--- a/packages/test-runner-core/src/server/plugins/api/createSourceMapFunction.ts
+++ b/packages/test-runner-core/src/server/plugins/api/createSourceMapFunction.ts
@@ -10,12 +10,6 @@ export type SourceMapFunction = (
   userAgent: string,
 ) => Promise<StackLocation | null>;
 
-interface CachedSourceMap {
-  sourceMap?: SourceMapConverter;
-  consumer?: SourceMapConsumer;
-  loadingPromise?: Promise<void>;
-}
-
 function resolveRelativeTo(relativeTo: string, filePath: string): string {
   if (path.isAbsolute(filePath)) {
     return filePath;
@@ -36,57 +30,32 @@ export function createSourceMapFunction(
   host: string,
   port: number,
 ): SourceMapFunction {
-  const cachedSourceMaps = new Map<string, CachedSourceMap | null>();
+  const cachedSourceMaps = new Map<string, Promise<SourceMapConverter | undefined>>();
 
   return async ({ browserUrl, filePath, line, column }, userAgent) => {
+    const cacheKey = `${filePath}${userAgent}`;
+
+    if (!cachedSourceMaps.has(cacheKey)) {
+      cachedSourceMaps.set(
+        cacheKey,
+        fetchSourceMap({
+          protocol,
+          host,
+          port,
+          browserUrl,
+          userAgent,
+        })
+          .then(({ sourceMap }) => sourceMap)
+          .catch(() => undefined),
+      );
+    }
+
+    const sourceMap = await cachedSourceMaps.get(cacheKey);
+    if (!sourceMap) {
+      return null;
+    }
+
     try {
-      const cacheKey = `${filePath}${userAgent}`;
-      let cached = cachedSourceMaps.get(cacheKey);
-      if (cached) {
-        if (cached.loadingPromise) {
-          // a request for this source map is already being done in parallel, wait for it to finish
-          await cached.loadingPromise;
-        }
-
-        if (!cached.sourceMap) {
-          // we know there is no source map for this file
-          return null;
-        }
-      } else {
-        cached = {};
-      }
-      cachedSourceMaps.set(cacheKey, cached);
-
-      // get the raw source map, from cache or new
-      let sourceMap: SourceMapConverter | undefined;
-      if (cached.sourceMap) {
-        sourceMap = cached?.sourceMap;
-      } else {
-        // fetch source map, maintain a loading boolean for parallel calls to wait before resolving
-        let resolveLoading: () => void;
-        const loadingPromise = new Promise<void>(resolve => {
-          resolveLoading = resolve;
-        });
-        cached.loadingPromise = loadingPromise;
-
-        try {
-          const result = await fetchSourceMap({
-            protocol,
-            host,
-            port,
-            browserUrl,
-            userAgent,
-          });
-          sourceMap = result.sourceMap;
-          cached.sourceMap = sourceMap;
-        } finally {
-          resolveLoading!();
-        }
-      }
-      if (!sourceMap) {
-        return null;
-      }
-
       // if there is no line and column we're looking for just the associated file, for example
       // the test file itself has source maps. if this is a single file source map, we can return
       // that.
@@ -104,13 +73,7 @@ export function createSourceMapFunction(
       }
 
       // do the actual source mapping
-      let consumer: SourceMapConsumer;
-      if (cached?.consumer) {
-        consumer = cached.consumer;
-      } else {
-        consumer = await new SourceMapConsumer(sourceMap.sourcemap);
-        cachedSourceMaps.get(cacheKey)!.consumer = consumer;
-      }
+      const consumer: SourceMapConsumer = await new SourceMapConsumer(sourceMap.sourcemap);
 
       let originalPosition = consumer.originalPositionFor({
         line: line ?? 0,
@@ -125,6 +88,8 @@ export function createSourceMapFunction(
           bias: SourceMapConsumer.LEAST_UPPER_BOUND,
         });
       }
+
+      consumer.destroy();
 
       if (originalPosition.line == null) {
         return null;


### PR DESCRIPTION
## What I did

1. Cleanup the caching code for readability
2. Destroy the consumer to prevent a leak that causes errors to not be displayed correctly

## Context

When running tests against a folder containing source maps, the source maps will point to the place where the actual error was thrown. When the source map is really big and the tests are run a lot of times (this problem persists during watch mode reruns) there is overflow happening somewhere. I have created an small reproduction repo here: https://github.com/remcovaes/source-map-bug-web-test-runner

Also, the consumer caching was broken, because it the cache was only filled after a promise was resolved, which means that multiple promises where started and all those promises had cache misses. I think removing the consumer cache will not result a performance issue as it was not working correct anyway. Also, I think destroying the consumer is more important and there is not another logical place where this can be done easily.
