### PR TITLE
fix: remove vulnerability by updating `ip` package

### DIFF
--- a/.changeset/grumpy-foxes-laugh.md
+++ b/.changeset/grumpy-foxes-laugh.md
@@ -1,0 +1,12 @@
+---
+'@web/test-runner-browserstack': patch
+'@web/test-runner-saucelabs': patch
+'@web/test-runner-core': patch
+'@web/dev-server': patch
+---
+
+Vulnerability fix in `ip` package.
+For more info, see:
+
+- https://github.com/advisories/GHSA-78xj-cgh5-2h22
+- https://github.com/indutny/node-ip/issues/136#issuecomment-1952083593

--- a/package-lock.json
+++ b/package-lock.json
@@ -35747,20 +35747,20 @@
     },
     "packages/dev-server": {
       "name": "@web/dev-server",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.11",
         "@types/command-line-args": "^5.0.0",
         "@web/config-loader": "^0.3.0",
-        "@web/dev-server-core": "^0.7.0",
+        "@web/dev-server-core": "^0.7.1",
         "@web/dev-server-rollup": "^0.6.1",
         "camelcase": "^6.2.0",
         "command-line-args": "^5.1.1",
         "command-line-usage": "^7.0.1",
         "debounce": "^1.2.0",
         "deepmerge": "^4.2.2",
-        "ip": "^1.1.5",
+        "ip": "^2.0.1",
         "nanocolors": "^0.2.1",
         "open": "^8.0.2",
         "portfinder": "^1.0.32"
@@ -35780,7 +35780,7 @@
     },
     "packages/dev-server-core": {
       "name": "@web/dev-server-core",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@types/koa": "^2.11.6",
@@ -36307,6 +36307,11 @@
         "node": ">=12.20.0"
       }
     },
+    "packages/dev-server/node_modules/ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
+    },
     "packages/dev-server/node_modules/table-layout": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-3.0.2.tgz",
@@ -36348,7 +36353,7 @@
     },
     "packages/mocks": {
       "name": "@web/mocks",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@storybook/manager-api": "^7.0.0",
@@ -36738,7 +36743,7 @@
     },
     "packages/storybook-builder": {
       "name": "@web/storybook-builder",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@chialab/esbuild-plugin-commonjs": "^0.17.2",
@@ -36995,7 +37000,7 @@
       "dependencies": {
         "@web/test-runner-webdriver": "^0.8.0",
         "browserstack-local": "^1.4.8",
-        "ip": "^1.1.5",
+        "ip": "^2.0.1",
         "nanoid": "^3.1.25"
       },
       "devDependencies": {
@@ -37006,6 +37011,11 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "packages/test-runner-browserstack/node_modules/ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
     },
     "packages/test-runner-chrome": {
       "name": "@web/test-runner-chrome",
@@ -37085,7 +37095,7 @@
         "debounce": "^1.2.0",
         "dependency-graph": "^0.11.0",
         "globby": "^11.0.1",
-        "ip": "^1.1.5",
+        "ip": "^2.0.1",
         "istanbul-lib-coverage": "^3.0.0",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.0.2",
@@ -37120,6 +37130,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "packages/test-runner-core/node_modules/ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
     },
     "packages/test-runner-core/node_modules/istanbul-lib-report": {
       "version": "3.0.1",
@@ -37276,7 +37291,7 @@
       "license": "MIT",
       "dependencies": {
         "@web/test-runner-webdriver": "^0.8.0",
-        "ip": "^1.1.5",
+        "ip": "^2.0.1",
         "nanoid": "^3.1.25",
         "saucelabs": "^7.2.0",
         "webdriver": "^8.8.6",
@@ -37291,6 +37306,11 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "packages/test-runner-saucelabs/node_modules/ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
     },
     "packages/test-runner-selenium": {
       "name": "@web/test-runner-selenium",

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -65,7 +65,7 @@
     "command-line-usage": "^7.0.1",
     "debounce": "^1.2.0",
     "deepmerge": "^4.2.2",
-    "ip": "^1.1.5",
+    "ip": "^2.0.1",
     "nanocolors": "^0.2.1",
     "open": "^8.0.2",
     "portfinder": "^1.0.32"

--- a/packages/test-runner-browserstack/package.json
+++ b/packages/test-runner-browserstack/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@web/test-runner-webdriver": "^0.8.0",
     "browserstack-local": "^1.4.8",
-    "ip": "^1.1.5",
+    "ip": "^2.0.1",
     "nanoid": "^3.1.25"
   },
   "devDependencies": {

--- a/packages/test-runner-core/package.json
+++ b/packages/test-runner-core/package.json
@@ -68,7 +68,7 @@
     "debounce": "^1.2.0",
     "dependency-graph": "^0.11.0",
     "globby": "^11.0.1",
-    "ip": "^1.1.5",
+    "ip": "^2.0.1",
     "istanbul-lib-coverage": "^3.0.0",
     "istanbul-lib-report": "^3.0.1",
     "istanbul-reports": "^3.0.2",

--- a/packages/test-runner-saucelabs/package.json
+++ b/packages/test-runner-saucelabs/package.json
@@ -47,7 +47,7 @@
   ],
   "dependencies": {
     "@web/test-runner-webdriver": "^0.8.0",
-    "ip": "^1.1.5",
+    "ip": "^2.0.1",
     "nanoid": "^3.1.25",
     "saucelabs": "^7.2.0",
     "webdriver": "^8.8.6",


### PR DESCRIPTION
## What I did

Update `ip` dependency to latest version containing the fix.

> N.B. I added this as a patch release, since ip is [only used internally (for the address method)](https://github.com/search?q=repo%3Amodernweb-dev%2Fweb%20%27ip%27%3B&type=code). Also, it needs to reach as many consumers as possible, since it's quite a critical vulnerability: https://github.com/advisories/GHSA-78xj-cgh5-2h22

