### PR TITLE
fix: production builds

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build types for js packages
         run: npm run types
 
-      - name: Build for production
+      - name: Build specific packages for production
         run: npm run build:production
 
       - name: Version canary release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build types for js packages
         run: npm run types
 
-      - name: Build for production
+      - name: Build specific packages for production
         run: npm run build:production
 
       - name: Sync blog to dev.to

--- a/.github/workflows/verify-node.yml
+++ b/.github/workflows/verify-node.yml
@@ -43,7 +43,7 @@ jobs:
         run: npm run types
 
       # build for production in CI to make sure tests can run with production build
-      - name: Build for production
+      - name: Build specific packages for production
         run: npm run build:production
 
       - name: Lint

--- a/.github/workflows/verify-windows.yml
+++ b/.github/workflows/verify-windows.yml
@@ -36,7 +36,7 @@ jobs:
         run: npm run build
 
       # build for production in CI to make sure tests can run with production build
-      - name: Build for production
+      - name: Build specific packages for production
         run: npm run build:production
 
       - name: Test

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "npm run build:clean && tsc --build",
     "build:clean": "rimraf --glob packages/*/tsconfig.tsbuildinfo && rimraf --glob packages/*/dist",
-    "build:production": "npm run build:clean && node scripts/workspaces-scripts-bin.mjs build:production",
+    "build:production": "node scripts/workspaces-scripts-bin.mjs build:production",
     "build:site": "npm run build && rocket build",
     "build:watch": "npm run build:clean && tsc --build --watch",
     "dev-to-git": "dev-to-git",


### PR DESCRIPTION
I made a wrong assumption about how `npm run build:production` works.
It only builds certain packages, not all, so we shouldn't clean `dist` before it.
So I reverted that part of the previous PR #2441 and clarified what this command is for in the step names.