### PR TITLE
Bump chokidar v4

### DIFF
--- a/.changeset/giant-games-count.md
+++ b/.changeset/giant-games-count.md
@@ -1,0 +1,6 @@
+---
+'@web/test-runner-core': patch
+'@web/dev-server-core': patch
+---
+
+bump chokidar to v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -39798,7 +39798,7 @@
         "@types/koa": "^2.11.6",
         "@types/ws": "^7.4.0",
         "@web/parse5-utils": "^2.1.0",
-        "chokidar": "^3.4.3",
+        "chokidar": "^4.0.1",
         "clone": "^2.1.2",
         "es-module-lexer": "^1.0.0",
         "get-stream": "^6.0.0",
@@ -39826,6 +39826,34 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "packages/dev-server-core/node_modules/chokidar": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+      "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/dev-server-core/node_modules/readdirp": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.1.tgz",
+      "integrity": "sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "packages/dev-server-esbuild": {
@@ -40086,7 +40114,7 @@
         "picomatch": "^2.2.2"
       },
       "devDependencies": {
-        "@web/test-runner": "^0.18.0"
+        "@web/test-runner": "^0.19.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -40156,7 +40184,7 @@
         "@rollup/plugin-replace": "^5.0.5",
         "@types/parse5": "^6.0.1",
         "@types/whatwg-url": "^11.0.0",
-        "@web/test-runner-chrome": "^0.16.0",
+        "@web/test-runner-chrome": "^0.17.0",
         "@web/test-runner-core": "^0.13.0",
         "chai": "^4.2.0",
         "mocha": "^10.2.0",
@@ -41021,7 +41049,7 @@
     },
     "packages/mocks": {
       "name": "@web/mocks",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "@storybook/manager-api": "^7.0.0",
@@ -41536,7 +41564,7 @@
     },
     "packages/storybook-builder": {
       "name": "@web/storybook-builder",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-node-resolve": "^15.1.0",
@@ -41701,11 +41729,11 @@
     },
     "packages/storybook-framework-web-components": {
       "name": "@web/storybook-framework-web-components",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@storybook/web-components": "^7.0.0",
-        "@web/storybook-builder": "^0.1.0"
+        "@web/storybook-builder": "^0.1.17"
       },
       "devDependencies": {
         "@playwright/test": "^1.22.2",
@@ -41743,13 +41771,13 @@
     },
     "packages/test-runner": {
       "name": "@web/test-runner",
-      "version": "0.18.3",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "@web/browser-logs": "^0.4.0",
         "@web/config-loader": "^0.3.0",
         "@web/dev-server": "^0.4.0",
-        "@web/test-runner-chrome": "^0.16.0",
+        "@web/test-runner-chrome": "^0.17.0",
         "@web/test-runner-commands": "^0.9.0",
         "@web/test-runner-core": "^0.13.0",
         "@web/test-runner-mocha": "^0.9.0",
@@ -41830,7 +41858,7 @@
     },
     "packages/test-runner-chrome": {
       "name": "@web/test-runner-chrome",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@web/test-runner-core": "^0.13.0",
@@ -41919,7 +41947,7 @@
         "mkdirp": "^1.0.4"
       },
       "devDependencies": {
-        "@web/test-runner-chrome": "^0.16.0",
+        "@web/test-runner-chrome": "^0.17.0",
         "@web/test-runner-playwright": "^0.11.0",
         "@web/test-runner-webdriver": "^0.8.0",
         "mocha": "^10.2.0"
@@ -41954,7 +41982,7 @@
         "@types/istanbul-reports": "^3.0.0",
         "@web/browser-logs": "^0.4.0",
         "@web/dev-server-core": "^0.7.2",
-        "chokidar": "^3.4.3",
+        "chokidar": "^4.0.1",
         "cli-cursor": "^3.1.0",
         "co-body": "^6.1.0",
         "convert-source-map": "^2.0.0",
@@ -41977,6 +42005,21 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "packages/test-runner-core/node_modules/chokidar": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+      "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "packages/test-runner-core/node_modules/dependency-graph": {
@@ -42057,6 +42100,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/test-runner-core/node_modules/readdirp": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.1.tgz",
+      "integrity": "sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "packages/test-runner-core/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -42090,10 +42146,10 @@
     },
     "packages/test-runner-junit-reporter": {
       "name": "@web/test-runner-junit-reporter",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
-        "@web/test-runner-chrome": "^0.16.0",
+        "@web/test-runner-chrome": "^0.17.0",
         "@web/test-runner-core": "^0.13.0",
         "array-flat-polyfill": "^1.0.1",
         "xml": "^1.0.1"
@@ -42131,7 +42187,7 @@
         "es-module-lexer": "^1.3.1"
       },
       "devDependencies": {
-        "@web/test-runner-chrome": "^0.16.0",
+        "@web/test-runner-chrome": "^0.17.0",
         "@web/test-runner-core": "^0.13.0"
       },
       "engines": {
@@ -42162,10 +42218,10 @@
     },
     "packages/test-runner-puppeteer": {
       "name": "@web/test-runner-puppeteer",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@web/test-runner-chrome": "^0.16.0",
+        "@web/test-runner-chrome": "^0.17.0",
         "@web/test-runner-core": "^0.13.0",
         "puppeteer": "^23.2.0"
       },
@@ -42508,7 +42564,7 @@
     },
     "packages/test-runner-visual-regression": {
       "name": "@web/test-runner-visual-regression",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@types/mkdirp": "^1.0.1",
@@ -42521,7 +42577,7 @@
         "pngjs": "^7.0.0"
       },
       "devDependencies": {
-        "@web/test-runner-chrome": "^0.16.0",
+        "@web/test-runner-chrome": "^0.17.0",
         "@web/test-runner-playwright": "^0.11.0",
         "@web/test-runner-webdriver": "^0.8.0",
         "mocha": "^10.2.0"

--- a/packages/dev-server-core/package.json
+++ b/packages/dev-server-core/package.json
@@ -61,7 +61,7 @@
     "@types/koa": "^2.11.6",
     "@types/ws": "^7.4.0",
     "@web/parse5-utils": "^2.1.0",
-    "chokidar": "^3.4.3",
+    "chokidar": "^4.0.1",
     "clone": "^2.1.2",
     "es-module-lexer": "^1.0.0",
     "get-stream": "^6.0.0",

--- a/packages/dev-server-core/src/server/DevServerCoreConfig.ts
+++ b/packages/dev-server-core/src/server/DevServerCoreConfig.ts
@@ -1,7 +1,7 @@
 import { Middleware } from 'koa';
 import { Plugin } from '../plugins/Plugin';
 import { Server } from 'net';
-import chokidar from 'chokidar';
+import type { ChokidarOptions } from 'chokidar';
 
 export type MimeTypeMappings = Record<string, string>;
 
@@ -72,5 +72,5 @@ export interface DevServerCoreConfig {
   /**
    * Additional options you want to provide to chokidar file watcher
    */
-  chokidarOptions?: chokidar.WatchOptions;
+  chokidarOptions?: ChokidarOptions;
 }

--- a/packages/test-runner-core/package.json
+++ b/packages/test-runner-core/package.json
@@ -61,7 +61,7 @@
     "@types/istanbul-reports": "^3.0.0",
     "@web/browser-logs": "^0.4.0",
     "@web/dev-server-core": "^0.7.2",
-    "chokidar": "^3.4.3",
+    "chokidar": "^4.0.1",
     "cli-cursor": "^3.1.0",
     "co-body": "^6.1.0",
     "convert-source-map": "^2.0.0",


### PR DESCRIPTION
## What I did

1. Bumped chokidar to v4.0.1 which removes 11 dependencies and has better TypeScript support

local test pass, and it builds locally as well