### PR TITLE
chore: make local build closer to CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
     "node": ">=16.0.0"
   },
   "scripts": {
-    "build": "rimraf --glob packages/*/tsconfig.tsbuildinfo && tsc --build",
-    "build:production": "node scripts/workspaces-scripts-bin.mjs build:production",
+    "build": "npm run build:clean && tsc --build",
+    "build:clean": "rimraf --glob packages/*/tsconfig.tsbuildinfo && rimraf --glob packages/*/dist",
+    "build:production": "npm run build:clean && node scripts/workspaces-scripts-bin.mjs build:production",
     "build:site": "npm run build && rocket build",
-    "build:watch": "rimraf --glob packages/*/tsconfig.tsbuildinfo && tsc --build --watch",
+    "build:watch": "npm run build:clean && tsc --build --watch",
     "dev-to-git": "dev-to-git",
     "format": "npm run format:eslint && npm run format:prettier",
     "format:eslint": "eslint --ext .ts,.js,.mjs,.cjs . --fix",


### PR DESCRIPTION
I ran into the following issue in our CI (e.g. in https://github.com/modernweb-dev/web/actions/runs/6073283198/job/16474903432?pr=2437)

```
Run npm run build

> build
> rimraf --glob packages/*/tsconfig.tsbuildinfo && tsc --build

Error: packages/storybook-framework-web-components/src/types.ts(2,[1](https://github.com/modernweb-dev/web/actions/runs/6073283198/job/16474903432?pr=2437#step:6:1)5): error TS2305: Module '"@web/storybook-builder"' has no exported member 'BuilderOptions'.
Error: packages/storybook-framework-web-components/src/types.ts(2,31): error TS2305: Module '"@web/storybook-builder"' has no exported member 'StorybookConfigWds'.
Error: Process completed with exit code 2.
```

which I couldn't reproduce locally until I made a clean repository clone.

The reason is that we don't clean `dist` before build runs.

In my case I just accidentally removed source file when working on the PR and didn't see it with local `npm run build`, because the output `dist` folder contained the old built versions of this source file.

To prevent this and other similar issues when `dist` contains outdated files I think we should strictly remove it before running any if the `build` commands.