### PR TITLE
chore: add _site-dev and _merged_assets to .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -17,4 +17,6 @@ demo
 CHANGELOG.md
 .changeset
 _site
+_site-dev
 dist-types
+/docs/_merged_data


### PR DESCRIPTION
## What I did

Added `_side-dev` and `docs/_merged_assets` folders to `.eslintignore` to fix warnings I'm getting locally:

```
> lint:eslint
> eslint --ext .ts,.js,.mjs,.cjs .


/Users/serhii/cf/modernweb/_site-dev/guides/going-buildless/css/__mdjs-stories.js
  43:2  error  Unnecessary semicolon  @typescript-eslint/no-extra-semi
```

```
> lint:prettier
> node node_modules/prettier/bin-prettier.js "**/*.{ts,js,mjs,cjs,md}" --check --ignore-path .eslintignore

Checking formatting...
[warn] docs/_merged_data/site.cjs
[warn] Code style issues found in the above file. Forgot to run Prettier?
```