### PR TITLE
fix (test-runner-chrome): return inner timer result

### DIFF
--- a/integration/test-runner/tests/basic/browser-tests/timers.test.js
+++ b/integration/test-runner/tests/basic/browser-tests/timers.test.js
@@ -1,0 +1,80 @@
+import { expect } from '../../../../../node_modules/@esm-bundle/chai/esm/chai.js';
+
+describe('timers test', () => {
+  it('can call setTimeout', async () => {
+    const promise = new Promise((resolve) => {
+      window.setTimeout(() => {
+        resolve();
+      }, 0);
+    });
+    await promise;
+  });
+
+  it('can cancel setTimeout', async () => {
+    let called = false;
+    const timer = window.setTimeout(() => {
+      called = true;
+    }, 1);
+
+    expect(typeof timer).to.equal('number');
+
+    window.clearTimeout(timer);
+
+    await new Promise((resolve) => {
+      window.setTimeout(() => resolve(), 2);
+    });
+
+    expect(called).to.equal(false);
+  });
+
+  it('can call and cancel setInterval', async () => {
+    let callCount = 0;
+
+    const interval = window.setInterval(() => {
+      callCount++;
+    }, 1);
+
+    await new Promise((resolve) => {
+      window.setTimeout(() => resolve(), 2);
+    });
+
+    expect(callCount).to.be.greaterThan(0);
+
+    const oldCallCount = callCount;
+
+    window.clearInterval(interval);
+
+    await new Promise((resolve) => {
+      window.setTimeout(() => resolve(), 2);
+    });
+
+    expect(callCount).to.equal(oldCallCount);
+  });
+
+  it('can call requestAnimationFrame', async () => {
+    const promise = new Promise((resolve) => {
+      window.requestAnimationFrame(() => {
+        resolve();
+      });
+    });
+    await promise;
+  });
+
+  it('can cancel requestAnimationFrame', async () => {
+    let called = false;
+
+    const timer = window.requestAnimationFrame(() => {
+      called = true;
+    });
+
+    expect(typeof timer).to.equal('number');
+
+    window.cancelAnimationFrame(timer);
+
+    await new Promise((resolve) => {
+      window.setTimeout(() => resolve(), 2);
+    });
+
+    expect(called).to.equal(false);
+  });
+});

--- a/integration/test-runner/tests/basic/runBasicTest.ts
+++ b/integration/test-runner/tests/basic/runBasicTest.ts
@@ -69,5 +69,24 @@ export function runBasicTest(
         ]);
       }
     });
+
+    it('passes timers test', () => {
+      const sessions = allSessions.filter(s => s.testFile.endsWith('timers.test.js'));
+      expect(sessions.length === browserCount).to.equal(
+        true,
+        'Each browser should run timers.test.js',
+      );
+      for (const session of sessions) {
+        expect(session.testResults!.tests.length).to.equal(0);
+        expect(session.testResults!.suites.length).to.equal(1);
+        expect(session.testResults!.suites[0].tests.map(t => t.name)).to.eql([
+          'can call setTimeout',
+          'can cancel setTimeout',
+          'can call and cancel setInterval',
+          'can call requestAnimationFrame',
+          'can cancel requestAnimationFrame',
+        ]);
+      }
+    });
   });
 }

--- a/packages/test-runner-chrome/src/ChromeLauncherPage.ts
+++ b/packages/test-runner-chrome/src/ChromeLauncherPage.ts
@@ -69,13 +69,14 @@ export class ChromeLauncherPage {
         // eslint-disable-next-line @typescript-eslint/ban-types
         function patchFunction(name: string, fn: Function) {
           (window as any)[name] = (...args: unknown[]) => {
-            fn.call(window, ...args);
+            const result = fn.call(window, ...args);
             const id = Math.random().toString().substring(2);
             // Make sure that the tab running the test code is brought back to the front.
             window.__bringTabToFront(id);
             fn.call(window, () => {
               window.__releaseLock(id);
             });
+            return result;
           };
         }
 


### PR DESCRIPTION
Since we patched these timer methods, we forgot to return the actual timer result (e.g. `requestIdleCallback` returns a number).

This breaks all sorts of code right now which depends on a number being returned (e.g. for debouncers and what not).

cc @koddsson @Westbrook 