### PR TITLE
feat(rollup-plugin-html): glob patterns exclusion for external assets

### DIFF
--- a/.changeset/nervous-bugs-rhyme.md
+++ b/.changeset/nervous-bugs-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@web/rollup-plugin-html': minor
+---
+
+glob patterns exclusion for external assets

--- a/docs/docs/building/rollup-plugin-html.md
+++ b/docs/docs/building/rollup-plugin-html.md
@@ -362,6 +362,8 @@ export interface RollupPluginHTMLOptions {
   transformHtml?: TransformHtmlFunction | TransformHtmlFunction[];
   /** Whether to extract and bundle assets referenced in HTML. Defaults to true. */
   extractAssets?: boolean;
+  /** Whether to ignore assets referenced in HTML and CSS with glob patterns. */
+  externalAssets?: string | string[];
   /** Define a full absolute url to your site (e.g. https://domain.com) */
   absoluteBaseUrl?: string;
   /** Whether to set full absolute urls for ['meta[property=og:image]', 'link[rel=canonical]', 'meta[property=og:url]'] or not. Requires a absoluteBaseUrl to be set. Default to true. */

--- a/package-lock.json
+++ b/package-lock.json
@@ -41551,10 +41551,12 @@
         "glob": "^10.0.0",
         "html-minifier-terser": "^7.1.0",
         "lightningcss": "^1.24.0",
-        "parse5": "^6.0.1"
+        "parse5": "^6.0.1",
+        "picomatch": "^2.2.2"
       },
       "devDependencies": {
         "@types/html-minifier-terser": "^7.0.0",
+        "@types/picomatch": "^2.2.1",
         "rollup": "^4.4.0"
       },
       "engines": {

--- a/packages/rollup-plugin-html/package.json
+++ b/packages/rollup-plugin-html/package.json
@@ -48,10 +48,12 @@
     "glob": "^10.0.0",
     "html-minifier-terser": "^7.1.0",
     "lightningcss": "^1.24.0",
-    "parse5": "^6.0.1"
+    "parse5": "^6.0.1",
+    "picomatch": "^4.0.1"
   },
   "devDependencies": {
     "@types/html-minifier-terser": "^7.0.0",
-    "rollup": "^4.4.0"
+    "rollup": "^4.4.0",
+    "@types/picomatch": "^2.3.3"
   }
 }

--- a/packages/rollup-plugin-html/package.json
+++ b/packages/rollup-plugin-html/package.json
@@ -49,11 +49,11 @@
     "html-minifier-terser": "^7.1.0",
     "lightningcss": "^1.24.0",
     "parse5": "^6.0.1",
-    "picomatch": "^4.0.1"
+    "picomatch": "^2.2.2"
   },
   "devDependencies": {
     "@types/html-minifier-terser": "^7.0.0",
-    "rollup": "^4.4.0",
-    "@types/picomatch": "^2.3.3"
+    "@types/picomatch": "^2.2.1",
+    "rollup": "^4.4.0"
   }
 }

--- a/packages/rollup-plugin-html/src/RollupPluginHTMLOptions.ts
+++ b/packages/rollup-plugin-html/src/RollupPluginHTMLOptions.ts
@@ -29,6 +29,8 @@ export interface RollupPluginHTMLOptions {
   transformHtml?: TransformHtmlFunction | TransformHtmlFunction[];
   /** Whether to extract and bundle assets referenced in HTML. Defaults to true. */
   extractAssets?: boolean;
+  /** Whether to ignore assets referenced in HTML and CSS with glob patterns. */
+  externalAssets?: string | string[];
   /** Define a full absolute url to your site (e.g. https://domain.com) */
   absoluteBaseUrl?: string;
   /** Whether to set full absolute urls for ['meta[property=og:image]', 'link[rel=canonical]', 'meta[property=og:url]'] or not. Requires a absoluteBaseUrl to be set. Default to true. */

--- a/packages/rollup-plugin-html/src/assets/utils.ts
+++ b/packages/rollup-plugin-html/src/assets/utils.ts
@@ -1,5 +1,6 @@
 import { Document, Element } from 'parse5';
 import path from 'path';
+import picomatch from 'picomatch';
 import { findElements, getTagName, getAttribute } from '@web/parse5-utils';
 import { createError } from '../utils.js';
 import { serialize } from 'v8';
@@ -142,4 +143,12 @@ export function getSourcePaths(node: Element) {
 
 export function findAssets(document: Document) {
   return findElements(document, isAsset);
+}
+
+// picomatch follows glob spec and requires "./" to be removed for the matcher to work
+// it is safe, because with or without it resolves to the same file
+// read more: https://github.com/micromatch/picomatch/issues/77
+const removeLeadingSlash = (str: string) => (str.startsWith('./') ? str.slice(2) : str);
+export function createAssetPicomatchMatcher(glob?: string | string[]) {
+  return picomatch(glob || [], { format: removeLeadingSlash });
 }

--- a/packages/rollup-plugin-html/src/input/extract/extractAssets.ts
+++ b/packages/rollup-plugin-html/src/input/extract/extractAssets.ts
@@ -1,6 +1,7 @@
 import { Document, serialize } from 'parse5';
 import fs from 'fs';
 import path from 'path';
+import picomatch from 'picomatch';
 import { InputAsset } from '../InputData.js';
 import {
   findAssets,
@@ -14,6 +15,7 @@ export interface ExtractAssetsParams {
   htmlFilePath: string;
   htmlDir: string;
   rootDir: string;
+  externalAssets?: string | string[];
   absolutePathPrefix?: string;
 }
 
@@ -24,6 +26,9 @@ export function extractAssets(params: ExtractAssetsParams): InputAsset[] {
   for (const node of assetNodes) {
     const sourcePaths = getSourcePaths(node);
     for (const sourcePath of sourcePaths) {
+      const isExternal = picomatch(params.externalAssets || []);
+      if (isExternal(sourcePath)) continue;
+
       const filePath = resolveAssetFilePath(
         sourcePath,
         params.htmlDir,

--- a/packages/rollup-plugin-html/src/input/extract/extractAssets.ts
+++ b/packages/rollup-plugin-html/src/input/extract/extractAssets.ts
@@ -1,13 +1,13 @@
 import { Document, serialize } from 'parse5';
 import fs from 'fs';
 import path from 'path';
-import picomatch from 'picomatch';
 import { InputAsset } from '../InputData.js';
 import {
   findAssets,
   getSourcePaths,
   isHashedAsset,
   resolveAssetFilePath,
+  createAssetPicomatchMatcher,
 } from '../../assets/utils.js';
 
 export interface ExtractAssetsParams {
@@ -22,7 +22,7 @@ export interface ExtractAssetsParams {
 export function extractAssets(params: ExtractAssetsParams): InputAsset[] {
   const assetNodes = findAssets(params.document);
   const allAssets: InputAsset[] = [];
-  const isExternal = picomatch(params.externalAssets || []);
+  const isExternal = createAssetPicomatchMatcher(params.externalAssets);
 
   for (const node of assetNodes) {
     const sourcePaths = getSourcePaths(node);

--- a/packages/rollup-plugin-html/src/input/extract/extractAssets.ts
+++ b/packages/rollup-plugin-html/src/input/extract/extractAssets.ts
@@ -22,11 +22,11 @@ export interface ExtractAssetsParams {
 export function extractAssets(params: ExtractAssetsParams): InputAsset[] {
   const assetNodes = findAssets(params.document);
   const allAssets: InputAsset[] = [];
+  const isExternal = picomatch(params.externalAssets || []);
 
   for (const node of assetNodes) {
     const sourcePaths = getSourcePaths(node);
     for (const sourcePath of sourcePaths) {
-      const isExternal = picomatch(params.externalAssets || []);
       if (isExternal(sourcePath)) continue;
 
       const filePath = resolveAssetFilePath(

--- a/packages/rollup-plugin-html/src/input/extract/extractModulesAndAssets.ts
+++ b/packages/rollup-plugin-html/src/input/extract/extractModulesAndAssets.ts
@@ -8,11 +8,12 @@ export interface ExtractParams {
   htmlFilePath: string;
   rootDir: string;
   extractAssets: boolean;
+  externalAssets?: string | string[];
   absolutePathPrefix?: string;
 }
 
 export function extractModulesAndAssets(params: ExtractParams) {
-  const { html, htmlFilePath, rootDir, absolutePathPrefix } = params;
+  const { html, htmlFilePath, rootDir, externalAssets, absolutePathPrefix } = params;
   const htmlDir = path.dirname(htmlFilePath);
   const document = parse(html);
 
@@ -24,7 +25,14 @@ export function extractModulesAndAssets(params: ExtractParams) {
     absolutePathPrefix,
   });
   const assets = params.extractAssets
-    ? extractAssets({ document, htmlDir, htmlFilePath, rootDir, absolutePathPrefix })
+    ? extractAssets({
+        document,
+        htmlDir,
+        htmlFilePath,
+        rootDir,
+        externalAssets,
+        absolutePathPrefix,
+      })
     : [];
 
   // turn mutated AST back to a string

--- a/packages/rollup-plugin-html/src/input/getInputData.ts
+++ b/packages/rollup-plugin-html/src/input/getInputData.ts
@@ -31,17 +31,20 @@ export interface CreateInputDataParams {
   rootDir: string;
   filePath?: string;
   extractAssets: boolean;
+  externalAssets?: string | string[];
   absolutePathPrefix?: string;
 }
 
 function createInputData(params: CreateInputDataParams): InputData {
-  const { name, html, rootDir, filePath, extractAssets, absolutePathPrefix } = params;
+  const { name, html, rootDir, filePath, extractAssets, externalAssets, absolutePathPrefix } =
+    params;
   const htmlFilePath = filePath ? filePath : path.resolve(rootDir, name);
   const result = extractModulesAndAssets({
     html,
     htmlFilePath,
     rootDir,
     extractAssets,
+    externalAssets,
     absolutePathPrefix,
   });
 
@@ -63,6 +66,7 @@ export function getInputData(
     rootDir = process.cwd(),
     flattenOutput,
     extractAssets = true,
+    externalAssets,
     absolutePathPrefix,
     exclude: ignore,
   } = pluginOptions;
@@ -77,6 +81,7 @@ export function getInputData(
         html: input.html,
         rootDir,
         extractAssets,
+        externalAssets,
         absolutePathPrefix,
       });
       result.push(data);
@@ -97,6 +102,7 @@ export function getInputData(
           rootDir,
           filePath,
           extractAssets,
+          externalAssets,
           absolutePathPrefix,
         });
         result.push(data);

--- a/packages/rollup-plugin-html/src/output/emitAssets.ts
+++ b/packages/rollup-plugin-html/src/output/emitAssets.ts
@@ -4,6 +4,7 @@ import { transform } from 'lightningcss';
 import fs from 'fs';
 
 import { InputAsset, InputData } from '../input/InputData';
+import { createAssetPicomatchMatcher } from '../assets/utils.js';
 import { RollupPluginHTMLOptions, TransformAssetFunction } from '../RollupPluginHTMLOptions';
 
 export interface EmittedAssets {
@@ -81,6 +82,7 @@ export async function emitAssets(
 
       let ref: string;
       let basename = path.basename(asset.filePath);
+      const isExternal = createAssetPicomatchMatcher(options.externalAssets);
       const emittedExternalAssets = new Map();
       if (asset.hashed) {
         if (basename.endsWith('.css') && options.bundleAssetsFromCss) {
@@ -95,7 +97,7 @@ export async function emitAssets(
                 // https://www.w3.org/TR/html4/types.html#:~:text=ID%20and%20NAME%20tokens%20must,tokens%20defined%20by%20other%20attributes.
                 const [filePath, idRef] = url.url.split('#');
 
-                if (shouldHandleAsset(filePath)) {
+                if (shouldHandleAsset(filePath) && !isExternal(filePath)) {
                   // Read the asset file, get the asset from the source location on the FS using asset.filePath
                   const assetLocation = path.resolve(path.dirname(asset.filePath), filePath);
                   const assetContent = fs.readFileSync(assetLocation);

--- a/packages/rollup-plugin-html/src/output/getOutputHTML.ts
+++ b/packages/rollup-plugin-html/src/output/getOutputHTML.ts
@@ -53,6 +53,7 @@ export async function getOutputHTML(params: GetOutputHTMLParams) {
       outputDir,
       rootDir,
       emittedAssets,
+      externalAssets: pluginOptions.externalAssets,
       absolutePathPrefix,
       publicPath: pluginOptions.publicPath,
     });

--- a/packages/rollup-plugin-html/src/output/injectedUpdatedAssetPaths.ts
+++ b/packages/rollup-plugin-html/src/output/injectedUpdatedAssetPaths.ts
@@ -1,7 +1,6 @@
 import { getAttribute, setAttribute } from '@web/parse5-utils';
 import { Document } from 'parse5';
 import path from 'path';
-import picomatch from 'picomatch';
 
 import {
   findAssets,
@@ -9,6 +8,7 @@ import {
   getSourcePaths,
   isHashedAsset,
   resolveAssetFilePath,
+  createAssetPicomatchMatcher,
 } from '../assets/utils.js';
 import { InputData } from '../input/InputData.js';
 import { createError } from '../utils.js';
@@ -49,7 +49,7 @@ export function injectedUpdatedAssetPaths(args: InjectUpdatedAssetPathsArgs) {
     absolutePathPrefix,
   } = args;
   const assetNodes = findAssets(document);
-  const isExternal = picomatch(externalAssets || []);
+  const isExternal = createAssetPicomatchMatcher(externalAssets);
 
   for (const node of assetNodes) {
     const sourcePaths = getSourcePaths(node);

--- a/packages/rollup-plugin-html/src/output/injectedUpdatedAssetPaths.ts
+++ b/packages/rollup-plugin-html/src/output/injectedUpdatedAssetPaths.ts
@@ -1,6 +1,7 @@
 import { getAttribute, setAttribute } from '@web/parse5-utils';
 import { Document } from 'parse5';
 import path from 'path';
+import picomatch from 'picomatch';
 
 import {
   findAssets,
@@ -20,6 +21,7 @@ export interface InjectUpdatedAssetPathsArgs {
   outputDir: string;
   rootDir: string;
   emittedAssets: EmittedAssets;
+  externalAssets?: string | string[];
   publicPath?: string;
   absolutePathPrefix?: string;
 }
@@ -42,6 +44,7 @@ export function injectedUpdatedAssetPaths(args: InjectUpdatedAssetPathsArgs) {
     outputDir,
     rootDir,
     emittedAssets,
+    externalAssets,
     publicPath = './',
     absolutePathPrefix,
   } = args;
@@ -50,6 +53,9 @@ export function injectedUpdatedAssetPaths(args: InjectUpdatedAssetPathsArgs) {
   for (const node of assetNodes) {
     const sourcePaths = getSourcePaths(node);
     for (const sourcePath of sourcePaths) {
+      const isExternal = picomatch(externalAssets || []);
+      if (isExternal(sourcePath)) continue;
+
       const htmlFilePath = input.filePath ? input.filePath : path.join(rootDir, input.name);
       const htmlDir = path.dirname(htmlFilePath);
       const filePath = resolveAssetFilePath(sourcePath, htmlDir, rootDir, absolutePathPrefix);

--- a/packages/rollup-plugin-html/src/output/injectedUpdatedAssetPaths.ts
+++ b/packages/rollup-plugin-html/src/output/injectedUpdatedAssetPaths.ts
@@ -49,11 +49,11 @@ export function injectedUpdatedAssetPaths(args: InjectUpdatedAssetPathsArgs) {
     absolutePathPrefix,
   } = args;
   const assetNodes = findAssets(document);
+  const isExternal = picomatch(externalAssets || []);
 
   for (const node of assetNodes) {
     const sourcePaths = getSourcePaths(node);
     for (const sourcePath of sourcePaths) {
-      const isExternal = picomatch(externalAssets || []);
       if (isExternal(sourcePath)) continue;
 
       const htmlFilePath = input.filePath ? input.filePath : path.join(rootDir, input.name);

--- a/packages/rollup-plugin-html/test/fixtures/assets/image-d.png
+++ b/packages/rollup-plugin-html/test/fixtures/assets/image-d.png
@@ -1,0 +1,1 @@
+image-d.png

--- a/packages/rollup-plugin-html/test/fixtures/assets/image-d.svg
+++ b/packages/rollup-plugin-html/test/fixtures/assets/image-d.svg
@@ -1,0 +1,1 @@
+image-d.svg

--- a/packages/rollup-plugin-html/test/fixtures/assets/styles-with-referenced-assets.css
+++ b/packages/rollup-plugin-html/test/fixtures/assets/styles-with-referenced-assets.css
@@ -1,0 +1,15 @@
+#a1 {
+  background-image: url('image-a.png');
+}
+
+#a2 {
+  background-image: url('image-a.svg');
+}
+
+#d1 {
+  background-image: url('./image-d.png');
+}
+
+#d2 {
+  background-image: url('./image-d.svg');
+}


### PR DESCRIPTION
Fixes #811

## What I did

1. Added a plugin option for providing glob patterns in order to exclude assets from being extracted.

Very useful for stuff that already lives in a `public` folder and are copied as-is.


## Why?

`extractAssets` is all or nothing.

`transformAssets` doesn't provide a way to skip an asset.

Also related: #2631