### PR TITLE
Remove node-fetch since fetch is already implemented in node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "@types/chai": "^4.2.22",
         "@types/mocha": "^10.0.1",
         "@types/node": "*",
-        "@types/node-fetch": "^2.5.8",
         "@typescript-eslint/eslint-plugin": "^5.3.0",
         "@typescript-eslint/parser": "^5.59.1",
         "alex": "^11.0.0",
@@ -11136,14 +11135,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/date-fns": {
       "version": "2.30.0",
       "dev": true,
@@ -13768,19 +13759,6 @@
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^10.17.0 || >=12.3.0"
-      },
-      "peerDependenciesMeta": {
-        "domexception": {
-          "optional": true
-        }
       }
     },
     "node_modules/figures": {
@@ -30097,7 +30075,7 @@
     },
     "packages/dev-server": {
       "name": "@web/dev-server",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.11",
@@ -30160,32 +30138,15 @@
         "abort-controller": "^3.0.0",
         "express": "^4.18.2",
         "nanoid": "^3.1.25",
-        "node-fetch": "3.0.0-beta.9",
         "portfinder": "^1.0.32"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "packages/dev-server-core/node_modules/node-fetch": {
-      "version": "3.0.0-beta.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^3.0.1",
-        "fetch-blob": "^2.1.1"
-      },
-      "engines": {
-        "node": "^10.17 || >=12.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "packages/dev-server-esbuild": {
       "name": "@web/dev-server-esbuild",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "dependencies": {
         "@mdn/browser-compat-data": "^4.0.0",
@@ -30198,7 +30159,6 @@
         "@types/ua-parser-js": "^0.7.35",
         "@web/dev-server-rollup": "^0.5.4",
         "lit-element": "^3.0.0 || ^4.0.1",
-        "node-fetch": "3.0.0-beta.9",
         "preact": "^10.5.9"
       },
       "engines": {
@@ -30254,25 +30214,9 @@
         "@esbuild/win32-x64": "0.19.5"
       }
     },
-    "packages/dev-server-esbuild/node_modules/node-fetch": {
-      "version": "3.0.0-beta.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^3.0.1",
-        "fetch-blob": "^2.1.1"
-      },
-      "engines": {
-        "node": "^10.17 || >=12.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "packages/dev-server-hmr": {
       "name": "@web/dev-server-hmr",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@web/dev-server-core": "^0.6.2"
@@ -30372,28 +30316,11 @@
         "@web/test-runner-core": "^0.12.0",
         "chai": "^4.2.0",
         "mocha": "^10.2.0",
-        "node-fetch": "3.0.0-beta.9",
         "postcss": "^8.4.31",
         "rollup-plugin-postcss": "^4.0.2"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "packages/dev-server-rollup/node_modules/node-fetch": {
-      "version": "3.0.0-beta.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^3.0.1",
-        "fetch-blob": "^2.1.1"
-      },
-      "engines": {
-        "node": "^10.17 || >=12.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "packages/dev-server-storybook": {
@@ -30587,7 +30514,7 @@
     },
     "packages/mocks": {
       "name": "@web/mocks",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "MIT",
       "dependencies": {
         "@storybook/manager-api": "^7.0.0",
@@ -30598,7 +30525,7 @@
         "msw": "0.0.0-fetch.rc-23"
       },
       "devDependencies": {
-        "@web/dev-server": "^0.3.0",
+        "@web/dev-server": "^0.3.7",
         "@web/dev-server-storybook": "^1.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@types/chai": "^4.2.22",
     "@types/mocha": "^10.0.1",
     "@types/node": "*",
-    "@types/node-fetch": "^2.5.8",
     "@typescript-eslint/eslint-plugin": "^5.3.0",
     "@typescript-eslint/parser": "^5.59.1",
     "alex": "^11.0.0",

--- a/packages/dev-server-core/package.json
+++ b/packages/dev-server-core/package.json
@@ -85,7 +85,6 @@
     "abort-controller": "^3.0.0",
     "express": "^4.18.2",
     "nanoid": "^3.1.25",
-    "node-fetch": "3.0.0-beta.9",
     "portfinder": "^1.0.32"
   }
 }

--- a/packages/dev-server-core/src/test-helpers.ts
+++ b/packages/dev-server-core/src/test-helpers.ts
@@ -1,7 +1,6 @@
 import portfinder from 'portfinder';
 import { expect } from 'chai';
 import { green, red, yellow } from 'nanocolors';
-import fetch, { RequestInit } from 'node-fetch';
 
 import { DevServer } from './server/DevServer';
 import { DevServerCoreConfig } from './server/DevServerCoreConfig';

--- a/packages/dev-server-core/test/middleware/basePathMiddleware.test.ts
+++ b/packages/dev-server-core/test/middleware/basePathMiddleware.test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import fetch from 'node-fetch';
 
 import { DevServer } from '../../src/server/DevServer';
 import { createTestServer } from '../helpers';

--- a/packages/dev-server-core/test/middleware/etagCacheMiddleware.test.ts
+++ b/packages/dev-server-core/test/middleware/etagCacheMiddleware.test.ts
@@ -42,7 +42,9 @@ describe('etag cache middleware', () => {
 
       expect(etag).to.be.a('string');
 
-      const cachedResponse = await fetch(`${host}${testFileAName}`, { headers: { 'If-None-Match': etag, 'Cache-Control': 'max-age=3600' } });
+      const cachedResponse = await fetch(`${host}${testFileAName}`, {
+        headers: { 'If-None-Match': etag, 'Cache-Control': 'max-age=3600' },
+      });
 
       expect(cachedResponse.status).to.equal(304);
       expect(await cachedResponse.text()).to.equal('');

--- a/packages/dev-server-core/test/middleware/etagCacheMiddleware.test.ts
+++ b/packages/dev-server-core/test/middleware/etagCacheMiddleware.test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import fetch from 'node-fetch';
 import path from 'path';
 import fs from 'fs';
 import { nanoid } from 'nanoid';
@@ -36,15 +35,14 @@ describe('etag cache middleware', () => {
 
     it("returns 304 responses if file hasn't changed", async () => {
       const initialResponse = await fetch(`${host}${testFileAName}`);
-      const etag = initialResponse.headers.get('etag');
+      const etag = initialResponse.headers.get('etag')!;
 
       expect(initialResponse.status).to.equal(200);
       expect(await initialResponse.text()).to.equal('// this file is cached');
 
       expect(etag).to.be.a('string');
 
-      const headers = { headers: { 'if-none-match': etag } as Record<string, string> };
-      const cachedResponse = await fetch(`${host}${testFileAName}`, headers);
+      const cachedResponse = await fetch(`${host}${testFileAName}`, { headers: { 'If-None-Match': etag, 'Cache-Control': 'max-age=3600' } });
 
       expect(cachedResponse.status).to.equal(304);
       expect(await cachedResponse.text()).to.equal('');

--- a/packages/dev-server-core/test/middleware/historyApiFallbackMiddleware.test.ts
+++ b/packages/dev-server-core/test/middleware/historyApiFallbackMiddleware.test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import fetch from 'node-fetch';
 import path from 'path';
 
 import { createTestServer } from '../helpers';

--- a/packages/dev-server-core/test/middleware/pluginFileParsedMiddleware.test.ts
+++ b/packages/dev-server-core/test/middleware/pluginFileParsedMiddleware.test.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { Context } from 'koa';
-import fetch from 'node-fetch';
 
 import { createTestServer } from '../helpers';
 

--- a/packages/dev-server-core/test/middleware/pluginMimeTypeMiddleware.test.ts
+++ b/packages/dev-server-core/test/middleware/pluginMimeTypeMiddleware.test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import fetch from 'node-fetch';
 
 import { createTestServer } from '../helpers';
 

--- a/packages/dev-server-core/test/middleware/pluginServeMiddleware.test.ts
+++ b/packages/dev-server-core/test/middleware/pluginServeMiddleware.test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import fetch from 'node-fetch';
 
 import { createTestServer } from '../helpers';
 

--- a/packages/dev-server-core/test/middleware/pluginTransformMiddleware.test.ts
+++ b/packages/dev-server-core/test/middleware/pluginTransformMiddleware.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-restricted-syntax, no-await-in-loop */
 import { expect } from 'chai';
-import fetch from 'node-fetch';
 
 import { createTestServer } from '../helpers';
 import { fetchText, expectIncludes } from '../../src/test-helpers';
@@ -189,16 +188,17 @@ describe('plugin-transform middleware', () => {
     try {
       const responseOne = await fetch(`${host}/src/foo.js`);
       const textOne = await responseOne.text();
-      const headersOne = responseOne.headers.raw();
+
+      const headersOne = responseOne.headers;
 
       const responseTwo = await fetch(`${host}/src/foo.js`);
       const textTwo = await responseTwo.text();
-      const headersTwo = responseTwo.headers.raw();
+      const headersTwo = responseTwo.headers;
 
       expect(textOne).equal('console.log("foo")');
       expect(textTwo).equal('console.log("foo")');
-      expect(headersOne['x-foo']).eql(['bar']);
-      expect(headersOne).eql(headersTwo);
+      expect(headersOne.get('x-foo')).eql('bar');
+      expect(Object.fromEntries(headersOne.entries())).eql(Object.fromEntries(headersTwo.entries()))
     } finally {
       server.stop();
     }

--- a/packages/dev-server-core/test/middleware/pluginTransformMiddleware.test.ts
+++ b/packages/dev-server-core/test/middleware/pluginTransformMiddleware.test.ts
@@ -198,7 +198,9 @@ describe('plugin-transform middleware', () => {
       expect(textOne).equal('console.log("foo")');
       expect(textTwo).equal('console.log("foo")');
       expect(headersOne.get('x-foo')).eql('bar');
-      expect(Object.fromEntries(headersOne.entries())).eql(Object.fromEntries(headersTwo.entries()))
+      expect(Object.fromEntries(headersOne.entries())).eql(
+        Object.fromEntries(headersTwo.entries()),
+      );
     } finally {
       server.stop();
     }

--- a/packages/dev-server-core/test/middleware/serveFilesMiddleware.test.ts
+++ b/packages/dev-server-core/test/middleware/serveFilesMiddleware.test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import fetch from 'node-fetch';
 import path from 'path';
 
 import { createTestServer } from '../helpers';

--- a/packages/dev-server-core/test/plugins/mimeTypesPlugin.test.ts
+++ b/packages/dev-server-core/test/plugins/mimeTypesPlugin.test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import fetch from 'node-fetch';
 
 import { createTestServer } from '../helpers';
 

--- a/packages/dev-server-core/test/plugins/transformModuleImportsPlugin.test.ts
+++ b/packages/dev-server-core/test/plugins/transformModuleImportsPlugin.test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import fetch from 'node-fetch';
 
 import { transformImports } from '../../src/plugins/transformModuleImportsPlugin';
 import type { PluginSyntaxError } from '../../src/logger/PluginSyntaxError';

--- a/packages/dev-server-core/test/server/DevServer.test.ts
+++ b/packages/dev-server-core/test/server/DevServer.test.ts
@@ -4,7 +4,6 @@ import Koa from 'koa';
 import { Server } from 'net';
 import { FSWatcher } from 'chokidar';
 import { expect } from 'chai';
-import fetch from 'node-fetch';
 import portfinder from 'portfinder';
 import { Stub, stubMethod } from 'hanbi';
 import { ServerStartParams } from '../../src/plugins/Plugin';
@@ -88,7 +87,6 @@ describe('http2', () => {
   it('serves a website', async () => {
     const { server, host } = await createTestServer({ hostname: 'localhost', http2: true });
     const response = await fetch(`${host}/index.html`);
-    console.log(response.body, response.size);
     const responseText = await response.text();
 
     // It's a bit of a shame that we can't verify that the response was delivered with a http/2

--- a/packages/dev-server-core/test/web-sockets/webSocketsPlugin.test.ts
+++ b/packages/dev-server-core/test/web-sockets/webSocketsPlugin.test.ts
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import { expect } from 'chai';
 
 import { createTestServer } from '../helpers';

--- a/packages/dev-server-esbuild/package.json
+++ b/packages/dev-server-esbuild/package.json
@@ -61,7 +61,6 @@
     "@types/ua-parser-js": "^0.7.35",
     "@web/dev-server-rollup": "^0.6.0",
     "lit-element": "^3.0.0 || ^4.0.1",
-    "node-fetch": "3.0.0-beta.9",
     "preact": "^10.5.9"
   }
 }

--- a/packages/dev-server-esbuild/package.json
+++ b/packages/dev-server-esbuild/package.json
@@ -52,9 +52,9 @@
   ],
   "dependencies": {
     "@mdn/browser-compat-data": "^4.0.0",
-    "esbuild": "^0.19.5",
     "@web/dev-server-core": "^0.7.0",
     "parse5": "^6.0.1",
+    "esbuild": "^0.19.5",
     "ua-parser-js": "^1.0.33"
   },
   "devDependencies": {

--- a/packages/dev-server-esbuild/test/banner-footer.test.ts
+++ b/packages/dev-server-esbuild/test/banner-footer.test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import fetch from 'node-fetch';
 import { createTestServer } from '@web/dev-server-core/test-helpers';
 import { expectIncludes } from '@web/dev-server-core/test-helpers';
 

--- a/packages/dev-server-esbuild/test/json.test.ts
+++ b/packages/dev-server-esbuild/test/json.test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import fetch from 'node-fetch';
 import { expectIncludes, createTestServer } from '@web/dev-server-core/test-helpers';
 
 import { esbuildPlugin } from '../src/index';

--- a/packages/dev-server-esbuild/test/jsx.test.ts
+++ b/packages/dev-server-esbuild/test/jsx.test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import fetch from 'node-fetch';
 import { expectIncludes, createTestServer } from '@web/dev-server-core/test-helpers';
 
 import { esbuildPlugin } from '../src/index';

--- a/packages/dev-server-esbuild/test/target.test.ts
+++ b/packages/dev-server-esbuild/test/target.test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import fetch from 'node-fetch';
 import { createTestServer, expectIncludes } from '@web/dev-server-core/test-helpers';
 
 import { esbuildPlugin } from '../src/index';

--- a/packages/dev-server-esbuild/test/ts.test.ts
+++ b/packages/dev-server-esbuild/test/ts.test.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import { expect } from 'chai';
-import fetch from 'node-fetch';
 import { createTestServer } from '@web/dev-server-core/test-helpers';
 import { expectIncludes, expectNotIncludes } from '@web/dev-server-core/test-helpers';
 import { Plugin as RollupPlugin } from 'rollup';

--- a/packages/dev-server-esbuild/test/tsx.test.ts
+++ b/packages/dev-server-esbuild/test/tsx.test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import fetch from 'node-fetch';
 import { createTestServer } from '@web/dev-server-core/test-helpers';
 import { expectIncludes, expectNotIncludes } from '@web/dev-server-core/test-helpers';
 

--- a/packages/dev-server-hmr/test/HmrPlugin.test.ts
+++ b/packages/dev-server-hmr/test/HmrPlugin.test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import fetch from 'node-fetch';
 import { stubMethod, restore as restoreStubs } from 'hanbi';
 import { createTestServer, fetchText, expectIncludes } from '@web/dev-server-core/test-helpers';
 import { posix as pathUtil } from 'path';

--- a/packages/dev-server-rollup/package.json
+++ b/packages/dev-server-rollup/package.json
@@ -67,7 +67,6 @@
     "@web/test-runner-core": "^0.13.0",
     "chai": "^4.2.0",
     "mocha": "^10.2.0",
-    "node-fetch": "3.0.0-beta.9",
     "postcss": "^8.4.31",
     "rollup-plugin-postcss": "^4.0.2"
   }

--- a/packages/dev-server-rollup/test/node/plugins/node-resolve.test.ts
+++ b/packages/dev-server-rollup/test/node/plugins/node-resolve.test.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import rollupNodeResolve from '@rollup/plugin-node-resolve';
 import rollupCommonjs from '@rollup/plugin-commonjs';
-import fetch from 'node-fetch';
 
 import { createTestServer, fetchText, expectIncludes } from '../test-helpers';
 import { fromRollup } from '../../../src/index';


### PR DESCRIPTION
We don't need `node-fetch` any more as the platform (nodejs) has caught up with standards and has `fetch` as a built-in global variable since node v18.