### PR TITLE
docs: adds code coverage reporter config example

### DIFF
--- a/docs/docs/test-runner/writing-tests/code-coverage.md
+++ b/docs/docs/test-runner/writing-tests/code-coverage.md
@@ -104,7 +104,7 @@ By default coverage reporting uses the lcov reporter. Should you want to use add
 ```js
 // web-test-runner.config.mjs
 
-module.exports = {
+export default {
   coverageConfig: {
     report: true,
     reportDir: 'test-coverage',

--- a/docs/docs/test-runner/writing-tests/code-coverage.md
+++ b/docs/docs/test-runner/writing-tests/code-coverage.md
@@ -13,7 +13,7 @@ In the config you can define code coverage thresholds, the test run fails if you
 ```js
 // web-test-runner.config.mjs
 
-module.exports = {
+export default {
   coverageConfig: {
     report: true,
     reportDir: 'test-coverage',

--- a/docs/docs/test-runner/writing-tests/code-coverage.md
+++ b/docs/docs/test-runner/writing-tests/code-coverage.md
@@ -94,3 +94,27 @@ export default {
   ],
 };
 ```
+
+## Coverage reporting
+
+By default coverage reporting uses the lcov reporter. Should you want to use additional reporters, for example, cobertura, then the `reporter` config element should be modified.
+
+**Example config:**
+
+```js
+// web-test-runner.config.mjs
+
+module.exports = {
+  coverageConfig: {
+    report: true,
+    reportDir: 'test-coverage',
+    reporters: ['cobertura', 'lcov']
+    threshold: {
+      statements: 70,
+      branches: 70,
+      functions: 70,
+      lines: 70,
+    },
+  },
+};
+```


### PR DESCRIPTION
adds documentation to show how cobertura can be added to the coverageConfig for enhanced reporting

Closes #1548