### PR TITLE
Update migration-to-storybook-7.md

### DIFF
--- a/docs/docs/storybook-builder/migration-to-storybook-7.md
+++ b/docs/docs/storybook-builder/migration-to-storybook-7.md
@@ -19,7 +19,7 @@ npm install @storybook/builder-vite@0.4 @storybook/web-components@6 --save-dev
 Then proceed with the `upgrade` script and follow it's interactive process:
 
 ```bash
-npx storybook@latest upgrade
+npx storybook@7 upgrade
 ```
 
 Then [configure the builder and framework](./configuration.md#configuring-builder-and-framework) in the main Storybook configuration.


### PR DESCRIPTION
As Storybook 8 is out there, users need to use the right version to migrate.

## What I did

1. Change `latest` to `7` to avoid using the upgrade command from the wrong CLI.
