### PR TITLE
docs: use superscript for footnotes mark

### DIFF
--- a/docs/guides/going-buildless/serving.md
+++ b/docs/guides/going-buildless/serving.md
@@ -96,9 +96,9 @@ Links with fully qualified URLs can link a page on your server, to pages on anot
 <a href="https://google.com/">if you click me I will open google</a>
 ```
 
-Because the URL is fully-qualified, adding that `<a>` tag to any page anywhere on the web will have the same behavior[^1], namely opening google's home page.
+Because the URL is fully-qualified, adding that `<a>` tag to any page anywhere on the web will have the same behavior<sup>[^1]</sup>, namely opening google's home page.
 
-[^1]: Assuming that the page doesn't use JavaScript or other techniques to surreptitiously change the destination of the link
+<sup>[^1]</sup>: Assuming that the page doesn't use JavaScript or other techniques to surreptitiously change the destination of the link
 
 ### Absolute URLs
 


### PR DESCRIPTION
This is how it looks in prod:

![image](https://github.com/user-attachments/assets/5197727b-7772-45b1-aa9e-f05c41f0c42e)

And this is after my change:

![image](https://github.com/user-attachments/assets/f2f3f3a9-bf5e-4894-b0f7-6de72809e693)
