### PR TITLE
fix(storybook-builder): fix providerImportSource extension when using @storybook/addon-essentials

### DIFF
--- a/.changeset/clean-olives-fly.md
+++ b/.changeset/clean-olives-fly.md
@@ -1,0 +1,5 @@
+---
+'@web/storybook-builder': patch
+---
+
+fix providerImportSource extension when using @storybook/addon-essentials

--- a/package-lock.json
+++ b/package-lock.json
@@ -41315,7 +41315,7 @@
     },
     "packages/storybook-builder": {
       "name": "@web/storybook-builder",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-node-resolve": "^15.1.0",


### PR DESCRIPTION
## What I did

1. Fixed issue when an MDX file is compiled with a wrong module path (`"./../../../node_modules/@storybook/addon-docs/dist/shims/mdx-react-shim"`) without an extension, which is coming from `@storybook/addon-essentials` https://github.com/storybookjs/storybook/blob/v7.6.17/code/addons/essentials/src/docs/preset.ts#L10

```js
/*@jsxRuntime automatic @jsxImportSource react*/
import {Fragment as _Fragment, jsxDEV as _jsxDEV} from "./../../../node_modules/.prebundled_modules/react/jsx-dev-runtime.mjs";


import {
  useMDXComponents as _provideComponents
} from "./../../../node_modules/@storybook/addon-docs/dist/shims/mdx-react-shim"; // this is a bug


function _createMdxContent(props) {
  const _components = Object.assign({
    h1: "h1",
    p: "p",
    code: "code",
    pre: "pre"
  }, _provideComponents(), props.components);
```

I didn't catch this bug here, because `wds-outside-root` happens to add an extension when I run tests in a monorepo. But it doesn't happen in simple repos where `wds-outside-root` is not used. Not sure how to improve tests in such a way that it happens here, the risk is if I do more like in a simple repo, then the monorepo setup won't be tested. So I'll keep things as is, especially given it's such a weird and rare bug.

I'll try to fix it in the Storybook too, but unlikely it's gonna be backported to Storybook 7 which I need to support for now.