### PR TITLE
Avoid network errors when a large number of files are served with http2 ERR_HTTP2_PROTOCOL_ERROR

### DIFF
--- a/.changeset/smart-mice-relax.md
+++ b/.changeset/smart-mice-relax.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server-core': minor
+---
+
+Raise-up the maxSessionMemory of the http2 server to avoid network errors when a large number of files are served

--- a/packages/dev-server-core/src/server/createServer.ts
+++ b/packages/dev-server-core/src/server/createServer.ts
@@ -79,6 +79,7 @@ export function createServer(
           : path.join(dir, '..', '.self-signed-dev-server-ssl.cert'),
       ),
       allowHTTP1: true,
+      maxSessionMemory: 20,
     };
 
     const httpsRedirectServer = httpServer.createServer(httpsRedirect);


### PR DESCRIPTION
## Issue

I am experiencing network errors. It is due to the large number of files my page is loading (300 to 400 hundred).

The number of files shouldn't be a problem, especially in a project that advocate ESM, importmap, modulepreload, http2/3 multiplexing, etc...

![ERR_HTTP2_PROTOCOL_ERROR](https://github.com/modernweb-dev/web/assets/1979087/d627b200-2dbd-46ee-a1d3-7cb73df994a7)

## Solution

Raise-up the maxSessionMemory of the http2 server from the default value (10) to 20