### PR TITLE
fix: replace ip dependency due to security bug CVE-2024-29415

### DIFF
--- a/.changeset/lemon-suns-sneeze.md
+++ b/.changeset/lemon-suns-sneeze.md
@@ -1,0 +1,8 @@
+---
+'@web/test-runner-browserstack': patch
+'@web/test-runner-saucelabs': patch
+'@web/test-runner-core': patch
+'@web/dev-server': patch
+---
+
+replace ip dependency due to security bug CVE-2024-29415

--- a/package-lock.json
+++ b/package-lock.json
@@ -15617,6 +15617,88 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/default-gateway": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
+      "integrity": "sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==",
+      "dependencies": {
+        "execa": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/default-gateway/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/default-gateway/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/default-gateway/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/default-gateway/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/default-gateway/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-gateway/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -21320,6 +21402,14 @@
       "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
       "license": "MIT"
     },
+    "node_modules/ip-regex": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -21698,6 +21788,17 @@
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
       "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-ip": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+      "dependencies": {
+        "ip-regex": "^4.0.0"
+      },
       "engines": {
         "node": ">=8"
       }
@@ -39676,7 +39777,7 @@
         "command-line-usage": "^7.0.1",
         "debounce": "^1.2.0",
         "deepmerge": "^4.2.2",
-        "ip": "^2.0.1",
+        "internal-ip": "^6.2.0",
         "nanocolors": "^0.2.1",
         "open": "^8.0.2",
         "portfinder": "^1.0.32"
@@ -40783,10 +40884,22 @@
       "integrity": "sha512-Ctp4hInA0BEavlUoRy9mhGq0i+JSo/AwVyX2EFgZmV1kYB+Zq+EMBAn52QWu6FbRr10hRb6pBl420upbp4++vg==",
       "dev": true
     },
-    "packages/dev-server/node_modules/ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
+    "packages/dev-server/node_modules/internal-ip": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-6.2.0.tgz",
+      "integrity": "sha512-D8WGsR6yDt8uq7vDMu7mjcR+yRMm3dW8yufyChmszWRjcSHuxLBkR3GdS2HZAjodsaGuCvXeEJpueisXJULghg==",
+      "dependencies": {
+        "default-gateway": "^6.0.0",
+        "ipaddr.js": "^1.9.1",
+        "is-ip": "^3.1.0",
+        "p-event": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/internal-ip?sponsor=1"
+      }
     },
     "packages/dev-server/node_modules/js-yaml": {
       "version": "4.1.0",
@@ -40817,6 +40930,20 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "dev": true
+    },
+    "packages/dev-server/node_modules/p-event": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
+      "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+      "dependencies": {
+        "p-timeout": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "packages/dev-server/node_modules/puppeteer": {
       "version": "22.3.0",
@@ -41562,7 +41689,7 @@
       "dependencies": {
         "@web/test-runner-webdriver": "^0.8.0",
         "browserstack-local": "^1.4.8",
-        "ip": "^2.0.1",
+        "internal-ip": "^6.2.0",
         "nanoid": "^3.1.25"
       },
       "devDependencies": {
@@ -41574,10 +41701,36 @@
         "node": ">=18.0.0"
       }
     },
-    "packages/test-runner-browserstack/node_modules/ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
+    "packages/test-runner-browserstack/node_modules/internal-ip": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-6.2.0.tgz",
+      "integrity": "sha512-D8WGsR6yDt8uq7vDMu7mjcR+yRMm3dW8yufyChmszWRjcSHuxLBkR3GdS2HZAjodsaGuCvXeEJpueisXJULghg==",
+      "dependencies": {
+        "default-gateway": "^6.0.0",
+        "ipaddr.js": "^1.9.1",
+        "is-ip": "^3.1.0",
+        "p-event": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/internal-ip?sponsor=1"
+      }
+    },
+    "packages/test-runner-browserstack/node_modules/p-event": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
+      "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+      "dependencies": {
+        "p-timeout": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "packages/test-runner-chrome": {
       "name": "@web/test-runner-chrome",
@@ -41784,7 +41937,7 @@
         "debounce": "^1.2.0",
         "dependency-graph": "^0.11.0",
         "globby": "^11.0.1",
-        "ip": "^2.0.1",
+        "internal-ip": "^6.2.0",
         "istanbul-lib-coverage": "^3.0.0",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.0.2",
@@ -41820,10 +41973,22 @@
         "node": ">=8"
       }
     },
-    "packages/test-runner-core/node_modules/ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
+    "packages/test-runner-core/node_modules/internal-ip": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-6.2.0.tgz",
+      "integrity": "sha512-D8WGsR6yDt8uq7vDMu7mjcR+yRMm3dW8yufyChmszWRjcSHuxLBkR3GdS2HZAjodsaGuCvXeEJpueisXJULghg==",
+      "dependencies": {
+        "default-gateway": "^6.0.0",
+        "ipaddr.js": "^1.9.1",
+        "is-ip": "^3.1.0",
+        "p-event": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/internal-ip?sponsor=1"
+      }
     },
     "packages/test-runner-core/node_modules/istanbul-lib-report": {
       "version": "3.0.1",
@@ -41849,6 +42014,20 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/test-runner-core/node_modules/p-event": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
+      "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+      "dependencies": {
+        "p-timeout": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -42165,7 +42344,7 @@
       "license": "MIT",
       "dependencies": {
         "@web/test-runner-webdriver": "^0.8.0",
-        "ip": "^2.0.1",
+        "internal-ip": "^6.2.0",
         "nanoid": "^3.1.25",
         "saucelabs": "^7.2.0",
         "webdriver": "^8.8.6",
@@ -42181,10 +42360,36 @@
         "node": ">=18.0.0"
       }
     },
-    "packages/test-runner-saucelabs/node_modules/ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
+    "packages/test-runner-saucelabs/node_modules/internal-ip": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-6.2.0.tgz",
+      "integrity": "sha512-D8WGsR6yDt8uq7vDMu7mjcR+yRMm3dW8yufyChmszWRjcSHuxLBkR3GdS2HZAjodsaGuCvXeEJpueisXJULghg==",
+      "dependencies": {
+        "default-gateway": "^6.0.0",
+        "ipaddr.js": "^1.9.1",
+        "is-ip": "^3.1.0",
+        "p-event": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/internal-ip?sponsor=1"
+      }
+    },
+    "packages/test-runner-saucelabs/node_modules/p-event": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
+      "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+      "dependencies": {
+        "p-timeout": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "packages/test-runner-selenium": {
       "name": "@web/test-runner-selenium",

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -65,7 +65,7 @@
     "command-line-usage": "^7.0.1",
     "debounce": "^1.2.0",
     "deepmerge": "^4.2.2",
-    "ip": "^2.0.1",
+    "internal-ip": "^6.2.0",
     "nanocolors": "^0.2.1",
     "open": "^8.0.2",
     "portfinder": "^1.0.32"

--- a/packages/dev-server/src/logger/logStartMessage.ts
+++ b/packages/dev-server/src/logger/logStartMessage.ts
@@ -1,6 +1,6 @@
 import { DevServerConfig } from '../config/DevServerConfig';
 import { Logger } from '@web/dev-server-core';
-import ip from 'ip';
+import internalIp from 'internal-ip';
 import { bold, cyan, white } from 'nanocolors';
 
 const createAddress = (config: DevServerConfig, host: string, path: string) =>
@@ -8,7 +8,7 @@ const createAddress = (config: DevServerConfig, host: string, path: string) =>
 
 function logNetworkAddress(config: DevServerConfig, logger: Logger, openPath: string) {
   try {
-    const address = ip.address();
+    const address = internalIp.v4.sync();
     if (typeof address === 'string') {
       logger.log(`${white('Network:')}  ${cyan(createAddress(config, address, openPath))}`);
     }

--- a/packages/test-runner-browserstack/package.json
+++ b/packages/test-runner-browserstack/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@web/test-runner-webdriver": "^0.8.0",
     "browserstack-local": "^1.4.8",
-    "ip": "^2.0.1",
+    "internal-ip": "^6.2.0",
     "nanoid": "^3.1.25"
   },
   "devDependencies": {

--- a/packages/test-runner-browserstack/src/browserstackLauncher.ts
+++ b/packages/test-runner-browserstack/src/browserstackLauncher.ts
@@ -1,7 +1,7 @@
 import { BrowserLauncher, TestRunnerCoreConfig } from '@web/test-runner-core';
 import { WebdriverLauncher } from '@web/test-runner-webdriver';
 import browserstack from 'browserstack-local';
-import ip from 'ip';
+import internalIp from 'internal-ip';
 import {
   registerBrowserstackLocal,
   unregisterBrowserstackLocal,
@@ -14,7 +14,10 @@ export interface BrowserstackLauncherArgs {
 }
 
 const REQUIRED_CAPABILITIES = ['name', 'browserstack.user', 'browserstack.key', 'project', 'build'];
-const localIp = ip.address();
+const localIp = internalIp.v4.sync() as string;
+if (!localIp) {
+  throw new Error('Can not determine the local IP.');
+}
 
 export class BrowserstackLauncher extends WebdriverLauncher {
   constructor(

--- a/packages/test-runner-core/package.json
+++ b/packages/test-runner-core/package.json
@@ -68,7 +68,7 @@
     "debounce": "^1.2.0",
     "dependency-graph": "^0.11.0",
     "globby": "^11.0.1",
-    "ip": "^2.0.1",
+    "internal-ip": "^6.2.0",
     "istanbul-lib-coverage": "^3.0.0",
     "istanbul-lib-report": "^3.0.1",
     "istanbul-reports": "^3.0.2",

--- a/packages/test-runner-core/src/cli/getManualDebugMenu.ts
+++ b/packages/test-runner-core/src/cli/getManualDebugMenu.ts
@@ -1,11 +1,11 @@
 import { cyan, gray } from 'nanocolors';
-import ip from 'ip';
+import internalIp from 'internal-ip';
 
 import { TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig';
 
 export function getManualDebugMenu(config: TestRunnerCoreConfig): string[] {
   const localAddress = `${config.protocol}//${config.hostname}:${config.port}/`;
-  const networkAddress = `${config.protocol}//${ip.address()}:${config.port}/`;
+  const networkAddress = `${config.protocol}//${internalIp.v4.sync()}:${config.port}/`;
 
   return [
     'Debug manually in a browser not controlled by the test runner.',

--- a/packages/test-runner-saucelabs/package.json
+++ b/packages/test-runner-saucelabs/package.json
@@ -47,7 +47,7 @@
   ],
   "dependencies": {
     "@web/test-runner-webdriver": "^0.8.0",
-    "ip": "^2.0.1",
+    "internal-ip": "^6.2.0",
     "nanoid": "^3.1.25",
     "saucelabs": "^7.2.0",
     "webdriver": "^8.8.6",

--- a/packages/test-runner-saucelabs/src/SauceLabsLauncher.ts
+++ b/packages/test-runner-saucelabs/src/SauceLabsLauncher.ts
@@ -1,10 +1,13 @@
 import { TestRunnerCoreConfig } from '@web/test-runner-core';
 import { RemoteOptions } from 'webdriverio';
 import { WebdriverLauncher } from '@web/test-runner-webdriver';
-import ip from 'ip';
+import internalIp from 'internal-ip';
 import { SauceLabsLauncherManager } from './SauceLabsLauncherManager.js';
 
-const networkAddress = ip.address();
+const localIp = internalIp.v4.sync() as string;
+if (!localIp) {
+  throw new Error('Can not determine the local IP.');
+}
 
 export class SauceLabsLauncher extends WebdriverLauncher {
   constructor(
@@ -16,7 +19,7 @@ export class SauceLabsLauncher extends WebdriverLauncher {
   }
 
   startSession(sessionId: string, url: string) {
-    return super.startSession(sessionId, url.replace(/(localhost|127\.0\.0\.1)/, networkAddress));
+    return super.startSession(sessionId, url.replace(/(localhost|127\.0\.0\.1)/, localIp));
   }
 
   async startDebugSession() {

--- a/packages/test-runner-saucelabs/src/SauceLabsLauncherManager.ts
+++ b/packages/test-runner-saucelabs/src/SauceLabsLauncherManager.ts
@@ -4,7 +4,7 @@ import SaucelabsAPI, {
   SauceConnectOptions,
   SauceConnectInstance,
 } from 'saucelabs';
-import ip from 'ip';
+import internalIp from 'internal-ip';
 
 /**
  * Wraps a Promise with a timeout, rejecing the promise with the timeout.
@@ -53,7 +53,7 @@ export class SauceLabsLauncherManager {
     this.connectionPromise = withTimeout(
       this.api.startSauceConnect({
         ...this.connectOptions,
-        noSslBumpDomains: `127.0.0.1,localhost,${ip.address()}`,
+        noSslBumpDomains: `127.0.0.1,localhost,${internalIp.v4.sync()}`,
       }),
       '[Saucelabs] Timed out setting up Sauce Connect proxy after 5 minutes.',
     );


### PR DESCRIPTION
## What I did

Fixes #2747 

`ip` package is now archived on GitHub https://github.com/indutny/node-ip/
PRs with a fix won't be released
![image](https://github.com/modernweb-dev/web/assets/137844/cbd6f39d-9089-4db8-8433-088b1e580303)
