### PR TITLE
feat(mocks): update mocks addon styles to support dark mode

### DIFF
--- a/.changeset/plenty-llamas-cross.md
+++ b/.changeset/plenty-llamas-cross.md
@@ -1,0 +1,5 @@
+---
+'@web/mocks': patch
+---
+
+Update mocks addon styles to support dark mode

--- a/package-lock.json
+++ b/package-lock.json
@@ -40956,7 +40956,7 @@
     },
     "packages/mocks": {
       "name": "@web/mocks",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@storybook/manager-api": "^7.0.0",
@@ -41480,7 +41480,7 @@
     },
     "packages/storybook-framework-web-components": {
       "name": "@web/storybook-framework-web-components",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@storybook/web-components": "^7.0.0",

--- a/packages/mocks/storybook/addon/register-addon.js
+++ b/packages/mocks/storybook/addon/register-addon.js
@@ -18,16 +18,22 @@ export function registerAddon(addons, React, createAddon) {
     static styles = css`
       table {
         width: 100%;
+        margin-bottom: 10px;
         border-collapse: collapse;
       }
 
+      tr {
+        border-bottom: 1px solid hsla(203, 50%, 30%, 0.2);
+      }
+
       thead {
-        background-color: #f2f2f2;
+        background-color: hsla(203, 50%, 30%, 0.1);
       }
 
       tr th:first-child {
         width: 9ch;
       }
+
       tr th:nth-child(2) {
         width: 9ch;
       }
@@ -37,13 +43,14 @@ export function registerAddon(addons, React, createAddon) {
         text-align: left;
       }
 
-      tbody tr:nth-child(0) {
-        background-color: #e8e8e8;
-      }
-
       tbody td {
         padding: 10px;
-        border-top: 1px solid #ddd;
+      }
+
+      .message {
+        padding: 30px;
+        text-align: center;
+        font-weight: bold;
       }
     `;
 
@@ -67,11 +74,11 @@ export function registerAddon(addons, React, createAddon) {
 
     render() {
       if (this.state === 'PENDING') {
-        return html`Loading...`;
+        return html`<div class="message">Loading...</div>`;
       }
 
       if (!this.mocks.length) {
-        return html`No mocks configured.`;
+        return html`<div class="message">No mocks configured.</div>`;
       }
 
       return html`


### PR DESCRIPTION
## What I did

1. Use hsla values for background and border color so it works for both - light and dark mode:

<img width="828" alt="image" src="https://github.com/modernweb-dev/web/assets/5550537/1dcf6617-40ec-4c11-85e9-9490146c62ee">

<img width="820" alt="image" src="https://github.com/modernweb-dev/web/assets/5550537/f3d06615-8805-4cd3-8ccc-3f89e892cbdb">

2. Slightly improve styles when loading / no mocks:

<img width="825" alt="image" src="https://github.com/modernweb-dev/web/assets/5550537/afa50a79-3495-43b0-a532-3bbf0aeda4d9">

<img width="825" alt="image" src="https://github.com/modernweb-dev/web/assets/5550537/9599d03d-926b-4de3-a5fb-6648b0e910a5">
