### PR TITLE
`dev-server-core/WebSocketsManager`: send periodic ping over WebSockets to prevent connection closure for inactivity

### DIFF
--- a/packages/dev-server-core/src/web-sockets/WebSocketsManager.ts
+++ b/packages/dev-server-core/src/web-sockets/WebSocketsManager.ts
@@ -29,7 +29,10 @@ export class WebSocketsManager extends EventEmitter<Events> {
     });
     this.webSocketServer.on('connection', webSocket => {
       this.openSockets.add(webSocket);
+      // Ping periodically to prevent socket from being closed with error status 1006 due to inactivity e.g. when testing on Browserstack
+      const pingInterval = setInterval(() => { webSocket.ping() }, 10000);
       webSocket.on('close', () => {
+        clearInterval(pingInterval);
         this.openSockets.delete(webSocket);
       });
 


### PR DESCRIPTION
## What I did

1. Added pinging mechanism over the web sockets to prevent unexpected connection closure after ~60s (with websocket error `1006`) when testing on BrowserStack (Safari).

I couldn't get to the bottom of what exactly is causing the timeout, but sending periodic ping messages fixes it. I checked if the `ws` server is closing the connection, but it doesn't seem to be the case; using a ping to keep the connection alive is suggested [here](https://github.com/websockets/ws/issues/1436).