### PR TITLE
Speed up browser tests

### DIFF
--- a/packages/dev-server-hmr/test/browser.test.ts
+++ b/packages/dev-server-hmr/test/browser.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { stubMethod } from 'hanbi';
-import { timeout, createTestServer, expectIncludes } from '@web/dev-server-core/test-helpers';
+import { createTestServer, expectIncludes } from '@web/dev-server-core/test-helpers';
 import { Browser, HTTPResponse, launch as launchPuppeteer, Page } from 'puppeteer';
 import { posix as pathUtil } from 'path';
 
@@ -18,16 +18,6 @@ function trackErrors(page: Page) {
     }
   });
   return errors;
-}
-
-type Predicate = (...args: unknown[]) => Promise<boolean> | boolean;
-
-async function pollFor(predicate: Predicate): Promise<void> {
-  let content = await predicate();
-  while (!content) {
-    await timeout(10);
-    content = await predicate();
-  }
 }
 
 describe('browser tests', function () {
@@ -171,9 +161,8 @@ describe('browser tests', function () {
         page.waitForResponse((r: HTTPResponse) => r.url().startsWith(`${host}/baz.js`)),
       ]);
 
-      await pollFor(async () => {
-        const content = await page.content();
-        return content.includes('<body> foo  a  bar  a  foo  b  bar  b </body>');
+      await page.waitForFunction(() => {
+        return document.body.outerHTML === '<body> foo  a  bar  a  foo  b  bar  b </body>'
       });
 
       for (const error of errors) {

--- a/packages/dev-server-hmr/test/browser.test.ts
+++ b/packages/dev-server-hmr/test/browser.test.ts
@@ -161,9 +161,9 @@ describe('browser tests', function () {
         page.waitForResponse((r: HTTPResponse) => r.url().startsWith(`${host}/baz.js`)),
       ]);
 
-      await page.waitForFunction(() => {
-        return document.body.outerHTML === '<body> foo  a  bar  a  foo  b  bar  b </body>'
-      });
+      await page.waitForFunction(
+        () => document.body.outerHTML === '<body> foo  a  bar  a  foo  b  bar  b </body>',
+      );
 
       for (const error of errors) {
         throw error;

--- a/packages/dev-server-hmr/test/browser.test.ts
+++ b/packages/dev-server-hmr/test/browser.test.ts
@@ -24,7 +24,7 @@ type Predicate = (...args: unknown[]) => Promise<boolean> | boolean;
 
 async function pollFor(predicate: Predicate): Promise<void> {
   let content = await predicate();
-  while(!content) {
+  while (!content) {
     await timeout(10);
     content = await predicate();
   }
@@ -41,7 +41,7 @@ describe('browser tests', function () {
     await browser.close();
   });
 
-  it('should bubble when bubbles is true', async function() {
+  it('should bubble when bubbles is true', async function () {
     this.timeout(3000);
     const { server, host } = await createTestServer({
       rootDir: __dirname,
@@ -170,10 +170,10 @@ describe('browser tests', function () {
         page.waitForResponse((r: HTTPResponse) => r.url().startsWith(`${host}/bar.js`)),
         page.waitForResponse((r: HTTPResponse) => r.url().startsWith(`${host}/baz.js`)),
       ]);
-      
+
       await pollFor(async () => {
         const content = await page.content();
-        return content.includes('<body> foo  a  bar  a  foo  b  bar  b </body>')
+        return content.includes('<body> foo  a  bar  a  foo  b  bar  b </body>');
       });
 
       for (const error of errors) {

--- a/packages/dev-server-hmr/test/browser.test.ts
+++ b/packages/dev-server-hmr/test/browser.test.ts
@@ -21,8 +21,6 @@ function trackErrors(page: Page) {
 }
 
 describe('browser tests', function () {
-  this.timeout(10000);
-
   let browser: Browser;
 
   before(async () => {
@@ -33,7 +31,8 @@ describe('browser tests', function () {
     await browser.close();
   });
 
-  it('should bubble when bubbles is true', async () => {
+  it('should bubble when bubbles is true', async function() {
+    this.timeout(3000);
     const { server, host } = await createTestServer({
       rootDir: __dirname,
       plugins: [
@@ -85,7 +84,7 @@ describe('browser tests', function () {
     const errors = trackErrors(page);
 
     try {
-      await page.goto(`${host}/foo.html`, { waitUntil: 'networkidle0' });
+      await page.goto(`${host}/foo.html`);
       expectIncludes(await page.content(), '<body> a </body>');
 
       files['/foo.js'] = files['/foo.js'].replace('" a "', '" b "');
@@ -117,13 +116,12 @@ describe('browser tests', function () {
     const errors = trackErrors(page);
 
     try {
-      await page.goto(`${host}/foo.html`, { waitUntil: 'networkidle0' });
+      await page.goto(`${host}/foo.html`);
       expectIncludes(await page.content(), '<body> a </body>');
 
       files['/bar.js'] = 'export default " b ";';
       server.fileWatcher.emit('change', pathUtil.join(__dirname, '/bar.js'));
       await page.waitForResponse((r: HTTPResponse) => r.url().startsWith(`${host}/bar.js`));
-      await new Promise(r => setTimeout(r, 1000));
       expectIncludes(await page.content(), '<body> a  b </body>');
 
       for (const error of errors) {
@@ -152,8 +150,8 @@ describe('browser tests', function () {
     const errors = trackErrors(page);
 
     try {
-      await page.goto(`${host}/foo.html`, { waitUntil: 'networkidle0' });
-      // expectIncludes(await page.content(), '<body> foo  a  bar  a </body>');
+      await page.goto(`${host}/foo.html`);
+      expectIncludes(await page.content(), '<body> foo  a  bar  a </body>');
 
       files['/baz.js'] = 'export default " b ";';
       server.fileWatcher.emit('change', pathUtil.join(__dirname, '/baz.js'));
@@ -162,7 +160,6 @@ describe('browser tests', function () {
         page.waitForResponse((r: HTTPResponse) => r.url().startsWith(`${host}/bar.js`)),
         page.waitForResponse((r: HTTPResponse) => r.url().startsWith(`${host}/baz.js`)),
       ]);
-      await new Promise(r => setTimeout(r, 1000));
       expectIncludes(await page.content(), '<body> foo  a  bar  a  foo  b  bar  b </body>');
 
       for (const error of errors) {
@@ -191,12 +188,12 @@ describe('browser tests', function () {
     const errors = trackErrors(page);
 
     try {
-      await page.goto(`${host}/foo.html`, { waitUntil: 'networkidle0' });
+      await page.goto(`${host}/foo.html`);
       await page.evaluate('document.body.appendChild(document.createTextNode(" c "))');
       expectIncludes(await page.content(), '<body> a  b  c </body>');
 
       server.fileWatcher.emit('change', pathUtil.join(__dirname, '/baz.js'));
-      await page.waitForNavigation({ waitUntil: 'networkidle0' });
+      await page.waitForNavigation();
       expectIncludes(await page.content(), '<body> a  b </body>');
 
       for (const error of errors) {


### PR DESCRIPTION
I noticed that these tests are running really slow and wanted to see if I could make them faster. A few removals of some waiting calls and they are running faster (on my machine).

## Before

```
    ✔ should bubble when bubbles is true (2063ms)
    ✔ should hot replace a module (2074ms)
    ✔ should hot replace a bubbled module (3073ms)
    ✔ hot replaces multiple bubbled modules (3109ms)
    ✔ reloads the page when a module has no hot replacable parent (4091ms)


  5 passing (15s)
```

## After

```
    ✔ should bubble when bubbles is true (2058ms)
    ✔ should hot replace a module (81ms)
    ✔ should hot replace a bubbled module (73ms)
    ✔ hot replaces multiple bubbled modules (68ms)
    ✔ reloads the page when a module has no hot replacable parent (90ms)


  5 passing (3s)
```