### PR TITLE
Allow web socket based refresh in middleware mode

### DIFF
--- a/.changeset/green-arachnid-crossing.md
+++ b/.changeset/green-arachnid-crossing.md
@@ -1,0 +1,5 @@
+---
+"@web/storybook-builder": patch
+---
+
+Pass Storybook server into middleware mode to enable live refresh

--- a/.changeset/orange-octopus-murmurs.md
+++ b/.changeset/orange-octopus-murmurs.md
@@ -1,0 +1,5 @@
+---
+"@web/dev-server-core": patch
+---
+
+Allow web socket based refresh in middleware mode, by accepting the source `server` as an option for the `middlewareMode` config property

--- a/packages/dev-server-core/src/server/DevServer.ts
+++ b/packages/dev-server-core/src/server/DevServer.ts
@@ -19,7 +19,6 @@ export class DevServer {
     public config: DevServerCoreConfig,
     public logger: Logger,
     public fileWatcher = chokidar.watch([]),
-    externalServer?: Server,
   ) {
     if (!config) throw new Error('Missing config.');
     if (!logger) throw new Error('Missing logger.');
@@ -28,7 +27,7 @@ export class DevServer {
       this.logger,
       this.config,
       this.fileWatcher,
-      config.middlewareMode,
+      !!config.middlewareMode,
     );
     this.koaApp = app;
     if (server) {
@@ -40,8 +39,11 @@ export class DevServer {
           this.connections.delete(connection);
         });
       });
-    } else if (externalServer) {
-      this.webSockets = new WebSocketsManager(externalServer);
+    } else if (
+      typeof this.config.middlewareMode === 'object' &&
+      this.config.middlewareMode.server
+    ) {
+      this.webSockets = new WebSocketsManager(this.config.middlewareMode.server);
     }
   }
 

--- a/packages/dev-server-core/src/server/DevServer.ts
+++ b/packages/dev-server-core/src/server/DevServer.ts
@@ -19,6 +19,7 @@ export class DevServer {
     public config: DevServerCoreConfig,
     public logger: Logger,
     public fileWatcher = chokidar.watch([]),
+    externalServer?: Server,
   ) {
     if (!config) throw new Error('Missing config.');
     if (!logger) throw new Error('Missing logger.');
@@ -39,6 +40,8 @@ export class DevServer {
           this.connections.delete(connection);
         });
       });
+    } else if (externalServer) {
+      this.webSockets = new WebSocketsManager(externalServer);
     }
   }
 

--- a/packages/dev-server-core/src/server/DevServerCoreConfig.ts
+++ b/packages/dev-server-core/src/server/DevServerCoreConfig.ts
@@ -1,5 +1,6 @@
 import { Middleware } from 'koa';
 import { Plugin } from '../plugins/Plugin';
+import { Server } from 'net';
 
 export type MimeTypeMappings = Record<string, string>;
 
@@ -21,7 +22,7 @@ export interface DevServerCoreConfig {
   /**
    * Whether to run server or not and allow to use as a middleware connected to another server.
    */
-  middlewareMode?: boolean;
+  middlewareMode?: boolean | { server: Server };
   basePath?: string;
   /**
    * The app's index.html file. When set, serves the index.html for non-file requests. Use this to enable SPA routing

--- a/packages/dev-server/src/startDevServer.ts
+++ b/packages/dev-server/src/startDevServer.ts
@@ -7,7 +7,6 @@ import { readFileConfig } from './config/readFileConfig';
 import { DevServerStartError } from './DevServerStartError';
 import { createLogger } from './logger/createLogger';
 import { openBrowser } from './openBrowser';
-import { Server } from 'net';
 
 export interface StartDevServerParams {
   /**
@@ -38,10 +37,6 @@ export interface StartDevServerParams {
    * Array to read the CLI args from. Defaults to process.argv.
    */
   argv?: string[];
-  /**
-   * When running as a middleware the server that WDS is running in.
-   */
-  externalServer?: Server;
 }
 
 /**
@@ -56,7 +51,6 @@ export async function startDevServer(options: StartDevServerParams = {}) {
     autoExitProcess = true,
     logStartMessage = true,
     argv = process.argv,
-    externalServer,
   } = options;
 
   try {
@@ -75,7 +69,7 @@ export async function startDevServer(options: StartDevServerParams = {}) {
     config.plugins = config.plugins ?? [];
     config.plugins.unshift(loggerPlugin);
 
-    const server = new DevServer(config, logger, undefined, externalServer);
+    const server = new DevServer(config, logger);
 
     if (autoExitProcess) {
       process.on('uncaughtException', error => {

--- a/packages/dev-server/src/startDevServer.ts
+++ b/packages/dev-server/src/startDevServer.ts
@@ -7,6 +7,7 @@ import { readFileConfig } from './config/readFileConfig';
 import { DevServerStartError } from './DevServerStartError';
 import { createLogger } from './logger/createLogger';
 import { openBrowser } from './openBrowser';
+import { Server } from 'net';
 
 export interface StartDevServerParams {
   /**
@@ -37,6 +38,10 @@ export interface StartDevServerParams {
    * Array to read the CLI args from. Defaults to process.argv.
    */
   argv?: string[];
+  /**
+   * When running as a middleware the server that WDS is running in.
+   */
+  externalServer?: Server;
 }
 
 /**
@@ -51,6 +56,7 @@ export async function startDevServer(options: StartDevServerParams = {}) {
     autoExitProcess = true,
     logStartMessage = true,
     argv = process.argv,
+    externalServer,
   } = options;
 
   try {
@@ -69,7 +75,7 @@ export async function startDevServer(options: StartDevServerParams = {}) {
     config.plugins = config.plugins ?? [];
     config.plugins.unshift(loggerPlugin);
 
-    const server = new DevServer(config, logger);
+    const server = new DevServer(config, logger, undefined, externalServer);
 
     if (autoExitProcess) {
       process.on('uncaughtException', error => {

--- a/packages/storybook-builder/src/index.ts
+++ b/packages/storybook-builder/src/index.ts
@@ -53,7 +53,12 @@ export const bail: WdsBuilder['bail'] = async () => {
   await wdsServer?.stop();
 };
 
-export const start: WdsBuilder['start'] = async ({ startTime, options, router }) => {
+export const start: WdsBuilder['start'] = async ({
+  startTime,
+  options,
+  router,
+  server: externalServer,
+}) => {
   const previewDirOrigin = join(getNodeModuleDir('@storybook/preview'), 'dist');
   router.use('/sb-preview', express.static(previewDirOrigin, { immutable: true, maxAge: '5m' }));
   router.use(`/${PREBUNDLED_MODULES_DIR}`, express.static(resolve(`./${PREBUNDLED_MODULES_DIR}`)));
@@ -114,6 +119,7 @@ export const start: WdsBuilder['start'] = async ({ startTime, options, router })
     autoExitProcess: false,
     logStartMessage: false,
     config: wdsFinalConfig,
+    externalServer,
   });
 
   router.use(wdsServer.koaApp.callback());

--- a/packages/storybook-builder/src/index.ts
+++ b/packages/storybook-builder/src/index.ts
@@ -53,12 +53,7 @@ export const bail: WdsBuilder['bail'] = async () => {
   await wdsServer?.stop();
 };
 
-export const start: WdsBuilder['start'] = async ({
-  startTime,
-  options,
-  router,
-  server: externalServer,
-}) => {
+export const start: WdsBuilder['start'] = async ({ startTime, options, router, server }) => {
   const previewDirOrigin = join(getNodeModuleDir('@storybook/preview'), 'dist');
   router.use('/sb-preview', express.static(previewDirOrigin, { immutable: true, maxAge: '5m' }));
   router.use(`/${PREBUNDLED_MODULES_DIR}`, express.static(resolve(`./${PREBUNDLED_MODULES_DIR}`)));
@@ -108,7 +103,9 @@ export const start: WdsBuilder['start'] = async ({
   }
 
   // setup middleware mode
-  wdsFinalConfig.middlewareMode = true;
+  wdsFinalConfig.middlewareMode = {
+    server,
+  };
   wdsFinalConfig.port = undefined;
   wdsFinalConfig.hostname = undefined;
 
@@ -119,7 +116,6 @@ export const start: WdsBuilder['start'] = async ({
     autoExitProcess: false,
     logStartMessage: false,
     config: wdsFinalConfig,
-    externalServer,
   });
 
   router.use(wdsServer.koaApp.callback());


### PR DESCRIPTION
## What I did

1. Accept an external server when running in middleware mode.
2. Pass the server from Storybook Builder as an external server.
3. Use the external server, when available, to hang the web socket needed to watch changes.

Fixes #2471
