### PR TITLE
fix(storybook-builder): clean up .prebundled_modules before creating new bundles

### DIFF
--- a/.changeset/tricky-schools-unite.md
+++ b/.changeset/tricky-schools-unite.md
@@ -1,0 +1,5 @@
+---
+'@web/storybook-builder': patch
+---
+
+clean up `.prebundled_modules` before creating new bundles

--- a/packages/storybook-builder/src/rollup-plugin-prebundle-modules.ts
+++ b/packages/storybook-builder/src/rollup-plugin-prebundle-modules.ts
@@ -1,5 +1,6 @@
 import { stringifyProcessEnvs } from '@storybook/core-common';
 import { build } from 'esbuild';
+import { remove } from 'fs-extra';
 import { join } from 'path';
 import type { Plugin } from 'rollup';
 import { esbuildPluginCommonjsNamedExports } from './esbuild-plugin-commonjs-named-exports.js';
@@ -16,10 +17,12 @@ export function rollupPluginPrebundleModules(env: Record<string, string>): Plugi
     async buildStart() {
       const modules = CANDIDATES.filter(moduleExists);
 
+      const modulesDir = join(process.cwd(), PREBUNDLED_MODULES_DIR);
+      await remove(modulesDir);
+
       for (const module of modules) {
         modulePaths[module] = join(
-          process.cwd(),
-          PREBUNDLED_MODULES_DIR,
+          modulesDir,
           module.endsWith('.js') ? module.replace(/\.js$/, '.mjs') : `${module}.mjs`,
         );
       }


### PR DESCRIPTION
## What I did

1. clean up .prebundled_modules before creating new bundles

Using it as a cache is currently not supported and requires programming the logic to do checks of the original files, or relying on esbuild internal caching mechanism (if any), which is yet to be investigated and implemented.
For now this folder accumulates old bundled files and creates a lot of confusion when debugging it, that results in really poor DX when working on the library, so I decided to remove it between runs before the cache is implemented.