### PR TITLE
fix(browser-logs): do not log nullish errors

### DIFF
--- a/packages/browser-logs/src/logUncaughtErrors.ts
+++ b/packages/browser-logs/src/logUncaughtErrors.ts
@@ -1,5 +1,7 @@
 window.addEventListener('error', e => {
-  console.error(e.error);
+  if (e.error != null) {
+    console.error(e.error);
+  }
 });
 
 window.addEventListener('unhandledrejection', e => {


### PR DESCRIPTION
## What I did

1. Add a nullish condition on `e.error` before logging.

## Why?

Because in some situations, the `error` in the `event` can be `null`.

This pollutes the browser log console.
This pollutes the test logs (through the browser error reporter).

I faced that when trying to ignore some errors using this technique:
* https://github.com/lit/lit/tree/main/packages/labs/virtualizer#resizeobserver-loop-limit-exceeded-errors
* https://github.com/lit/lit/blob/main/packages/labs/virtualizer/src/support/resize-observer-errors.ts
