### PR TITLE
fix(test-runner): unify visual-written representation of skipped tests

### DIFF
--- a/.changeset/modern-planes-yawn.md
+++ b/.changeset/modern-planes-yawn.md
@@ -1,0 +1,5 @@
+---
+"@web/test-runner": patch
+---
+
+Unify visual-written representation of skipped tests.

--- a/packages/test-runner/src/reporter/summaryReporter.ts
+++ b/packages/test-runner/src/reporter/summaryReporter.ts
@@ -30,8 +30,15 @@ export function summaryReporter(opts: Options): Reporter {
   let args: ReporterArgs;
   let favoriteBrowser: string;
 
-  function log(logger: Logger, name: string, passed: boolean, prefix = '  ', postfix = '') {
-    const sign = passed ? green('✓') : red('𐄂');
+  function log(
+    logger: Logger,
+    name: string,
+    passed: boolean,
+    skipped: boolean,
+    prefix = '  ',
+    postfix = '',
+  ) {
+    const sign = skipped ? dim('-') : passed ? green('✓') : red('𐄂');
     if (flatten) logger.log(`${sign} ${name}${postfix}`);
     else logger.log(`${prefix}  ${sign} ${name}`);
   }
@@ -44,7 +51,7 @@ export function summaryReporter(opts: Options): Reporter {
   ) {
     const browserName = browser?.name ? ` ${dim(`[${browser.name}]`)}` : '';
     for (const result of results?.tests ?? []) {
-      log(logger, result.name, result.passed, prefix, browserName);
+      log(logger, result.name, result.passed, result.skipped, prefix, browserName);
     }
 
     for (const suite of results?.suites ?? []) {


### PR DESCRIPTION
## What I did

### Unifying Visual and Written Representation of 'Skipped' Information for  better comprehension - cognitive accessibility.

Presently, when a test is skipped, the visual representation uses a red "X" symbol, while the written summary denotes the skip with a gray label. 

To enhance understanding and cognitive accessibility, I suggest introducing a new visual symbol, “-,” rendered in a subdued color, to complement the existing skipped label. This alignment of visual and written representations aims to improve clarity and consistency.

- https://www.w3.org/WAI/WCAG2/supplemental/patterns/o4p10-status-feedback/

### Visual

#### `x red`

<img width="1677" alt="skipped-old-red" src="https://github.com/modernweb-dev/web/assets/3649029/0b52168b-991f-42ec-bc07-9442a8cad2c0">

#### `- dim`

<img width="1677" alt="skipped-new-dim" src="https://github.com/modernweb-dev/web/assets/3649029/522892f0-9d14-4eb1-86a5-428a0fc1aefc">