### PR TITLE
chore(dev-server-rollup): Bump the version of whatwg-url.

### DIFF
--- a/.changeset/angry-hairs-bathe.md
+++ b/.changeset/angry-hairs-bathe.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server-rollup': patch
+---
+
+Bumping the version of whatwg-url in order to resolve an issue with a dependency.

--- a/package-lock.json
+++ b/package-lock.json
@@ -40094,7 +40094,7 @@
         "nanocolors": "^0.2.1",
         "parse5": "^6.0.1",
         "rollup": "^4.4.0",
-        "whatwg-url": "^11.0.0"
+        "whatwg-url": "^14.0.0"
       },
       "devDependencies": {
         "@babel/plugin-transform-template-literals": "^7.12.1",
@@ -40207,6 +40207,14 @@
         }
       }
     },
+    "packages/dev-server-rollup/node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "packages/dev-server-rollup/node_modules/slash": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
@@ -40217,6 +40225,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/dev-server-rollup/node_modules/tr46": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/dev-server-rollup/node_modules/whatwg-url": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+      "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+      "dependencies": {
+        "tr46": "^5.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/dev-server-storybook": {

--- a/packages/dev-server-rollup/package.json
+++ b/packages/dev-server-rollup/package.json
@@ -53,7 +53,7 @@
     "nanocolors": "^0.2.1",
     "parse5": "^6.0.1",
     "rollup": "^4.4.0",
-    "whatwg-url": "^11.0.0"
+    "whatwg-url": "^14.0.0"
   },
   "devDependencies": {
     "@babel/plugin-transform-template-literals": "^7.12.1",


### PR DESCRIPTION
## What I did

1. Update the version of the whatwg-url to ^14.0.0 which will resolve [this issue](https://github.com/modernweb-dev/web/issues/2755) with the deprecation warning.
