### PR TITLE
fix(storybook-builder): import both globals and globalsNameReferenceM…

### DIFF
--- a/.changeset/khaki-melons-attack.md
+++ b/.changeset/khaki-melons-attack.md
@@ -1,0 +1,5 @@
+---
+'@web/storybook-builder': patch
+---
+
+fix: import both globals and globalsNameReferenceMap from @storybook/preview/globals and use the one that is set. This fixes issue https://github.com/modernweb-dev/web/issues/2619

--- a/packages/storybook-builder/src/index.ts
+++ b/packages/storybook-builder/src/index.ts
@@ -1,7 +1,9 @@
 import rollupPluginNodeResolve from '@rollup/plugin-node-resolve';
 import { getBuilderOptions } from '@storybook/core-common';
 import { logger } from '@storybook/node-logger';
-import { globals } from '@storybook/preview/globals';
+// Import both globals and globalsNameReferenceMap to prevent retrocompatibility.
+// @ts-ignore
+import { globals, globalsNameReferenceMap } from '@storybook/preview/globals';
 import type { Builder, Options, StorybookConfig as StorybookConfigBase } from '@storybook/types';
 import { DevServerConfig, mergeConfigs, startDevServer } from '@web/dev-server';
 import type { DevServer } from '@web/dev-server-core';
@@ -74,7 +76,7 @@ export const start: WdsBuilder['start'] = async ({ startTime, options, router, s
       },
       wdsPluginPrebundleModules(env),
       wdsPluginStorybookBuilder(options),
-      wdsPluginExternalGlobals(globals),
+      wdsPluginExternalGlobals(globalsNameReferenceMap || globals),
     ],
   };
 
@@ -146,7 +148,7 @@ export const build: WdsBuilder['build'] = async ({ startTime, options }) => {
       rollupPluginNodeResolve(),
       rollupPluginPrebundleModules(env),
       rollupPluginStorybookBuilder(options),
-      rollupPluginExternalGlobals(globals),
+      rollupPluginExternalGlobals(globalsNameReferenceMap || globals),
     ],
   };
 


### PR DESCRIPTION
…ap from @storybook/preview/globals

## What I did

1. Import both globals and globalsNameReferenceMap exports from @storybook/preview/globals.
2. Instead of using globals, only use it when globalsNameReferenceMap has no value to preserve retrocompatibility.
