### PR TITLE
test-runner-module-mocking: bug when loaded normally in previous test before intercepted in next

### DIFF
--- a/packages/test-runner-module-mocking/test/fixtures/bug-cache/browser-test-1.js
+++ b/packages/test-runner-module-mocking/test/fixtures/bug-cache/browser-test-1.js
@@ -1,0 +1,14 @@
+import { expect } from '../chai.js';
+
+// this module gets improted here first and gets cached by the dev server
+// resulting in `import { getCurrentHour } from './time-library.js';` being cached too
+// the following test intercepts "time-library.js", but that has no impact on the cached "getTimeOfDay.js"
+// so the mocking won't work for any module we need to intercept inside "getTimeOfDay.js" in any following test
+import { getTimeOfDay } from './fixture/getTimeOfDay.js';
+
+describe('1st test', () => {
+  it('works', () => {
+    const timeOfDay = getTimeOfDay();
+    expect(typeof timeOfDay === 'string').to.equal(true);
+  });
+});

--- a/packages/test-runner-module-mocking/test/fixtures/bug-cache/browser-test-2.js
+++ b/packages/test-runner-module-mocking/test/fixtures/bug-cache/browser-test-2.js
@@ -1,0 +1,27 @@
+import { expect } from '../chai.js';
+import { importMockable } from '../../../browser/index.js';
+
+const path = new URL(import.meta.resolve('./fixture/time-library.js')).pathname;
+const timeLibrary = await importMockable(path);
+const { getTimeOfDay } = await import('./fixture/getTimeOfDay.js');
+
+let backup;
+describe('2nd test', () => {
+  it('can run a module normally', () => {
+    backup = timeLibrary.getCurrentHour;
+    const timeOfDay = getTimeOfDay();
+    expect(timeOfDay).to.equal('night');
+  });
+
+  it('can intercept a module', () => {
+    timeLibrary.getCurrentHour = () => 12;
+    const timeOfDay = getTimeOfDay();
+    expect(timeOfDay).to.equal('day');
+  });
+
+  it('can restore an intercepted module', () => {
+    timeLibrary.getCurrentHour = backup;
+    const timeOfDay = getTimeOfDay();
+    expect(timeOfDay).to.equal('night');
+  });
+});

--- a/packages/test-runner-module-mocking/test/fixtures/bug-cache/fixture/getTimeOfDay.js
+++ b/packages/test-runner-module-mocking/test/fixtures/bug-cache/fixture/getTimeOfDay.js
@@ -1,0 +1,9 @@
+import { getCurrentHour } from './time-library.js';
+
+export function getTimeOfDay() {
+  const hour = getCurrentHour();
+  if (hour < 6 || hour > 18) {
+    return 'night';
+  }
+  return 'day';
+}

--- a/packages/test-runner-module-mocking/test/fixtures/bug-cache/fixture/time-library.js
+++ b/packages/test-runner-module-mocking/test/fixtures/bug-cache/fixture/time-library.js
@@ -1,0 +1,3 @@
+export function getCurrentHour() {
+  return 2;
+}

--- a/packages/test-runner-module-mocking/test/moduleMockingPlugin.test.ts
+++ b/packages/test-runner-module-mocking/test/moduleMockingPlugin.test.ts
@@ -20,6 +20,17 @@ describe('moduleMockingPlugin', function test() {
     });
   });
 
+  it('can intercept server relative modules after previous test loaded them normally', async () => {
+    await runTests({
+      files: [
+        path.join(dirname, 'fixtures', 'bug-cache', 'browser-test-1.js'),
+        path.join(dirname, 'fixtures', 'bug-cache', 'browser-test-2.js'),
+      ],
+      browsers: [chromeLauncher()],
+      plugins: [moduleMockingPlugin(), nodeResolvePlugin('', false, {})],
+    });
+  });
+
   it('can intercept bare modules', async () => {
     const rootDir = path.resolve(dirname, 'fixtures', 'bare', 'fixture');
     // Define the bare module as duped to force nodeResolve to use the passed rootDir instead of the cwd


### PR DESCRIPTION
## What I did

1. provided a minimal reproduction of the bug

We discussed a similar situation, but different, when the order of mocking and importing was relevant within a single test.
But between 2 independent test files such problem wasn't discussed thoroughly, so I consider this to be a bug.
I hope my reproduction sheds some light on what goes wrong.

The biggest difference is that within a single test file you can make any order of loading modules you want, therefore this solution was OK.
But between 2 files I can't really guarantee this. In my repository I have tens of test files, many of them import reusable utilities. The module graph can be quite random depending on the unit test entry point.
The only solution I see is to have a special entry point for all unit tests which is guaranteed to be first loaded which will mock all necessary modules beforehand, but I don't think this is an acceptable solution, it scatters the test logic. We can as well just make a configuration for this then, but still same problem with scattering the test logic.

Fun fact: I was even able to use `test-runner-module-mocking` first without any issue, before smth changed in the order of test files loading, and caused this bug. Not so fun actually, as I spent a few hours debugging this and finding the root cause.