### PR TITLE
js-tests.md: Refer to chai as an ES module

### DIFF
--- a/docs/docs/test-runner/writing-tests/js-tests.md
+++ b/docs/docs/test-runner/writing-tests/js-tests.md
@@ -5,7 +5,7 @@ Javascript files are loaded by the test framework that is configured. The defaul
 For example:
 
 ```js
-import { expect } from '@esm-bundle/chai';
+import { expect } from 'chai';
 import { myFunction } from '../src/myFunction.js';
 
 describe('myFunction', () => {


### PR DESCRIPTION
Since 5.0, chai is distributed as an ES module, no need for the wrapper.

## What I did

1. I modernized the reference to `chai` in the example.
