### PR TITLE
Set fetchPriority of polyfills to high

### DIFF
--- a/packages/polyfills-loader/src/createPolyfillsLoader.ts
+++ b/packages/polyfills-loader/src/createPolyfillsLoader.ts
@@ -21,6 +21,7 @@ const loadScriptFunction = `
   function loadScript(src, type, attributes) {
     return new Promise(function (resolve) {
       var script = document.createElement('script');
+      script.fetchPriority = 'high';
       function onLoaded() {
         if (script.parentElement) {
           script.parentElement.removeChild(script);
@@ -221,6 +222,7 @@ export async function createPolyfillsLoader(
 
       if (${coreJs.test}) {
         var s = document.createElement('script');
+        s.fetchPriority = 'high';
         function onLoaded() {
           document.head.removeChild(s);
           polyfillsLoader();


### PR DESCRIPTION
I set the `fetchPriority` of polyfill scripts to `high` to hint to the browser that these are important scripts that should have a high priority.

For browsers that don't support this attribute this operation is a no-op.

## Reading 📖 

https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchPriority
