### PR TITLE
fix: test result serialization with immutable or unserializable errors

### DIFF
--- a/integration/test-runner/tests/test-failure/browser-tests/fail-readonly-actual.test.js
+++ b/integration/test-runner/tests/test-failure/browser-tests/fail-readonly-actual.test.js
@@ -1,6 +1,0 @@
-import { expect } from '../../../../../node_modules/@esm-bundle/chai/esm/chai.js';
-
-it('readonly actual', function() {
-  const fixture = Object.freeze({x: {}});
-  expect(fixture).to.equal(null);
-})

--- a/integration/test-runner/tests/test-failure/browser-tests/fail-unserializable-actual.test.js
+++ b/integration/test-runner/tests/test-failure/browser-tests/fail-unserializable-actual.test.js
@@ -1,0 +1,21 @@
+import { expect } from '../../../../../node_modules/@esm-bundle/chai/esm/chai.js';
+
+xit('readonly actual', function() {
+  const fixture = Object.freeze({x: {}});
+  expect(fixture).to.equal(null);
+})
+
+it('symbol actual', function() {
+  const fixture = Symbol('foo');
+  expect(fixture).to.equal(null);
+})
+
+it('globalThis actual', function() {
+  const fixture = globalThis;
+  expect(fixture).to.equal(null);
+})
+
+it('HTMLElement actual', function() {
+  const fixture = document.createElement('div');
+  expect(fixture).to.equal(null);
+})

--- a/integration/test-runner/tests/test-failure/runTestFailureTest.ts
+++ b/integration/test-runner/tests/test-failure/runTestFailureTest.ts
@@ -209,13 +209,16 @@ export function runTestFailureTest(
       }
     });
 
-    it('handles tests that error with a readonly actual', () => {
-      const sessions = allSessions.filter(s => s.testFile.endsWith('fail-readonly-actual.test.js'));
+    it('handles tests that error with an immutable or unserializable actual', () => {
+      const sessions = allSessions.filter(s => s.testFile.endsWith('fail-unserializable-actual.test.js'));
       expect(sessions.length === browserCount).to.equal(true);
       for (const session of sessions) {
-        expect(session.testResults!.tests.map(t => t.name)).to.eql(['readonly actual']);
+        expect(session.testResults!.tests.map(t => t.name)).to.eql(['unserializable actual']);
         expect(session.passed).to.be.false;
         expect(session.testResults!.tests![0].error!.message).to.equal(
+          'expected { x: {} } to equal null',
+        );
+        expect(session.testResults!.tests![1].error!.message).to.equal(
           'expected { x: {} } to equal null',
         );
       }


### PR DESCRIPTION
## What I did

1. Add test cases for the troublesome test results, see #2772
