### PR TITLE
feat(dev-server): don't deepmerge exportConditions. allow user config to fully replace the default

### DIFF
--- a/.changeset/tidy-spoons-work.md
+++ b/.changeset/tidy-spoons-work.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server': patch
+---
+
+Fix an issue where the nodeResolve plugin wasn't accepting user configuration correctly

--- a/packages/dev-server/demo/export-conditions/config.mjs
+++ b/packages/dev-server/demo/export-conditions/config.mjs
@@ -1,0 +1,10 @@
+import { fileURLToPath } from 'url';
+import { resolve } from 'path';
+
+export default {
+  rootDir: resolve(fileURLToPath(import.meta.url), '..', '..', '..'),
+  appIndex: '/demo/export-conditions/index.html',
+  nodeResolve: {
+    exportConditions: ['default']
+  },
+};

--- a/packages/dev-server/demo/export-conditions/index.html
+++ b/packages/dev-server/demo/export-conditions/index.html
@@ -1,0 +1,31 @@
+<html>
+  <body>
+    <img width="100" src="../logo.png" />
+
+    <h1>Node resolve demo</h1>
+    <p>A demo which resolves bare module imports</p>
+
+    <div id="test"></div>
+
+    <script type="module">
+      // inline bare modules are resolved
+      import { render, html } from 'lit-html';
+
+      window.__inlineNodeResolve = !!render && !!html;
+    </script>
+
+    <script type="module">
+
+      window.__tests = {
+        // lit-html only adds this global in development mode
+        // so when the exportCondition is overwritten, it'll be undefined
+        prodExport: typeof window.litIssuedWarnings === 'undefined',
+      };
+      document.getElementById('test').innerHTML = `<pre>${JSON.stringify(
+        window.__tests,
+        null,
+        2,
+      )}</pre>`;
+    </script>
+  </body>
+</html>

--- a/packages/dev-server/src/plugins/nodeResolvePlugin.ts
+++ b/packages/dev-server/src/plugins/nodeResolvePlugin.ts
@@ -14,7 +14,7 @@ export function nodeResolvePlugin(
       extensions: ['.mjs', '.js', '.cjs', '.jsx', '.json', '.ts', '.tsx'],
       moduleDirectories: ['node_modules', 'web_modules'],
       // allow resolving polyfills for nodejs libs
-      preferBuiltins: false
+      preferBuiltins: false,
     },
     userOptionsObject,
   );

--- a/packages/dev-server/src/plugins/nodeResolvePlugin.ts
+++ b/packages/dev-server/src/plugins/nodeResolvePlugin.ts
@@ -14,11 +14,13 @@ export function nodeResolvePlugin(
       extensions: ['.mjs', '.js', '.cjs', '.jsx', '.json', '.ts', '.tsx'],
       moduleDirectories: ['node_modules', 'web_modules'],
       // allow resolving polyfills for nodejs libs
-      preferBuiltins: false,
-      exportConditions: ['development'],
+      preferBuiltins: false
     },
     userOptionsObject,
   );
+
+  // use user config exportConditions if present. otherwise use ['development']
+  options.exportConditions = userOptionsObject.exportConditions || ['development'];
 
   return rollupAdapter(
     nodeResolve(options),

--- a/packages/dev-server/test/integration.test.mjs
+++ b/packages/dev-server/test/integration.test.mjs
@@ -33,6 +33,10 @@ const testCases = [
     name: 'syntax',
     tests: ['stage4', 'inlineStage4', 'importMeta', 'staticImports', 'dynamicImports'],
   },
+  {
+    name: 'export-conditions',
+    tests: ['prodExport'],
+  },
 ];
 
 describe('integration tests', () => {

--- a/packages/test-runner-commands/browser/commands.d.ts
+++ b/packages/test-runner-commands/browser/commands.d.ts
@@ -138,7 +138,7 @@ export function sendMouse(payload: SendMousePayload): Promise<void>;
 
 /**
  * Selects an option in a <select> element by value or label
- * 
+ *
  * @example
  * ```
  * it('natively selects an option by value', async () => {


### PR DESCRIPTION
fixes #2413 

## What I did
1. removed exportConditions config from the deepmerge
2. handle exportConditions separately and allow the user config of exportConditions to fully replace the default array if present.
3. Add an export-conditions test case

