### PR TITLE
fix(storybook-builder): fix tocbot default import by @storybook/blocks

### DIFF
--- a/.changeset/four-scissors-greet.md
+++ b/.changeset/four-scissors-greet.md
@@ -1,0 +1,5 @@
+---
+'@web/storybook-builder': patch
+---
+
+fix tocbot default import by @storybook/blocks

--- a/packages/storybook-builder/src/esbuild-plugin-commonjs-named-exports.ts
+++ b/packages/storybook-builder/src/esbuild-plugin-commonjs-named-exports.ts
@@ -19,7 +19,13 @@ export function esbuildPluginCommonjsNamedExports(module: string, namedExports: 
           contents: `
             import { default as commonjsExports } from '${module}?force-original';
             ${namedExports
-              .map(name => `export const ${name} = commonjsExports.${name};`)
+              .map(name => {
+                if (name === 'default') {
+                  return `export default commonjsExports;`;
+                } else {
+                  return `export const ${name} = commonjsExports.${name};`;
+                }
+              })
               .join('\n')}
           `,
         };

--- a/packages/storybook-builder/src/rollup-plugin-prebundle-modules.ts
+++ b/packages/storybook-builder/src/rollup-plugin-prebundle-modules.ts
@@ -50,7 +50,7 @@ export function rollupPluginPrebundleModules(env: Record<string, string>): Plugi
           /* for @storybook/addon-docs */
           // tocbot can't be automatically transformed by @chialab/esbuild-plugin-commonjs
           // so we need a manual wrapper
-          esbuildPluginCommonjsNamedExports('tocbot', ['init', 'destroy']),
+          esbuildPluginCommonjsNamedExports('tocbot', ['default', 'init', 'destroy']),
 
           esbuildPluginCommonjs(),
         ],


### PR DESCRIPTION
## What I did

1. (storybook-builder): fix tocbot default import by @storybook/blocks

At least before 7.4.0 the Storybook used `default` import from `tocbot`.
I noticed that when testing in #2485
At some point it was changed to named `init` and `destroy`, therefore I didn't noticed this in my manual test earlier with later versions.
For backwards compatibility it's best to fix this.