### PR TITLE
helper-libraries.md: mention semantic-dom-diff instead

### DIFF
--- a/docs/docs/test-runner/writing-tests/helper-libraries.md
+++ b/docs/docs/test-runner/writing-tests/helper-libraries.md
@@ -18,7 +18,7 @@ expect(undefined).to.not.be.a('function');
 
 ## Chai plugins
 
-- [@open-wc/chai-dom-equals](https://www.npmjs.com/package/@open-wc/chai-dom-equals) for diffing HTML
+- [@open-wc/semantic-dom-diff](https://www.npmjs.com/package/@open-wc/semantic-dom-diff) for diffing HTML
 - [chai-a11y-axe](https://www.npmjs.com/package/chai-a11y-axe) for testing accessibility
 
 ## Testing helpers


### PR DESCRIPTION
...instead of the deprecated one.

## What I did

1. I followed the link, saw that the NPM.js page touted the chai plugin in the successor library
2. Changed the wording, the link
