### PR TITLE
fix: fix infinite loop if no package.json is present

### DIFF
--- a/packages/config-loader/src/getPackageType.js
+++ b/packages/config-loader/src/getPackageType.js
@@ -20,7 +20,12 @@ async function getPackageType(basedir) {
         return pkgJson.type || 'commonjs';
       }
 
+      const previousPath = currentPath
       currentPath = path.resolve(currentPath, '..');
+
+      if(currentPath == previousPath) {
+        return 'commonjs'
+      }
     }
   } catch (e) {
     // don't log any error


### PR DESCRIPTION
When launching web-test-runner from global npm packages, and without a package.json in the current or any of the parent directory, it hangs on an infinite loop searching for a package.json, due to path.resolve('/', '..') returning '/'.