### PR TITLE
fix(dev-server-core): fix readonly error serialization

### DIFF
--- a/.changeset/cool-terms-exercise.md
+++ b/.changeset/cool-terms-exercise.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server-core': patch
+---
+
+Fix readonly object serialization

--- a/integration/test-runner/tests/test-failure/browser-tests/fail-readonly-actual.test.js
+++ b/integration/test-runner/tests/test-failure/browser-tests/fail-readonly-actual.test.js
@@ -1,0 +1,6 @@
+import { expect } from '../../../../../node_modules/@esm-bundle/chai/esm/chai.js';
+
+it('readonly actual', function() {
+  const fixture = Object.freeze({x: {}});
+  expect(fixture).to.equal(null);
+})

--- a/integration/test-runner/tests/test-failure/runTestFailureTest.ts
+++ b/integration/test-runner/tests/test-failure/runTestFailureTest.ts
@@ -208,5 +208,17 @@ export function runTestFailureTest(
         expect(session.errors).to.eql([ERROR_NOT_IMPORTABLE]);
       }
     });
+
+    it('handles tests that error with a readonly actual', () => {
+      const sessions = allSessions.filter(s => s.testFile.endsWith('fail-readonly-actual.test.js'));
+      expect(sessions.length === browserCount).to.equal(true);
+      for (const session of sessions) {
+        expect(session.testResults!.tests.map(t => t.name)).to.eql(['readonly actual']);
+        expect(session.passed).to.be.false;
+        expect(session.testResults!.tests![0].error!.message).to.equal(
+          'expected { x: {} } to equal null',
+        );
+      }
+    });
   });
 }

--- a/packages/dev-server-core/src/web-sockets/webSocketsPlugin.ts
+++ b/packages/dev-server-core/src/web-sockets/webSocketsPlugin.ts
@@ -40,7 +40,8 @@ export function webSocketsPlugin(): Plugin {
         }
 
         export function stable (obj, replacer, spacer) {
-          var tmp = deterministicDecirc(obj, '', [], undefined) || obj
+          var target = structuredClone(obj)
+          var tmp = deterministicDecirc(target, '', [], undefined) || target
           var res
           if (replacerStack.length === 0) {
             res = JSON.stringify(tmp, replacer, spacer)


### PR DESCRIPTION
Fixes #2728 
## What I did

1. Add integration test for error reporting with readonly / frozen objects
2. Create a structuredClone of messages when running stringification with (mutating) circurlar reference removal
