### PR TITLE
chore: add selectOption plugin correctly

### DIFF
--- a/.changeset/pink-socks-look.md
+++ b/.changeset/pink-socks-look.md
@@ -1,0 +1,6 @@
+---
+'@web/test-runner': patch
+'@web/test-runner-commands': patch
+---
+
+Add the selectOption plugin's exports and types correctly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ git remote add upstream git@github.com:modernweb-dev/web.git
 Now that you have cloned the repository, ensure you have node 18+ installed, then run the following command to set up the development environment.
 
 ```sh
-npm run install
+npm install
 npm run build
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32733,7 +32733,7 @@
     },
     "packages/dev-server": {
       "name": "@web/dev-server",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.11",
@@ -32976,7 +32976,7 @@
     },
     "packages/dev-server-storybook": {
       "name": "@web/dev-server-storybook",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -33003,7 +33003,7 @@
       },
       "devDependencies": {
         "@types/path-is-inside": "^1.0.0",
-        "@web/dev-server": "^0.3.1",
+        "@web/dev-server": "^0.3.2",
         "htm": "^3.1.0"
       },
       "engines": {
@@ -33331,7 +33331,7 @@
     },
     "packages/mocks": {
       "name": "@web/mocks",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "dependencies": {
         "@web/storybook-prebuilt": "^0.1.37",

--- a/packages/test-runner-commands/browser/commands.d.ts
+++ b/packages/test-runner-commands/browser/commands.d.ts
@@ -8,6 +8,7 @@ import {
   RemoveFilePayload,
   SnapshotPluginConfig,
   SaveSnapshotPayload,
+  SelectOptionPayload,
   SendMousePayload,
 } from '../dist/index';
 
@@ -134,6 +135,23 @@ export function sendKeys(payload: SendKeysPayload): Promise<void>;
  *
  **/
 export function sendMouse(payload: SendMousePayload): Promise<void>;
+
+/**
+ * Selects an option in a <select> element by value or label
+ * 
+ * @example
+ * ```
+ * it('natively selects an option by value', async () => {
+ *  const valueToSelect = 'first';
+ *  const select = document.querySelector('#testSelect');
+ *
+ *  await selectOption({ selector: '#testSelect', value: valueToSelect });
+ *
+ *  expect(select.value).to.equal(valueToSelect);
+ *});
+ *```
+ */
+export function selectOption(payload: SelectOptionPayload): Promise<void>;
 
 /**
  * Resets the mouse position to (0, 0) and releases mouse buttons.

--- a/packages/test-runner-commands/plugins.mjs
+++ b/packages/test-runner-commands/plugins.mjs
@@ -4,6 +4,7 @@ import cjsEntrypoint from './dist/index.js';
 const {
   setViewportPlugin,
   emulateMediaPlugin,
+  selectOptionPlugin,
   setUserAgentPlugin,
   sendKeysPlugin,
   sendMousePlugin,
@@ -15,6 +16,7 @@ const {
 export {
   setViewportPlugin,
   emulateMediaPlugin,
+  selectOptionPlugin,
   setUserAgentPlugin,
   sendKeysPlugin,
   sendMousePlugin,

--- a/packages/test-runner-commands/src/index.ts
+++ b/packages/test-runner-commands/src/index.ts
@@ -1,5 +1,6 @@
 export { Viewport, setViewportPlugin } from './setViewportPlugin';
 export { Media, emulateMediaPlugin } from './emulateMediaPlugin';
+export { selectOptionPlugin, SelectOptionPayload } from './selectOptionPlugin';
 export { setUserAgentPlugin } from './setUserAgentPlugin';
 export { sendKeysPlugin, SendKeysPayload } from './sendKeysPlugin';
 export { sendMousePlugin, SendMousePayload } from './sendMousePlugin';

--- a/packages/test-runner/src/config/parseConfig.ts
+++ b/packages/test-runner/src/config/parseConfig.ts
@@ -2,6 +2,7 @@ import { CoverageConfig, TestRunnerCoreConfig, TestRunnerGroupConfig } from '@we
 import { chromeLauncher } from '@web/test-runner-chrome';
 import {
   emulateMediaPlugin,
+  selectOptionPlugin,
   setUserAgentPlugin,
   setViewportPlugin,
   sendKeysPlugin,
@@ -251,6 +252,7 @@ export async function parseConfig(
     setViewportPlugin(),
     emulateMediaPlugin(),
     setUserAgentPlugin(),
+    selectOptionPlugin(),
     filePlugin(),
     sendKeysPlugin(),
     sendMousePlugin(),


### PR DESCRIPTION
## What I did

- Resurrected [this old closed PR](https://github.com/modernweb-dev/web/pull/2047) to correctly add the `selectOption` command exports and plugin. This work never got merged, but is still needed iirc.
- Updated the CONTRIBUTING.md to correct the `npm run install` to `npm install` because there's no `install` npm script.
