### PR TITLE
Use split versions for all lit dependencies

### DIFF
--- a/.changeset/giant-countries-beam.md
+++ b/.changeset/giant-countries-beam.md
@@ -1,0 +1,8 @@
+---
+"@web/dev-server-esbuild": patch
+"@web/dev-server-hmr": patch
+"@web/dev-server": patch
+"@web/mocks": patch
+---
+
+Use split versions for all lit dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -32596,7 +32596,7 @@
       },
       "devDependencies": {
         "@types/command-line-usage": "^5.0.1",
-        "lit-html": "^2.7.3",
+        "lit-html": "^2.7.3 || ^3.0.0",
         "puppeteer": "^20.0.0"
       },
       "engines": {
@@ -32673,7 +32673,7 @@
       "devDependencies": {
         "@types/ua-parser-js": "^0.7.35",
         "@web/dev-server-rollup": "^0.5.4",
-        "lit-element": "^3.0.0",
+        "lit-element": "^3.0.0 || ^4.0.1",
         "node-fetch": "3.0.0-beta.9",
         "preact": "^10.5.9"
       },
@@ -32706,7 +32706,7 @@
         "@web/dev-server-core": "^0.6.2"
       },
       "devDependencies": {
-        "lit-html": "^2.7.3",
+        "lit-html": "^2.7.3 || ^3.0.0",
         "puppeteer": "^20.0.0"
       },
       "engines": {
@@ -32766,11 +32766,11 @@
     },
     "packages/dev-server-polyfill": {
       "name": "@web/dev-server-polyfill",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@web/dev-server": "^0.3.6",
-        "@web/polyfills-loader": "^2.1.3"
+        "@web/polyfills-loader": "^2.1.5"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -33035,7 +33035,7 @@
         "@storybook/preview-api": "^7.0.0",
         "@web/storybook-prebuilt": "^0.1.37",
         "@web/storybook-utils": "^1.0.0",
-        "lit": "^2.7.5",
+        "lit": "^2.7.5 || ^3.0.0",
         "msw": "0.0.0-fetch.rc-23"
       },
       "devDependencies": {
@@ -33228,7 +33228,7 @@
     },
     "packages/polyfills-loader": {
       "name": "@web/polyfills-loader",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.12.10",

--- a/packages/dev-server-esbuild/package.json
+++ b/packages/dev-server-esbuild/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@types/ua-parser-js": "^0.7.35",
     "@web/dev-server-rollup": "^0.5.4",
-    "lit-element": "^3.0.0",
+    "lit-element": "^3.0.0 || ^4.0.1",
     "node-fetch": "3.0.0-beta.9",
     "preact": "^10.5.9"
   }

--- a/packages/dev-server-hmr/package.json
+++ b/packages/dev-server-hmr/package.json
@@ -43,7 +43,7 @@
     "@web/dev-server-core": "^0.6.2"
   },
   "devDependencies": {
-    "lit-html": "^2.7.3",
+    "lit-html": "^2.7.3 || ^3.0.0",
     "puppeteer": "^20.0.0"
   }
 }

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -72,7 +72,7 @@
   },
   "devDependencies": {
     "@types/command-line-usage": "^5.0.1",
-    "lit-html": "^2.7.3",
+    "lit-html": "^2.7.3 || ^3.0.0",
     "puppeteer": "^20.0.0"
   }
 }

--- a/packages/mocks/package.json
+++ b/packages/mocks/package.json
@@ -64,7 +64,7 @@
     "@storybook/preview-api": "^7.0.0",
     "@web/storybook-prebuilt": "^0.1.37",
     "@web/storybook-utils": "^1.0.0",
-    "lit": "^2.7.5",
+    "lit": "^2.7.5 || ^3.0.0",
     "msw": "0.0.0-fetch.rc-23"
   },
   "devDependencies": {


### PR DESCRIPTION
## What I did

1. Split all versions of lit dependencies for consumption of ^2 || ^3.
