### PR TITLE
fix: mocks timing issue

### DIFF
--- a/.changeset/friendly-seahorses-serve.md
+++ b/.changeset/friendly-seahorses-serve.md
@@ -1,0 +1,5 @@
+---
+'@web/mocks': patch
+---
+
+workaround for MSW breaking change


### PR DESCRIPTION
## What I did

1. Works around the breaking change caused by `msw@2.1.0` https://github.com/mswjs/msw/issues/1981
