### PR TITLE
fix(dev-server-rollup): dedupe imports from outside root

### DIFF
--- a/.changeset/witty-ways-occur.md
+++ b/.changeset/witty-ways-occur.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server-rollup': patch
+---
+
+dedupe imports from outside root

--- a/packages/dev-server-rollup/src/rollupAdapter.ts
+++ b/packages/dev-server-rollup/src/rollupAdapter.ts
@@ -289,9 +289,9 @@ export function rollupAdapter(
 
         // append a path separator to rootDir so we are actually testing containment
         // of the normalized path within the rootDir folder
-        const checkRootDir = rootDir.endsWith(path.sep) ? rootDir : rootDir + path.sep;
+        const normalizedRootDir = rootDir.endsWith(path.sep) ? rootDir : rootDir + path.sep;
 
-        if (!normalizedPath.startsWith(checkRootDir)) {
+        if (!normalizedPath.startsWith(normalizedRootDir)) {
           const relativePath = path.relative(rootDir, normalizedPath);
           const dirUp = `..${path.sep}`;
           const lastDirUpIndex = relativePath.lastIndexOf(dirUp) + 3;
@@ -317,8 +317,17 @@ export function rollupAdapter(
           const importPath = toBrowserPath(relativePath.substring(lastDirUpIndex));
           resolvedImportPath = `/__wds-outside-root__/${dirUpStrings.length - 1}/${importPath}`;
         } else {
-          const resolveRelativeTo = path.dirname(filePath);
-          const relativeImportFilePath = path.relative(resolveRelativeTo, resolvedImportPath);
+          let relativeImportFilePath = '';
+
+          if (context.url.match(OUTSIDE_ROOT_REGEXP)) {
+            const pathInsideRootDir = `/${normalizedPath.replace(normalizedRootDir, '')}`;
+            const resolveRelativeTo = path.dirname(context.url);
+            relativeImportFilePath = path.relative(resolveRelativeTo, pathInsideRootDir);
+          } else {
+            const resolveRelativeTo = path.dirname(filePath);
+            relativeImportFilePath = path.relative(resolveRelativeTo, resolvedImportPath);
+          }
+
           resolvedImportPath = `./${toBrowserPath(relativeImportFilePath)}`;
         }
 

--- a/packages/dev-server-rollup/test/node/fixtures/monorepo-import-inside-from-outside/node_modules/storybook/index.js
+++ b/packages/dev-server-rollup/test/node/fixtures/monorepo-import-inside-from-outside/node_modules/storybook/index.js
@@ -1,0 +1,1 @@
+import 'react';

--- a/packages/dev-server-rollup/test/node/fixtures/monorepo-import-inside-from-outside/node_modules/storybook/package.json
+++ b/packages/dev-server-rollup/test/node/fixtures/monorepo-import-inside-from-outside/node_modules/storybook/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "storybook"
+}

--- a/packages/dev-server-rollup/test/node/fixtures/monorepo-import-inside-from-outside/src/packages/subpackage/app.js
+++ b/packages/dev-server-rollup/test/node/fixtures/monorepo-import-inside-from-outside/src/packages/subpackage/app.js
@@ -1,0 +1,1 @@
+import 'react';

--- a/packages/dev-server-rollup/test/node/fixtures/monorepo-import-inside-from-outside/src/packages/subpackage/node_modules/.prebundled_modules/react.mjs
+++ b/packages/dev-server-rollup/test/node/fixtures/monorepo-import-inside-from-outside/src/packages/subpackage/node_modules/.prebundled_modules/react.mjs
@@ -1,0 +1,1 @@
+export default 'react bundle';


### PR DESCRIPTION
## What I did

- for rollup adapter I deduped imports from outside root dir, so they are loaded from same URL as when requested by modules inside root dir

## Explainer

> check unit test for even more descriptive example

Same file was imported by a module inside `rootDir` and a module outside `rootDir` in such a way that from the browser perspective it's 2 different files.
I ran into this when playing with MDX in the `storybook-builder`, where some deps located in root monorepo node_modules were importing React in a different way to the way I was importing in my subpackage (where subpackage was a root dir).
As a result, prebundled React was loaded twice from 2 different URLs:

For `rootDir=packages/storybook-builder/` browser requests looked like:
- for a module `inside `: `http://localhost:3000/node_modules/.prebundled_modules/react.mjs`
- for a module `outside`: `http://localhost:3000/__wds-outside-root__/2/packages/storybook-builder/node_modules/.prebundled_modules/react.mjs`

So basically for outside modules it was resolved relative to their own root path `/__wds-outside-root__/2`.

It's not only a React problem, but also:
- problem for any package like React which must not be duplicated on the same page
- performance problem
- debugging nightmare (I actually remember now I had this problem before and couldn't understand why my breakpoints don't work some times... I guess it's because they were not working for one of 2 paths haha)

This was such a rollercoaster this bug, I almost gave up at some point, because I needed to learn lots of details about WDS internals and rollup adapter specifically, fun stuff :D