### PR TITLE
Update cli-and-configuration.md to not be in quirks mode

### DIFF
--- a/docs/docs/test-runner/cli-and-configuration.md
+++ b/docs/docs/test-runner/cli-and-configuration.md
@@ -221,7 +221,8 @@ For example to expose the global `process` variable:
 ```js
 export default {
   testRunnerHtml: testFramework =>
-    `<html>
+    `<!DOCTYPE html>
+    <html>
       <body>
         <script>window.process = { env: { NODE_ENV: "development" } }</script>
         <script type="module" src="${testFramework}"></script>
@@ -322,7 +323,8 @@ export default {
     {
       name: 'polyfills-a',
       testRunnerHtml: testFramework =>
-        `<html>
+        `<!DOCTYPE html>
+        <html>
           <body>
             <script src="./polyfills-a.js"></script>
             <script type="module" src="${testFramework}"></script>
@@ -332,7 +334,8 @@ export default {
     {
       name: 'polyfills-b',
       testRunnerHtml: testFramework =>
-        `<html>
+        `<!DOCTYPE html>
+        <html>
           <body>
             <script src="./polyfills-b.js"></script>
             <script type="module" src="${testFramework}"></script>


### PR DESCRIPTION
Probably dont want people running in browser quirks mode (like we have in Shoelace 🙈 )

## What I did

1. Changed documentation of testRunnerHTML to include a `<!DOCTYPE html>` so that users dont run their test suite in quirks mode.
