### PR TITLE
fix(parse5-utils): add support for templates in `findNode`

### DIFF
--- a/.changeset/sour-roses-smell.md
+++ b/.changeset/sour-roses-smell.md
@@ -1,0 +1,5 @@
+---
+'@web/parse5-utils': patch
+---
+
+Adds support to findNode to find nodes within <template> elements

--- a/packages/parse5-utils/src/index.js
+++ b/packages/parse5-utils/src/index.js
@@ -188,7 +188,7 @@ function findNode(nodes, test) {
     if (test(node)) {
       return node;
     }
-    const children = adapter.getChildNodes(/** @type {ParentNode} */ (node));
+    const children = getNodeChildren(node);
     if (Array.isArray(children)) {
       n.unshift(...children);
     }
@@ -216,23 +216,31 @@ function findNodes(nodes, test) {
       found.push(node);
     }
 
-    /** @type {Node[]} */
-    let children = [];
-
-    if (adapter.isElementNode(node) && adapter.getTagName(node) === 'template') {
-      const content = adapter.getTemplateContent(node);
-      if (content) {
-        children = adapter.getChildNodes(content);
-      }
-    } else {
-      children = adapter.getChildNodes(/** @type {ParentNode} */ (node));
-    }
-
+    const children = getNodeChildren(node);
     if (Array.isArray(children)) {
       n.unshift(...children);
     }
   }
   return found;
+}
+
+/**
+ * Get all children of a node or all children of a `<template>` element's content
+ * @param {Node} node
+ * @returns {Node[]}
+ */
+function getNodeChildren(node) {
+  /** @type {Node[]} */
+  let children = [];
+  if (adapter.isElementNode(node) && adapter.getTagName(node) === 'template') {
+    const content = adapter.getTemplateContent(node);
+    if (content) {
+      children = adapter.getChildNodes(content);
+    }
+  } else {
+    children = adapter.getChildNodes(/** @type {ParentNode} */ (node));
+  }
+  return children;
 }
 
 /**

--- a/packages/parse5-utils/test/index.test.js
+++ b/packages/parse5-utils/test/index.test.js
@@ -241,6 +241,24 @@ describe('parse5-utils', () => {
       }
       expect(found).to.exist;
     });
+
+    it('returns elements within template element', () => {
+      const doc = parse(`
+      <html>
+        <body>
+          <template>
+            <div id="foo">Hello world</div>
+          </template>
+        </body>
+      </html>
+    `);
+
+      const found = utils.findElement(doc, el => utils.getAttribute(el, 'id') === 'foo');
+      if (!found) {
+        throw new Error('No elemen found.');
+      }
+      expect(found).to.exist;
+    });
   });
 
   describe('findElements()', () => {


### PR DESCRIPTION
## What I did

1. Add a shared helper function for `findNode` and `findNodes` to find child nodes within `<template>` elements
2. Enable `findNode` to find children within a `<template>` element
3. Add a test for `findNode`

This expands on #2398 which added this functionality to `findNodes`.