### PR TITLE
docs: fix grammar and spelling errors in documentation.

### DIFF
--- a/docs/docs/building/polyfills-loader.md
+++ b/docs/docs/building/polyfills-loader.md
@@ -44,7 +44,7 @@ For your application code, we recommend using `preload` (or `modulepreload` when
 ```html
 <head>
   <link rel="preload" href="./app.js" />
-  <!-- for module scripts, add a corrs attribute -->
+  <!-- for module scripts, add a cors attribute -->
   <link rel="preload" href="./app.js" crossorigin="anonymous" />
 </head>
 ```
@@ -141,7 +141,7 @@ const config = {
 
 ## polyfills
 
-The polyfills config controls which polyills are injected onto the page. These are the possible polyfills:
+The polyfills config controls which polyfills are injected onto the page. These are the possible polyfills:
 
 - [coreJs](https://github.com/zloirock/core-js)
 - [regeneratorRuntime](https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime)

--- a/docs/docs/building/rollup-plugin-html.md
+++ b/docs/docs/building/rollup-plugin-html.md
@@ -242,7 +242,7 @@ export default {
 
 ### Minification
 
-Set the minify option to do default HTML minificiation. If you need custom options, you can implement your own minifier using the `transformHtml` option.
+Set the minify option to do default HTML minification. If you need custom options, you can implement your own minifier using the `transformHtml` option.
 
 ```js
 import { rollupPluginHTML as html } from '@web/rollup-plugin-html';

--- a/docs/docs/building/rollup-plugin-import-meta-assets.md
+++ b/docs/docs/building/rollup-plugin-import-meta-assets.md
@@ -88,7 +88,7 @@ Default: `null`
 By default, referenced assets detected by this plugin are just copied as is to the output directory, according to your configuration.
 
 When `transform` is defined, this function will be called for each asset with two parameters, the content of the asset as a [Buffer](https://nodejs.org/api/buffer.html) and the absolute path.
-This allows you to conditionnaly match on the absolute path and maybe transform the content.
+This allows you to conditionally match on the absolute path and maybe transform the content.
 
 When `transform` returns `null`, the asset is skipped from being processed.
 

--- a/docs/docs/dev-server/cli-and-configuration.md
+++ b/docs/docs/dev-server/cli-and-configuration.md
@@ -86,7 +86,7 @@ interface DevServerConfig {
   open?: 'string' | boolean;
   // index HTML to use for SPA routing / history API fallback
   appIndex?: string;
-  // reload the brower on file changes.
+  // reload the browser on file changes.
   watch?: boolean;
   // resolve bare module imports
   nodeResolve?: boolean | RollupNodeResolveOptions;

--- a/docs/docs/dev-server/plugins/esbuild.md
+++ b/docs/docs/dev-server/plugins/esbuild.md
@@ -76,7 +76,7 @@ The `auto-always` option looks at the user agent, but doesn't skip the latest ve
 
 ### Browser and language target
 
-The target option can be set to one or more browser or language targetversions, for example `chrome80` or `es2020`. The property can be an array, so you can set multiple browser targets. While the auto target options are specific to this plugin, the browser and language target come directly from esbuild. [Check the docs](https://github.com/evanw/esbuild) for more information.
+The target option can be set to one or more browser or language target versions, for example `chrome80` or `es2020`. The property can be an array, so you can set multiple browser targets. While the auto target options are specific to this plugin, the browser and language target come directly from esbuild. [Check the docs](https://github.com/evanw/esbuild) for more information.
 
 ### No target
 

--- a/docs/docs/test-runner/browser-launchers/browserstack.md
+++ b/docs/docs/test-runner/browser-launchers/browserstack.md
@@ -12,7 +12,7 @@ Install the package:
 npm i --save-dev @web/test-runner-browserstack
 ```
 
-Add the browser launcher to your `web-test-runner.confg.mjs`:
+Add the browser launcher to your `web-test-runner.config.mjs`:
 
 ```js
 import { browserstackLauncher } from '@web/test-runner-browserstack';

--- a/docs/docs/test-runner/browser-launchers/saucelabs.md
+++ b/docs/docs/test-runner/browser-launchers/saucelabs.md
@@ -12,7 +12,7 @@ Install the package:
 npm i --save-dev @web/test-runner-saucelabs
 ```
 
-Add the browser launcher to your `web-test-runner.confg.mjs`. To set up a local proxy to sauce labs, you first need to create the browser launcher which will share a common connection between all browsers:
+Add the browser launcher to your `web-test-runner.config.mjs`. To set up a local proxy to sauce labs, you first need to create the browser launcher which will share a common connection between all browsers:
 
 ```js
 import { createSauceLabsLauncher } from '@web/test-runner-saucelabs';

--- a/docs/docs/test-runner/commands.md
+++ b/docs/docs/test-runner/commands.md
@@ -334,7 +334,7 @@ it('natively holds and then releases a key', async () => {
 
 ### Select option
 
-The `selectOption` command allows you to select an option in a `<select>` tag by either a single value, a label string or as multiple values, depending on the specific implementations of the browser laucher you're using. Once selected, the native `change` and `input` events are dispatched automatically. The `selectOption` command needs the CSS selector to locate the `<select>` by and the value, label, or values to select. The function is async and should be awaited.
+The `selectOption` command allows you to select an option in a `<select>` tag by either a single value, a label string or as multiple values, depending on the specific implementations of the browser launcher you're using. Once selected, the native `change` and `input` events are dispatched automatically. The `selectOption` command needs the CSS selector to locate the `<select>` by and the value, label, or values to select. The function is async and should be awaited.
 
 The three major launchers all have different support for selecting options, and the `selectOption` takes this into account.Attempting to select an option via a method that is not implemented in the provided launcher will produce errors. Each supported launcher's option selection support is documented below.
 

--- a/docs/docs/test-runner/writing-tests/code-coverage.md
+++ b/docs/docs/test-runner/writing-tests/code-coverage.md
@@ -35,7 +35,7 @@ Web Test Runner uses [`v8-to-istanbul`](https://github.com/istanbuljs/v8-to-ista
 /* c8 ignore next [line count] */
 ```
 
-This is somewhat different than other tools where you might have specifically targetted `if` / `else` branches of logic with an ignore statement. Particularly, V8 does not create phantom `else` statements when calculating coverage, so it is likely that you will be able to use less of these statements than in the past.
+This is somewhat different than other tools where you might have specifically targeted `if` / `else` branches of logic with an ignore statement. Particularly, V8 does not create phantom `else` statements when calculating coverage, so it is likely that you will be able to use less of these statements than in the past.
 
 In this way, you can skip the rest of a line:
 

--- a/docs/docs/test-runner/writing-tests/html-tests.md
+++ b/docs/docs/test-runner/writing-tests/html-tests.md
@@ -27,7 +27,7 @@ With mocha, you need to define your tests inside the `runTests` function:
 </html>
 ```
 
-You can also go completely barebones and not use any test framework. In this case you are responsible for pinging back to the test runner yourself:
+You can also go completely bare bones and not use any test framework. In this case you are responsible for pinging back to the test runner yourself:
 
 ```html
 <html>

--- a/docs/guides/dev-server/using-plugins.md
+++ b/docs/guides/dev-server/using-plugins.md
@@ -103,7 +103,7 @@ export default {
 
 ## Babel
 
-When doing buildless development you want compilers to be as fast as possible. That's why we recommend esbuild for common transformatons like TS, JSX, and modern JS. [See our guide](./typescript-and-jsx.md) to learn more about how to set this up.
+When doing buildless development you want compilers to be as fast as possible. That's why we recommend esbuild for common transformations like TS, JSX, and modern JS. [See our guide](./typescript-and-jsx.md) to learn more about how to set this up.
 
 If you need to use babel because of a specific plugin, you can use `@rollup/plugin-babel`. In this example we use babel with the JSX plugin for preact:
 

--- a/docs/guides/going-buildless/es-modules.md
+++ b/docs/guides/going-buildless/es-modules.md
@@ -140,7 +140,7 @@ Many libraries are already shipping es module variants, but you need to do some 
 import foo from 'foo/dist/foo.mjs';
 ```
 
-Inspect your `node_modules` folder to see if you can find it, or check the docs if thas been documented.
+Inspect your `node_modules` folder to see if you can find it, or check the docs if that's been documented.
 
 ### Ask the author to distribute an ESM distribution
 

--- a/docs/guides/test-runner/code-coverage/index.md
+++ b/docs/guides/test-runner/code-coverage/index.md
@@ -44,7 +44,7 @@ export function calc(type, a, b) {
 ```
 
 And while we are at it we can also add `minus`, I'm sure that will come in handy that at some point as well.
-And if we provide a wrong type we should throw an error - better let the user know whats up.
+And if we provide a wrong type we should throw an error - better let the user know what's up.
 
 👉 `src/calc.js`
 
@@ -74,7 +74,7 @@ View full coverage report at coverage/lcov-report/index.html
 Finished running tests in 1s, all tests passed! 🎉
 ```
 
-As you can see, our test passed but our `Code coverage` is a bit on the low side.
+As you can see, our test passed but our code coverage is a bit on the low side.
 
 ## What to test
 
@@ -103,7 +103,7 @@ Adding a test for throwing an error will bring it to `100%`.
 ## Adding more features
 
 Let's add the possibility to `multiply`.
-While implementing `Lea` said it's time for a meeting so we put `return; // finish later` for now.
+While implementing, Lea said it's time for a meeting so we put `return; // finish later` for now.
 
 👉 `src/calc.js`
 
@@ -149,11 +149,12 @@ View full coverage report at coverage/lcov-report/index.html
 Finished running tests in 1s, all tests passed! 🎉
 ```
 
-uh nice `100%` - but it feels fishy? didn't we have a `finish later` somewhere?
+Uh, nice `100%` - but it feels fishy? Didn't we have a `finish later` somewhere?
 
 ## How come we have 100% code coverage?
 
-Lets first try to understand how code coverage works
+Let's first try to understand how code coverage works.
+
 The way code coverage gets measured is by applying a form of instrumentation. In short, before our code is executed it gets changed (instrumented) and it behaves something like this:
 
 ```js
@@ -162,7 +163,7 @@ if (this.value === 'cat') {
   console.log('We like cats too :)');
 }
 
-// becomes something like this (psoido code)
+// becomes something like this (pseudo code)
 __instrumented['functionUpdate'] += 1;
 if (this.value === 'cat') {
   __instrumented['functionUpdateBranch1yes'] += 1;
@@ -208,7 +209,7 @@ You should, therefore, see code coverage as a tool that only gives you guidance 
 
 ## Ignoring uncovered lines
 
-In more complex applications, it is likely that you will find yourself creating difficult, if not impossible, to test branches of functionality. While this can absolutely be a pointer to logic that is worth breaking down into more approachable parts, there will be cases where this is not feasible. If so, you may chose to ignore a line of code by using the `/* c8 ignore next */` custom comment. Using this, or more advanced forms of [ignoring uncovered lines](../../../docs/test-runner/writing-tests/code-coverage.md#ignoring-uncovered-lines) while computing code coverage can go a long way in preparing your project for long term maintanence.
+In more complex applications, it is likely that you will find yourself creating difficult, if not impossible, to test branches of functionality. While this can absolutely be a pointer to logic that is worth breaking down into more approachable parts, there will be cases where this is not feasible. If so, you may chose to ignore a line of code by using the `/* c8 ignore next */` custom comment. Using this, or more advanced forms of [ignoring uncovered lines](../../../docs/test-runner/writing-tests/code-coverage.md#ignoring-uncovered-lines) while computing code coverage can go a long way in preparing your project for long term maintenance.
 
 ## Coverage browser support
 

--- a/docs/guides/test-runner/typescript.md
+++ b/docs/guides/test-runner/typescript.md
@@ -3,8 +3,10 @@
 If you write your source files in TypeScript, you can test directly from sources without
 compiling using `tsc`. Add `esbuildPlugin({ ts: true })` to your `web-test-runner.config.js`
 file.
+
 This uses esbuild to [transform TS sources on-the-fly](https://esbuild.github.io/api/#transform-api).
 [There are some caveats to using esbuild with TypeScript](https://esbuild.github.io/content-types/#typescript-caveats).
+
 For example, if you use TypeScript paths to alias imports, you may need to build first.
 
 ```js
@@ -16,8 +18,8 @@ export default {
 };
 ```
 
-Keep in mind that esbuild merely removes TypeScript syntax and transforms decorators, etc;
-It does not provide any type checking, and it's [not intended to](https://esbuild.github.io/faq/#upcoming-roadmap). If you'd like to run `tsc` in parallel, you can use `concurrently` or `npm-run-all`
+Keep in mind that esbuild merely removes TypeScript syntax and transforms decorators, etc.;
+It does not provide any type checking and it's [not intended to](https://esbuild.github.io/faq/#upcoming-roadmap). If you'd like to run `tsc` in parallel, you can use `concurrently` or `npm-run-all`.
 
 <figure>
 
@@ -33,4 +35,4 @@ Example: Using `concurrently` to typecheck and test simultaneously
 
 </figure>
 
-Read more about the esbuild plugin in the [docs](../../docs/dev-server/plugins/esbuild.md)
+Read more about the esbuild plugin in the [docs](../../docs/dev-server/plugins/esbuild.md).


### PR DESCRIPTION
## What I did

1. Fixed grammar and typos in docs.
2. Addressed some Markdown issues (`test-runner/typescript.md`) where it looked like content was meant to be its own paragraph.
