### PR TITLE
fix(test-runner-mocha): move `@types/mocha` to dev dependency

### DIFF
--- a/.changeset/twenty-pants-draw.md
+++ b/.changeset/twenty-pants-draw.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-mocha': patch
+---
+
+Remove `@types/mocha` from dependencies so its global types don't leak into user code.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6449,7 +6449,8 @@
     "node_modules/@types/mocha": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
-      "integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q=="
+      "integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==",
+      "dev": true
     },
     "node_modules/@types/ms": {
       "version": "0.7.31",
@@ -33801,10 +33802,10 @@
       "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
-        "@types/mocha": "^10.0.1",
         "@web/test-runner-core": "^0.11.1"
       },
       "devDependencies": {
+        "@types/mocha": "^10.0.1",
         "deepmerge": "^4.2.2",
         "mocha": "^10.2.0"
       },

--- a/packages/test-runner-mocha/package.json
+++ b/packages/test-runner-mocha/package.json
@@ -35,10 +35,10 @@
     "framework"
   ],
   "dependencies": {
-    "@types/mocha": "^10.0.1",
     "@web/test-runner-core": "^0.11.1"
   },
   "devDependencies": {
+    "@types/mocha": "^10.0.1",
     "deepmerge": "^4.2.2",
     "mocha": "^10.2.0"
   }


### PR DESCRIPTION
Having an `@types/*` package with global symbols like `it` and `describe` forces these global types on downstream consumers which may not use them. TypeScript is fairly aggressive at pulling in globals from transitive dependencies, meaning that `@types/mocha` is applied to application code, which can cause challenges. For example, Jasmine types overlap and conflict with Mocha types, but transitively including `@types/mocha` through `@web/test-runner-mocha` makes Jasmine impossible to use with Web Test Runner. See [this commit](https://github.com/angular/angular-cli/pull/25860/commits/d95bb6325951a19e69a3da9790b0fa0873ee0600) for a motivating example.

One potential alternative solution I did not explore here but want to state for posterity: I think it is debatable whether `@web/test-runner` should have a dependency on `@web/test-runner-mocha`, given that Mocha is only one possible test framework which can be used. If a test environment is using Jasmine or any other framework it would make sense that it should _not_ depend on `@web/test-runner-mocha` yet that dependency is unavoidable here.

It seemed like Mocha being the default test runner was an intentional decision so I didn't try to change that. However I wonder if the better relationship between these two packages would be an optional peer dependency in `@web/test-runner` on `@web/test-runner-mocha`. Set up instructions or a script could configure this peer dependency by default, however I can understand the cost here and why it might be better to always include `@web/test-runner-mocha` and accept that some users just won't invoke that code path.

I suspect `@web/test-runner-mocha` also probably wants a peer dependency on `mocha` to restrict the specific versions which it supports as this seems to be configurable to the user. I _think_ users are supposed to `npm install mocha @types/mocha --save-dev` as I couldn't find any other non-dev dependency on `mocha`, though [the docs](https://modern-web.dev/docs/test-runner/test-frameworks/mocha/) don't state that. I didn't try adding a peer dep in this PR to keep it simple.

## What I did

1. Moved `@types/mocha` to `devDependencies`.
2. Ran `npm install` to update the lockfile.
3. This also bumped a few unrelated deps, so I reverted those changes to limit this to just the `@types/mocha` change.
