### PR TITLE
Update Slack page and add link to Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ There is much, much more to come so follow us on [Twitter](https://twitter.com/m
 
 We are always looking for contributors of all skill levels! If you're looking to ease your way into the project, try out a [good first issue](https://github.com/modernweb-dev/web/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
-If you are interested in helping contribute to Modern Web, please take a look at our [Contributing Guide](https://github.com/modernweb-dev/web/blob/master/CONTRIBUTING.md). Also, feel free to drop into [Slack](https://modern-web.dev/discover/slack/) and say hi. 👋
+If you are interested in helping contribute to Modern Web, please take a look at our [Contributing Guide](https://github.com/modernweb-dev/web/blob/master/CONTRIBUTING.md). Also, feel free to drop into [Discord](https://modern-web.dev/discover/discord/) and say hi. 👋
 
 ## Sponsored by
 

--- a/docs/_data/footer.json
+++ b/docs/_data/footer.json
@@ -28,8 +28,8 @@
         "href": "https://twitter.com/modern_web_dev"
       },
       {
-        "text": "Slack",
-        "href": "/discover/slack/"
+        "text": "Discord",
+        "href": "/discover/discord/"
       }
     ]
   },

--- a/docs/discover/discord.md
+++ b/docs/discover/discord.md
@@ -1,0 +1,3 @@
+# Discord
+
+[Join our Discord](https://discord.com/invite/sTdpM2rkKJ)

--- a/docs/discover/slack.md
+++ b/docs/discover/slack.md
@@ -1,5 +1,3 @@
 # Slack
 
-You can also find us on the Lit & Friends Slack in the [#open-wc](https://lit-and-friends.slack.com/archives/CE6D9DN05) channel.
-
-You can join the Lit & Friends Slack by visiting [https://lit.dev/slack-invite](https://lit.dev/slack-invite).
+Sorry, but we're no longer on Slack. Head on over to [our Discord page](/discover/discord) instead!


### PR DESCRIPTION
## What I did

1. Added a Discord page to replace the Slack page, since the channel is no longer active
2. Updated the Slack page to point to a new Discord page
3. Removed a link to the old Lit & Friends group since that's also no longer active

There isn't much content on the Discord page, so feel free to add whatever else you'd like to put there.
