### PR TITLE
Replace `mocha` with `node:test`

### DIFF
--- a/packages/rollup-plugin-copy/package.json
+++ b/packages/rollup-plugin-copy/package.json
@@ -29,8 +29,9 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "test:node": "mocha test/**/*.test.js --reporter dot",
-    "test:watch": "mocha test/**/*.test.js --watch --watch-files src,test --reporter dot"
+    "test": "npm run test:node",
+    "test:node": "node --test --test-reporter=dot test/**/*.test.js",
+    "test:watch": "node --test --test-reporter=dot --watch test/**/*.test.js"
   },
   "files": [
     "*.d.ts",

--- a/packages/rollup-plugin-copy/test/integration.test.js
+++ b/packages/rollup-plugin-copy/test/integration.test.js
@@ -1,4 +1,6 @@
-const path = require('path');
+const { describe, it } = require('node:test');
+const path = require('node:path');
+
 const { expect } = require('chai');
 const rollup = require('rollup');
 

--- a/packages/rollup-plugin-copy/test/listFiles.test.js
+++ b/packages/rollup-plugin-copy/test/listFiles.test.js
@@ -1,4 +1,6 @@
-const path = require('path');
+const { describe, it } = require('node:test');
+const path = require('node:path');
+
 const { expect } = require('chai');
 
 const { listFiles } = require('../src/listFiles.js');

--- a/packages/rollup-plugin-copy/test/patternsToFiles.test.js
+++ b/packages/rollup-plugin-copy/test/patternsToFiles.test.js
@@ -1,4 +1,6 @@
-const path = require('path');
+const { describe, it } = require('node:test');
+const path = require('node:path');
+
 const { expect } = require('chai');
 
 const { patternsToFiles } = require('../src/patternsToFiles.js');


### PR DESCRIPTION
I've been wanting to experiment with `node:test` as a replacement for `mocha` and thought I'd give it a try in `rollup-plugin-copy`.