### PR TITLE
chore: set type to commonjs in config-loader package.json

### DIFF
--- a/.changeset/popular-sheep-rush.md
+++ b/.changeset/popular-sheep-rush.md
@@ -1,0 +1,5 @@
+---
+'@web/config-loader': patch
+---
+
+Set type to commonjs in package.json

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -14,12 +14,13 @@
   "author": "modern-web",
   "homepage": "https://github.com/modernweb-dev/web/tree/master/packages/config-loader",
   "main": "src/index.js",
+  "type": "commonjs",
   "engines": {
     "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",
-    "test:node": "mocha test/**/*.test.js --reporter dot --no-experimental-detect-module",
+    "test:node": "mocha test/**/*.test.js --reporter dot",
     "test:watch": "mocha test/**/*.test.js --watch --watch-files .,src,test --reporter dot"
   },
   "files": [

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test:node": "mocha test/**/*.test.js --reporter dot",
+    "test:node": "mocha test/**/*.test.js --reporter dot --no-experimental-detect-module",
     "test:watch": "mocha test/**/*.test.js --watch --watch-files .,src,test --reporter dot"
   },
   "files": [


### PR DESCRIPTION
## What I did

Fixes https://github.com/modernweb-dev/web/issues/2793

Set `type` to `commonjs` to avoid test failure due to Node 22.7 experimental module syntax detection.