### PR TITLE
fix(rollup-plugin-import-meta-assets): fix #2421

### DIFF
--- a/.changeset/beige-spiders-eat.md
+++ b/.changeset/beige-spiders-eat.md
@@ -1,0 +1,5 @@
+---
+'@web/rollup-plugin-import-meta-assets': patch
+---
+
+Make import-meta-assets rollup plugin ignore patterns like "new URL('./', import.meta.url)" that reference directories.

--- a/packages/rollup-plugin-import-meta-assets/src/rollup-plugin-import-meta-assets.js
+++ b/packages/rollup-plugin-import-meta-assets/src/rollup-plugin-import-meta-assets.js
@@ -100,10 +100,12 @@ function importMetaAssets({ include, exclude, warnOnError, transform } = {}) {
               );
               modifiedCode = true;
             } catch (error) {
-              if (warnOnError) {
-                this.warn(error, node.arguments[0].start);
-              } else {
-                this.error(error, node.arguments[0].start);
+              if (error.code !== 'EISDIR') {
+                if (warnOnError) {
+                  this.warn(error, node.arguments[0].start);
+                } else {
+                  this.error(error, node.arguments[0].start);
+                }
               }
             }
           }

--- a/packages/rollup-plugin-import-meta-assets/src/rollup-plugin-import-meta-assets.js
+++ b/packages/rollup-plugin-import-meta-assets/src/rollup-plugin-import-meta-assets.js
@@ -48,6 +48,7 @@ function isNewUrlImportMetaUrl(node) {
 /**
  * Detects assets references relative to modules using patterns such as `new URL('./path/to/asset.ext', import.meta.url)`.
  * The assets are added to the rollup pipeline, allowing them to be transformed and hash the filenames.
+ * Patterns that represent directories are skipped.
  *
  * @param {object} options
  * @param {string|string[]} [options.include] A picomatch pattern, or array of patterns, which specifies the files in the build the plugin should operate on. By default all files are targeted.
@@ -100,6 +101,7 @@ function importMetaAssets({ include, exclude, warnOnError, transform } = {}) {
               );
               modifiedCode = true;
             } catch (error) {
+              // Do not process directories, just skip
               if (error.code !== 'EISDIR') {
                 if (warnOnError) {
                   this.warn(error, node.arguments[0].start);

--- a/packages/rollup-plugin-import-meta-assets/test/fixtures/directories-and-simple-entrypoint.js
+++ b/packages/rollup-plugin-import-meta-assets/test/fixtures/directories-and-simple-entrypoint.js
@@ -1,0 +1,20 @@
+const justUrlObject = new URL('./one.svg', import.meta.url);
+const href = new URL('./two.svg', import.meta.url).href;
+const pathname = new URL('./three.svg', import.meta.url).pathname;
+const searchParams = new URL('./four.svg', import.meta.url).searchParams;
+
+const directories = [
+  new URL('./', import.meta.url),
+  new URL('./one', import.meta.url),
+  new URL('./one/', import.meta.url),
+  new URL('./one/two', import.meta.url),
+  new URL('./one/two/', import.meta.url),
+];
+
+console.log({
+  justUrlObject,
+  href,
+  pathname,
+  searchParams,
+  directories,
+});

--- a/packages/rollup-plugin-import-meta-assets/test/fixtures/five
+++ b/packages/rollup-plugin-import-meta-assets/test/fixtures/five
@@ -1,0 +1,5 @@
+<svg  xmlns="http://www.w3.org/2000/svg"
+      xmlns:xlink="http://www.w3.org/1999/xlink">
+    <rect x="10" y="10" height="100" width="100"
+          style="stroke:#000000; fill: #800000"/>
+</svg>

--- a/packages/rollup-plugin-import-meta-assets/test/fixtures/simple-entrypoint.js
+++ b/packages/rollup-plugin-import-meta-assets/test/fixtures/simple-entrypoint.js
@@ -2,10 +2,12 @@ const justUrlObject = new URL('./one.svg', import.meta.url);
 const href = new URL('./two.svg', import.meta.url).href;
 const pathname = new URL('./three.svg', import.meta.url).pathname;
 const searchParams = new URL('./four.svg', import.meta.url).searchParams;
+const noExtension = new URL('./five', import.meta.url);
 
 console.log({
   justUrlObject,
   href,
   pathname,
   searchParams,
+  noExtension,
 });

--- a/packages/rollup-plugin-import-meta-assets/test/integration.test.js
+++ b/packages/rollup-plugin-import-meta-assets/test/integration.test.js
@@ -272,4 +272,24 @@ describe('rollup-plugin-import-meta-assets', () => {
       expectAsset(output, 'snapshots/two.svg', 'two.svg', 'assets/two-efaa9ab3.svg'),
     ]);
   });
+
+  it('ignores patterns that reference a directory', async () => {
+    const config = {
+      input: {
+        'directories-ignored': require.resolve('./fixtures/directories-and-simple-entrypoint.js'),
+      },
+      plugins: [importMetaAssets()],
+    };
+
+    const bundle = await rollup.rollup(config);
+    const { output } = await bundle.generate(outputConfig);
+
+    expect(output.length).to.equal(5);
+    expectChunk(output, 'snapshots/directories-ignored.js', 'directories-ignored.js', [
+      expectAsset(output, 'snapshots/one.svg', 'one.svg', 'assets/one-824f522a.svg'),
+      expectAsset(output, 'snapshots/two.svg', 'two.svg', 'assets/two-efaa9ab3.svg'),
+      expectAsset(output, 'snapshots/three.svg', 'three.svg', 'assets/three-63bfb103.svg'),
+      expectAsset(output, 'snapshots/four.svg', 'four.svg', 'assets/four-360cc920.svg'),
+    ]);
+  });
 });

--- a/packages/rollup-plugin-import-meta-assets/test/integration.test.js
+++ b/packages/rollup-plugin-import-meta-assets/test/integration.test.js
@@ -49,12 +49,13 @@ describe('rollup-plugin-import-meta-assets', () => {
     const bundle = await rollup.rollup(config);
     const { output } = await bundle.generate(outputConfig);
 
-    expect(output.length).to.equal(5);
+    expect(output.length).to.equal(6);
     expectChunk(output, 'snapshots/simple-bundle.js', 'simple-bundle.js', [
       expectAsset(output, 'snapshots/one.svg', 'one.svg', 'assets/one-824f522a.svg'),
       expectAsset(output, 'snapshots/two.svg', 'two.svg', 'assets/two-efaa9ab3.svg'),
       expectAsset(output, 'snapshots/three.svg', 'three.svg', 'assets/three-63bfb103.svg'),
       expectAsset(output, 'snapshots/four.svg', 'four.svg', 'assets/four-360cc920.svg'),
+      expectAsset(output, 'snapshots/five', 'five', 'assets/five-cd1ca868'),
     ]);
   });
 

--- a/packages/rollup-plugin-import-meta-assets/test/snapshots/directories-ignored.js
+++ b/packages/rollup-plugin-import-meta-assets/test/snapshots/directories-ignored.js
@@ -1,0 +1,20 @@
+const justUrlObject = new URL(new URL('assets/one-824f522a.svg', import.meta.url).href, import.meta.url);
+const href = new URL(new URL('assets/two-efaa9ab3.svg', import.meta.url).href, import.meta.url).href;
+const pathname = new URL(new URL('assets/three-63bfb103.svg', import.meta.url).href, import.meta.url).pathname;
+const searchParams = new URL(new URL('assets/four-360cc920.svg', import.meta.url).href, import.meta.url).searchParams;
+
+const directories = [
+  new URL('./', import.meta.url),
+  new URL('./one', import.meta.url),
+  new URL('./one/', import.meta.url),
+  new URL('./one/two', import.meta.url),
+  new URL('./one/two/', import.meta.url),
+];
+
+console.log({
+  justUrlObject,
+  href,
+  pathname,
+  searchParams,
+  directories,
+});

--- a/packages/rollup-plugin-import-meta-assets/test/snapshots/five
+++ b/packages/rollup-plugin-import-meta-assets/test/snapshots/five
@@ -1,0 +1,5 @@
+<svg  xmlns="http://www.w3.org/2000/svg"
+      xmlns:xlink="http://www.w3.org/1999/xlink">
+    <rect x="10" y="10" height="100" width="100"
+          style="stroke:#000000; fill: #800000"/>
+</svg>

--- a/packages/rollup-plugin-import-meta-assets/test/snapshots/simple-bundle.js
+++ b/packages/rollup-plugin-import-meta-assets/test/snapshots/simple-bundle.js
@@ -2,10 +2,12 @@ const justUrlObject = new URL(new URL('assets/one-824f522a.svg', import.meta.url
 const href = new URL(new URL('assets/two-efaa9ab3.svg', import.meta.url).href, import.meta.url).href;
 const pathname = new URL(new URL('assets/three-63bfb103.svg', import.meta.url).href, import.meta.url).pathname;
 const searchParams = new URL(new URL('assets/four-360cc920.svg', import.meta.url).href, import.meta.url).searchParams;
+const noExtension = new URL(new URL('assets/five-cd1ca868', import.meta.url).href, import.meta.url);
 
 console.log({
   justUrlObject,
   href,
   pathname,
   searchParams,
+  noExtension,
 });


### PR DESCRIPTION
Makes rollup-plugin-import-meta-assets ignore references to directories such as e.g. `new URL('./', import.meta.url)`