### PR TITLE
Update migration-to-storybook-7.md

### DIFF
--- a/docs/docs/storybook-builder/migration-to-storybook-7.md
+++ b/docs/docs/storybook-builder/migration-to-storybook-7.md
@@ -38,7 +38,7 @@ In the new setup you'll need to install and configure them explicitly.
 We recommend to install the following addons:
 
 ```bash
-npm install @storybook/addon-essentials @storybook/addon-links --save-dev
+npm install @storybook/addon-essentials@7 @storybook/addon-links@7 --save-dev
 ```
 
 Then register them in the Storybook main configuration file:


### PR DESCRIPTION
As we need to have all versions aligned, same happens here with the addons. Latest versions are 8.x

## What I did

1. Add @7 to packages to indicate we want to install the latest version on major 7.
