### PR TITLE
feat: Add option to modify chokidar watchOptions with @web/dev-server

### DIFF
--- a/packages/dev-server-core/src/server/DevServer.ts
+++ b/packages/dev-server-core/src/server/DevServer.ts
@@ -18,7 +18,7 @@ export class DevServer {
   constructor(
     public config: DevServerCoreConfig,
     public logger: Logger,
-    public fileWatcher = chokidar.watch([]),
+    public fileWatcher = chokidar.watch([], config.chokidarOptions),
   ) {
     if (!config) throw new Error('Missing config.');
     if (!logger) throw new Error('Missing logger.');

--- a/packages/dev-server-core/src/server/DevServerCoreConfig.ts
+++ b/packages/dev-server-core/src/server/DevServerCoreConfig.ts
@@ -1,6 +1,7 @@
 import { Middleware } from 'koa';
 import { Plugin } from '../plugins/Plugin';
 import { Server } from 'net';
+import chokidar from 'chokidar';
 
 export type MimeTypeMappings = Record<string, string>;
 
@@ -67,4 +68,9 @@ export interface DevServerCoreConfig {
    * Useful when you want more control over when files are build (e.g. when doing a test run using @web/test-runner).
    */
   disableFileWatcher?: boolean;
+
+  /**
+   * Additional options you want to provide to chokidar file watcher
+   */
+  chokidarOptions?: chokidar.WatchOptions;
 }

--- a/packages/dev-server/src/config/parseConfig.ts
+++ b/packages/dev-server/src/config/parseConfig.ts
@@ -16,6 +16,7 @@ const defaultConfig: Partial<DevServerConfig> = {
   clearTerminalOnReload: true,
   middleware: [],
   plugins: [],
+  chokidarOptions: {},
 };
 
 function validate(config: Record<string, unknown>, key: string, type: string) {


### PR DESCRIPTION
## What I did

1. Added option to provide chokidar Watchoptions to the web dev server watcher. This is due to numerous errors with especially windows environments not being able to utilize the dev server due to watch/file update errors.

Examples of said error happening

- https://github.com/facebook/create-react-app/issues/10253
- https://github.com/paulmillr/chokidar/issues/1297
- https://github.com/modernweb-dev/web/issues/2221

With this, we are able to provide a non-changed environment for all users, but provide extra configurability to the file watchers ( and therefore to caching, watchers, etc.) through the chokidarOptions tag.


---

Is there any other parts of the codebase this should touch? I'm not too familiar with changesets etc so please advice

