### PR TITLE
Add a test for the `http2` server functionality

### DIFF
--- a/packages/dev-server-core/src/test-helpers.ts
+++ b/packages/dev-server-core/src/test-helpers.ts
@@ -52,7 +52,11 @@ export async function createTestServer(
     _mockLogger,
   );
   await server.start();
-  return { server, port, host: `http://localhost:${port}` };
+
+  const url = new URL('http://localhost');
+  url.protocol = config.http2 ? 'https' : 'http';
+  url.port = port.toString();
+  return { server, port, host: url.toString().slice(0, -1) };
 }
 
 export const timeout = (ms = 0) => new Promise(resolve => setTimeout(resolve, ms));

--- a/packages/dev-server-core/test/server/DevServer.test.ts
+++ b/packages/dev-server-core/test/server/DevServer.test.ts
@@ -78,11 +78,11 @@ describe('http2', () => {
     //
     // A better way to achive this might be to _somehow_ load up the certificate used into the
     // testing process so that we aren't just turning off the TLS/SSL certificate validation.
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
   });
 
   after(() => {
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "1";
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '1';
   });
 
   it('serves a website', async () => {


### PR DESCRIPTION
I didn't see any other test and I figured a simple smoke-test would be good.
