### PR TITLE
fix(storybook-builder): simplify and speed up the CommonJS to ESM transformation

### DIFF
--- a/.changeset/warm-poems-watch.md
+++ b/.changeset/warm-poems-watch.md
@@ -1,0 +1,6 @@
+---
+'@web/storybook-builder': patch
+---
+
+simplify and speed up the CommonJS to ESM transformation
+make React conditional reexports work in production

--- a/package-lock.json
+++ b/package-lock.json
@@ -2681,66 +2681,6 @@
         "prettier": "^2.7.1"
       }
     },
-    "node_modules/@chialab/cjs-to-esm": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@chialab/cjs-to-esm/-/cjs-to-esm-0.17.11.tgz",
-      "integrity": "sha512-yzIKx1J7ykDoKm+CQXw/gkI0B3YbGDUAkkz70ohoPVI9stSeNwdvXMNcNwMQMndQleJkTS8aOi4j3JRrBbVAng==",
-      "license": "MIT",
-      "dependencies": {
-        "@chialab/estransform": "^0.17.3"
-      },
-      "engines": {
-        "node": ">=13"
-      }
-    },
-    "node_modules/@chialab/esbuild-plugin-commonjs": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@chialab/esbuild-plugin-commonjs/-/esbuild-plugin-commonjs-0.17.2.tgz",
-      "integrity": "sha512-C30UShSb89PJiO+mJTwAS1ei6aKVxMcxZQrl0g1JAJVd4d1AE6OjcbYlCs4847PcbmMNqYZrTcWpgIg+zRQL3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@chialab/cjs-to-esm": "^0.17.0",
-        "@chialab/esbuild-rna": "^0.17.0",
-        "@chialab/node-resolve": "^0.17.0"
-      },
-      "engines": {
-        "node": ">=13"
-      }
-    },
-    "node_modules/@chialab/esbuild-rna": {
-      "version": "0.17.8",
-      "resolved": "https://registry.npmjs.org/@chialab/esbuild-rna/-/esbuild-rna-0.17.8.tgz",
-      "integrity": "sha512-hovU4W5zlyMnbJjexdczpQ9mcUfFsJuv9FWUhzpXiQwPprlp5lul+frTed9s8AyVDTDq2yq3Gx2Ac411QsXYGA==",
-      "license": "MIT",
-      "dependencies": {
-        "@chialab/estransform": "^0.17.4",
-        "@chialab/node-resolve": "^0.17.1"
-      },
-      "engines": {
-        "node": ">=13"
-      }
-    },
-    "node_modules/@chialab/estransform": {
-      "version": "0.17.5",
-      "resolved": "https://registry.npmjs.org/@chialab/estransform/-/estransform-0.17.5.tgz",
-      "integrity": "sha512-maJUFkwk0ie0L4VvDO74NDYyRvaTQAI0qmSmrms8bZxUkZ+zQZd1ByWKDCYTRwtR6AOzTvgEOl2ZvEG+OUKv/A==",
-      "license": "MIT",
-      "dependencies": {
-        "@parcel/source-map": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=13"
-      }
-    },
-    "node_modules/@chialab/node-resolve": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@chialab/node-resolve/-/node-resolve-0.17.1.tgz",
-      "integrity": "sha512-YWaK0MKKeB0FILI6j7qiAlGoSC9MqJZDFXzlAgfOaMCbn8Feqh6njxv7mI3oVkdi7QwV6zPRaTN6hKig/NriMA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=13"
-      }
-    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -4601,18 +4541,6 @@
       "dependencies": {
         "@lit/reactive-element": "^1.0.0",
         "@open-wc/dedupe-mixin": "^1.4.0"
-      }
-    },
-    "node_modules/@parcel/source-map": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.1.1.tgz",
-      "integrity": "sha512-Ejx1P/mj+kMjQb8/y5XxDUn4reGdr+WyKYloBljpppUy8gs42T+BNoEOuRYqDVdgPc6NxduzIDoJS9pOFfV5Ew==",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^1.0.3"
-      },
-      "engines": {
-        "node": "^12.18.3 || >=14"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -14401,6 +14329,11 @@
       "dependencies": {
         "consola": "^3.2.3"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
     },
     "node_modules/clean-css": {
       "version": "5.3.2",
@@ -40137,7 +40070,7 @@
     },
     "packages/dev-server": {
       "name": "@web/dev-server",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.11",
@@ -40695,7 +40628,7 @@
     },
     "packages/dev-server-storybook": {
       "name": "@web/dev-server-storybook",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -40722,7 +40655,7 @@
       },
       "devDependencies": {
         "@types/path-is-inside": "^1.0.0",
-        "@web/dev-server": "^0.4.0",
+        "@web/dev-server": "^0.4.4",
         "htm": "^3.1.0"
       },
       "engines": {
@@ -41823,10 +41756,9 @@
     },
     "packages/storybook-builder": {
       "name": "@web/storybook-builder",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "dependencies": {
-        "@chialab/esbuild-plugin-commonjs": "^0.17.2",
         "@rollup/plugin-node-resolve": "^15.1.0",
         "@rollup/pluginutils": "^5.0.2",
         "@storybook/core-common": "^7.0.0",
@@ -41837,6 +41769,7 @@
         "@web/dev-server-rollup": "^0.6.1",
         "@web/rollup-plugin-html": "^2.3.0",
         "browser-assert": "^1.2.1",
+        "cjs-module-lexer": "^1.2.3",
         "es-module-lexer": "^1.2.1",
         "esbuild": "^0.19.5",
         "express": "^4.18.2",

--- a/packages/storybook-builder/package.json
+++ b/packages/storybook-builder/package.json
@@ -47,7 +47,6 @@
     "esm"
   ],
   "dependencies": {
-    "@chialab/esbuild-plugin-commonjs": "^0.17.2",
     "@rollup/plugin-node-resolve": "^15.1.0",
     "@rollup/pluginutils": "^5.0.2",
     "@storybook/core-common": "^7.0.0",
@@ -58,6 +57,7 @@
     "@web/dev-server-rollup": "^0.6.1",
     "@web/rollup-plugin-html": "^2.3.0",
     "browser-assert": "^1.2.1",
+    "cjs-module-lexer": "^1.2.3",
     "es-module-lexer": "^1.2.1",
     "esbuild": "^0.19.5",
     "express": "^4.18.2",

--- a/packages/storybook-builder/src/esbuild-plugin-commonjs-named-exports.ts
+++ b/packages/storybook-builder/src/esbuild-plugin-commonjs-named-exports.ts
@@ -1,35 +1,86 @@
 import type { Plugin } from 'esbuild';
+import { readFile } from 'fs-extra';
+import { dirname } from 'path';
 
-export function esbuildPluginCommonjsNamedExports(module: string, namedExports: string[]): Plugin {
+export function esbuildPluginCommonjsNamedExports(modules: string[]): Plugin {
   return {
     name: 'commonjs-named-exports',
-    setup(build) {
-      build.onResolve({ filter: new RegExp(`^${module}$`) }, args => {
+    async setup(build) {
+      const { init, parse } = await import('cjs-module-lexer');
+      await init();
+
+      build.onResolve({ filter: new RegExp(`^(${modules.join('|')})$`) }, async args => {
+        if (args.pluginData?.preventInfiniteRecursion) return;
+
+        const { path, ...rest } = args;
+        rest.pluginData = { preventInfiniteRecursion: true };
+        const resolveResult = await build.resolve(path, rest);
+        const resolvedPath = resolveResult.path;
+
+        // skip if resolved to an ESM file
+        if (resolvedPath.endsWith('.mjs')) return;
+
+        const namedExports = await getNamedExports(resolvedPath);
+
+        // skip if nothing is exported
+        // (or was an ESM file with .js extension or just failed)
+        if (namedExports.length === 0) return;
+
         return {
           path: args.path,
-          namespace: `commonjs-named-exports-${module}`,
+          namespace: 'commonjs-named-exports',
           pluginData: {
             resolveDir: args.resolveDir,
+            resolvedPath,
+            namedExports,
           },
         };
       });
-      build.onLoad({ filter: /.*/, namespace: `commonjs-named-exports-${module}` }, async args => {
+
+      build.onLoad({ filter: /.*/, namespace: `commonjs-named-exports` }, async args => {
+        const { resolveDir, resolvedPath, namedExports } = args.pluginData;
+
+        const filteredNamedExports = namedExports.filter((name: string) => {
+          return (
+            // interop for "default" export heavily relies on the esbuild work done automatically
+            // we just always reexport it
+            // but we need to filter it out here to prevent double reexport if "default" was identified by the lexer
+            name !== 'default' &&
+            // we don't need "__esModule" flag in this wrapper
+            // because it outputs native ESM which will be consumed by other native ESM in the browser
+            name !== '__esModule'
+          );
+        });
+
+        const finalExports = ['default', ...filteredNamedExports];
+
         return {
-          resolveDir: args.pluginData.resolveDir,
-          contents: `
-            import { default as commonjsExports } from '${module}?force-original';
-            ${namedExports
-              .map(name => {
-                if (name === 'default') {
-                  return `export default commonjsExports;`;
-                } else {
-                  return `export const ${name} = commonjsExports.${name};`;
-                }
-              })
-              .join('\n')}
-          `,
+          resolveDir,
+          contents: `export { ${finalExports.join(',')} } from '${resolvedPath}';`,
         };
       });
+
+      async function getNamedExports(path: string): Promise<string[]> {
+        const source = await readFile(path, 'utf8');
+
+        let exports: string[] = [];
+        let reexports: string[] = [];
+        try {
+          ({ exports, reexports } = parse(source));
+        } catch (e) {
+          // good place to start debugging if imports are not working
+        }
+
+        for (const reexport of reexports) {
+          const reexportPath = require.resolve(reexport, { paths: [dirname(path)] });
+          const deepExports = await getNamedExports(reexportPath);
+          for (const deepExport of deepExports) {
+            exports.push(deepExport);
+          }
+        }
+
+        return exports;
+      }
     },
   };
 }


### PR DESCRIPTION
## What I did

1. simplify and speed up the CommonJS to ESM transformation
2. make React conditional reexports work in production
3. remove `@chialab/esbuild-plugin-commonjs` and use low-level `cjs-module-lexer`

2nd caused a bug when I started working on MDX and created a static build of the storybook, which made React break with missing reexports like `import { createContext } from 'react';`
this was due to a lack of support in `@chialab/esbuild-plugin-commonjs` for conditional CommonJS reexports, specifically in this file https://www.runpkg.com/?react@18.2.0/index.js

```js
// react@18.2.0/index.js
'use strict';

if (process.env.NODE_ENV === 'production') {
  module.exports = require('./cjs/react.production.min.js');
} else {
  module.exports = require('./cjs/react.development.js');
}
```

after hours of debugging, seeing the output of `@chialab/esbuild-plugin-commonjs` and trying to make a patch for it, I gave up an decided to try to make smth similar myself with the help of low-level tools, where https://www.npmjs.com/package/cjs-module-lexer seems to be the most mature and was used by `@chialab/esbuild-plugin-commonjs` under-the-hood

I think the end result is better than the previous in all aspects (simplicity, speed and the readability of the output) and it solves the bug of MDX which I'm working on in another branch