### PR TITLE
fix: api prefix

### DIFF
--- a/.changeset/blue-ducks-care.md
+++ b/.changeset/blue-ducks-care.md
@@ -1,0 +1,5 @@
+---
+"@web/mocks": patch
+---
+
+fix: api prefix

--- a/packages/mocks/registerMockRoutes.js
+++ b/packages/mocks/registerMockRoutes.js
@@ -13,7 +13,8 @@ export function _registerMockRoutes(system, bypassServiceWorker = false, ...mock
   system.resetHandlers();
 
   const handlers = [];
-  for (const { method, endpoint, handler } of mocks.flat(Infinity)) {
+
+  for (let { method, endpoint, handler } of mocks.flat(Infinity)) {
     if (!SUPPORTED_METHODS.includes(method.toLowerCase())) {
       throw new Error(`Unsupported method ${method}`);
     }
@@ -21,6 +22,17 @@ export function _registerMockRoutes(system, bypassServiceWorker = false, ...mock
     if (!handler) {
       throw new Error(`Missing handler for method: "${method}", endpoint: "${endpoint}".
 This likely means there is something wrong with how you're using \`http.get(endpoint, handler)\`. Make sure the \`handler\` exists and is a function.`);
+    }
+
+    /**
+     * If the `endpoint` starts with a "/", we append a "*" in front of it because
+     * some api calls may have an optional prefix, for example: "https://api.localhost:8000/api/foo"
+     *
+     * Adding the "*" will match api calls made with a prefix, and api calls made without a prefix,
+     * without the need to overwrite the native fetch function.
+     */
+    if (endpoint.startsWith('/')) {
+      endpoint = '*' + endpoint;
     }
 
     handlers.push(

--- a/packages/mocks/storybook/decorator.js
+++ b/packages/mocks/storybook/decorator.js
@@ -36,28 +36,30 @@ export const withMocks = makeDecorator({
 
     const editedMocks = getEditedMocks() ?? [];
 
-    const finalizedMocks = mocks.map(mock => {
-      const editedMock = editedMocks.find(
-        edited => edited.method === mock.method && edited.endpoint === mock.endpoint,
-      );
+    if (Array.isArray(mocks)) {
+      const finalizedMocks = mocks.map(mock => {
+        const editedMock = editedMocks.find(
+          edited => edited.method === mock.method && edited.endpoint === mock.endpoint,
+        );
 
-      return editedMock
-        ? {
-            ...editedMock,
-            handler: () =>
-              new Response(JSON.stringify(editedMock.data), {
-                headers: {
-                  'Content-Type': 'application/json',
-                },
-                status: editedMock.status,
-              }),
-          }
-        : mock;
-    });
+        return editedMock
+          ? {
+              ...editedMock,
+              handler: () =>
+                new Response(JSON.stringify(editedMock.data), {
+                  headers: {
+                    'Content-Type': 'application/json',
+                  },
+                  status: editedMock.status,
+                }),
+            }
+          : mock;
+      });
 
-    if (finalizedMocks) {
-      addons.getChannel().emit('mocks:loaded', finalizedMocks.flat(Infinity));
-      registerMockRoutes(finalizedMocks);
+      if (finalizedMocks) {
+        addons.getChannel().emit('mocks:loaded', finalizedMocks.flat(Infinity));
+        registerMockRoutes(finalizedMocks);
+      }
     }
 
     return getStory(context);


### PR DESCRIPTION
## What I did

1. Append `*` for endpoints that start with a `/` so it also matches api calls made with an `api.` prefix
2. Add a check to see if Mocks are an array before trying to iterate over them
