### PR TITLE
fix(storybook-framework-web-components): watch code changes and auto-reload by default

### DIFF
--- a/.changeset/hot-dodos-push.md
+++ b/.changeset/hot-dodos-push.md
@@ -1,0 +1,5 @@
+---
+'@web/storybook-framework-web-components': patch
+---
+
+watch code changes and auto-reload by default

--- a/packages/storybook-framework-web-components/src/preset.ts
+++ b/packages/storybook-framework-web-components/src/preset.ts
@@ -5,3 +5,10 @@ export const core: PresetProperty<'core', StorybookConfig> = {
   builder: '@web/storybook-builder',
   renderer: '@storybook/web-components',
 };
+
+export const wdsFinal: StorybookConfig['wdsFinal'] = wdsConfig => {
+  return {
+    ...wdsConfig,
+    watch: true,
+  };
+};


### PR DESCRIPTION
## What I did

1. set `watch: true` to enable auto-reload by default

We implemented the baseline for auto-reload here https://github.com/modernweb-dev/web/pull/2482
But I overlooked the fact that `watch: true` wasn't set by default.
It should be, because it's expected of the Storybook to have this behavior by default, e.g. `@storybook/web-components-vite` has it.

If we make a stable HMR implementation and test it extensively, we can in the future enable that instead by default (these is what frameworks presets are for, also the one I patch here). For now it's just a simple page reload.