### PR TITLE
fix(test-runner): show suites for summaryReporter({ flatten: true })

### DIFF
--- a/.changeset/heavy-pianos-beam.md
+++ b/.changeset/heavy-pianos-beam.md
@@ -1,0 +1,5 @@
+---
+"@web/test-runner": patch
+---
+
+Show suites names for `summaryReporter` when `flatten` option is true

--- a/packages/test-runner/src/reporter/summaryReporter.ts
+++ b/packages/test-runner/src/reporter/summaryReporter.ts
@@ -51,7 +51,14 @@ export function summaryReporter(opts: Options): Reporter {
   ) {
     const browserName = browser?.name ? ` ${dim(`[${browser.name}]`)}` : '';
     for (const result of results?.tests ?? []) {
-      log(logger, result.name, result.passed, result.skipped, prefix, browserName);
+      log(
+        logger,
+        flatten ? `${prefix ?? ''} ${result.name}` : result.name,
+        result.passed,
+        result.skipped,
+        prefix,
+        browserName,
+      );
     }
 
     for (const suite of results?.suites ?? []) {


### PR DESCRIPTION
## What I did

1. make the summary reporter list the suite names when flatten is true

Before:

```
✓ imperatively instantiates [Chromium]
✓ should upgrade [Chromium]
✓ should be hidden on init [Chromium]
✓ should not be accessible [Chromium]
✓ should be visible [Chromium]
✓ should be accessible [Chromium]
✓ should focus the component [Chromium]
✓ should be visible [Chromium]
✓ should be accessible [Chromium]
✓ should focus the component [Chromium]
✓ should be hidden [Chromium]
✓ should be visible [Chromium]
✓ should be hidden on init [Chromium]
✓ should be visible [Chromium]
✓ should have a label of "Back to top" [Chromium]
✓ should have a label of "Back to top" [Chromium]
✓ should have a label of "Return to top" [Chromium]
✓ should have a label of "Return to top" [Chromium]
```

After:

```
✓  <pf-back-to-top> imperatively instantiates [Chromium]
✓  <pf-back-to-top> simply instantiating should upgrade [Chromium]
✓  <pf-back-to-top> when rendered in a viewport with a height smaller then content length should be hidden on init [Chromium]
✓  <pf-back-to-top> when rendered in a viewport with a height smaller then content length should not be accessible [Chromium]
✓  <pf-back-to-top> when rendered in a viewport with a height smaller then content length when scrolled 401px should be visible [Chromium]
✓  <pf-back-to-top> when rendered in a viewport with a height smaller then content length when scrolled 401px should be accessible [Chromium]
✓  <pf-back-to-top> when rendered in a viewport with a height smaller then content length when scrolled 401px pressing the tab key should focus the component [Chromium]
✓  <pf-back-to-top> when rendered in a viewport with a height smaller then content length when the always visible property is true should be visible [Chromium]
✓  <pf-back-to-top> when rendered in a viewport with a height smaller then content length when the always visible property is true should be accessible [Chromium]
✓  <pf-back-to-top> when rendered in a viewport with a height smaller then content length when the always visible property is true pressing the tab key should focus the component [Chromium]
✓  <pf-back-to-top> when rendered in a viewport with a height smaller then content length when the scroll distance is set to 1000 should be hidden [Chromium]
✓  <pf-back-to-top> when rendered in a viewport with a height smaller then content length when the scroll distance is set to 1000 when scrolled 1001px should be visible [Chromium]
✓  <pf-back-to-top> when rendered in an element with an overflowed height should be hidden on init [Chromium]
✓  <pf-back-to-top> when rendered in an element with an overflowed height when scrolled 401px should be visible [Chromium]
✓  <pf-back-to-top> when no text is provided as a link when scrolled should have a label of "Back to top" [Chromium]
✓  <pf-back-to-top> when no text is provided as a button when scrolled should have a label of "Back to top" [Chromium]
✓  <pf-back-to-top> when a label is provided as a link when scrolled should have a label of "Return to top" [Chromium]
✓  <pf-back-to-top> when a label is provided as a button when scrolled should have a label of "Return to top" [Chromium]
```