### PR TITLE
Add TestSession to filterBrowserLogs args to enable filtering by session result

### DIFF
--- a/.changeset/spicy-kangaroos-search.md
+++ b/.changeset/spicy-kangaroos-search.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-core': minor
+---
+
+Add TestSession to filterBrowserLogs args so logs can be filtered on session result

--- a/packages/test-runner-core/src/config/TestRunnerCoreConfig.ts
+++ b/packages/test-runner-core/src/config/TestRunnerCoreConfig.ts
@@ -47,7 +47,10 @@ export interface TestRunnerCoreConfig {
   watch: boolean;
 
   browserLogs?: boolean;
-  filterBrowserLogs?: (log: { type: string; args: any[] }, session?: Partial<TestSession>) => boolean;
+  filterBrowserLogs?: (
+    log: { type: string; args: any[] },
+    session?: Partial<TestSession>,
+  ) => boolean;
   coverage?: boolean;
   coverageConfig: CoverageConfig;
 

--- a/packages/test-runner-core/src/config/TestRunnerCoreConfig.ts
+++ b/packages/test-runner-core/src/config/TestRunnerCoreConfig.ts
@@ -1,6 +1,7 @@
 import { Middleware } from '@web/dev-server-core';
 import { BrowserLauncher } from '../browser-launcher/BrowserLauncher.js';
 import { TestFramework } from '../test-framework/TestFramework.js';
+import { TestSession } from '../test-session/TestSession.js';
 import { Reporter } from '../reporter/Reporter.js';
 import { Logger } from '../logger/Logger.js';
 import { TestRunnerPlugin } from '../server/TestRunnerPlugin.js';
@@ -46,7 +47,7 @@ export interface TestRunnerCoreConfig {
   watch: boolean;
 
   browserLogs?: boolean;
-  filterBrowserLogs?: (log: { type: string; args: any[] }) => boolean;
+  filterBrowserLogs?: (log: { type: string; args: any[] }, session?: Partial<TestSession>) => boolean;
   coverage?: boolean;
   coverageConfig: CoverageConfig;
 

--- a/packages/test-runner-core/src/server/plugins/api/parseBrowserLogs.ts
+++ b/packages/test-runner-core/src/server/plugins/api/parseBrowserLogs.ts
@@ -40,7 +40,7 @@ export async function parseBrowserLogs(
 
   const logs: any[][] = [];
   for (const log of logsWithType) {
-    if (!config.filterBrowserLogs || config.filterBrowserLogs(log)) {
+    if (!config.filterBrowserLogs || config.filterBrowserLogs(log, result)) {
       logs.push(log.args);
     }
   }

--- a/packages/test-runner-core/test/src/runner/TestRunner.test.ts
+++ b/packages/test-runner-core/test/src/runner/TestRunner.test.ts
@@ -252,8 +252,8 @@ describe('TestRunner', function () {
       const normalize = (x: string): string => x.replace(/\//g, path.sep);
       const { runner } = await createTestRunner({
         files: [
-          'packages/test-runner-core/test/fixtures/**/*.test.js',
-          '!packages/test-runner-core/test/fixtures/group-c/*',
+          './test/fixtures/**/*.test.js',
+          '!./test/fixtures/group-c/*',
         ].map(normalize),
       });
 

--- a/packages/test-runner-core/test/src/runner/TestRunner.test.ts
+++ b/packages/test-runner-core/test/src/runner/TestRunner.test.ts
@@ -251,7 +251,10 @@ describe('TestRunner', function () {
     it('can ignore files via string[] globs', async () => {
       const normalize = (x: string): string => x.replace(/\//g, path.sep);
       const { runner } = await createTestRunner({
-        files: ['./test/fixtures/**/*.test.js', '!./test/fixtures/group-c/*'].map(normalize),
+        files: [
+          'packages/test-runner-core/test/fixtures/**/*.test.js',
+          '!packages/test-runner-core/test/fixtures/group-c/*',
+        ].map(normalize),
       });
 
       const sessions = Array.from(runner.sessions.all());

--- a/packages/test-runner-core/test/src/runner/TestRunner.test.ts
+++ b/packages/test-runner-core/test/src/runner/TestRunner.test.ts
@@ -251,10 +251,7 @@ describe('TestRunner', function () {
     it('can ignore files via string[] globs', async () => {
       const normalize = (x: string): string => x.replace(/\//g, path.sep);
       const { runner } = await createTestRunner({
-        files: [
-          './test/fixtures/**/*.test.js',
-          '!./test/fixtures/group-c/*',
-        ].map(normalize),
+        files: ['./test/fixtures/**/*.test.js', '!./test/fixtures/group-c/*'].map(normalize),
       });
 
       const sessions = Array.from(runner.sessions.all());


### PR DESCRIPTION
## What I did

1. added the TestSession as an arg to filterBrowserLogs so that I can only print logs for failed sessions, see #2450 
2. updated paths in one of the test-runner-core tests to be package relative so that the test would pass for me (not sure if something about my env makes these fail, but those paths should be package-relative anyway IMO... commands run within a workspace context have CWD set to that package's root, not the multi-package root)
