### PR TITLE
Fix rollupAdapter handling of outside-workspace imports

### DIFF
--- a/packages/dev-server-rollup/src/rollupAdapter.ts
+++ b/packages/dev-server-rollup/src/rollupAdapter.ts
@@ -253,8 +253,8 @@ export function rollupAdapter(
           // if the resolve import path is outside our normal root, fully resolve the file path for rollup
           const matches = resolvedImportPath.match(OUTSIDE_ROOT_REGEXP);
           if (matches) {
-            const upDirs = new Array(parseInt(matches[1], 10) + 1).join(`..${path.sep}`);
-            resolvedImportPath = `\0${path.resolve(`${upDirs}${matches[2]}`)}`;
+            const upDirs = new Array(parseInt(matches[1], 10)).fill('..');
+            resolvedImportPath = `\0${path.resolve(rootDir, ...upDirs, matches[2])}`;
           }
           const urlParam = encodeURIComponent(resolvedImportPath);
           return `${VIRTUAL_FILE_PREFIX}/${filename}?${NULL_BYTE_PARAM}=${urlParam}`;


### PR DESCRIPTION
Fixes https://github.com/modernweb-dev/web/issues/2231

## What I did

1. Made rollupAdapter correctly take into account rootDir when rewriting outside-of-workspace resolved specifiers.

This PR is a draft because I can't get tests to run locally, and I'm not sure if there's an existing test fixture structure that can express a root dir.
