### PR TITLE
feat(test-runner-browserstack): Make the local proxy configurable

### DIFF
--- a/.changeset/chilled-books-burn.md
+++ b/.changeset/chilled-books-burn.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-browserstack': minor
+---
+
+Allow to disable the local proxy for CI environments

--- a/packages/test-runner-browserstack/src/browserstackLauncher.ts
+++ b/packages/test-runner-browserstack/src/browserstackLauncher.ts
@@ -11,15 +11,14 @@ import {
 export interface BrowserstackLauncherArgs {
   capabilities: Record<string, unknown>;
   localOptions?: Partial<browserstack.Options>;
+  local?: boolean
 }
 
 const REQUIRED_CAPABILITIES = ['name', 'browserstack.user', 'browserstack.key', 'project', 'build'];
-const localIp = internalIp.v4.sync() as string;
-if (!localIp) {
-  throw new Error('Can not determine the local IP.');
-}
 
 export class BrowserstackLauncher extends WebdriverLauncher {
+  private localIp?: string;
+
   constructor(
     private capabilities: Record<string, unknown>,
     public name: string,
@@ -34,19 +33,35 @@ export class BrowserstackLauncher extends WebdriverLauncher {
       user: capabilities['browserstack.user'] as string,
       key: capabilities['browserstack.key'] as string,
     });
+
+    if (this.capabilities['browserstack.local']) {
+      this.localIp = internalIp.v4.sync() as string;
+      if (!this.localIp) {
+        throw new Error('Can not determine the local IP.');
+      }
+    }
   }
 
   async initialize(config: TestRunnerCoreConfig) {
-    await registerBrowserstackLocal(
-      this,
-      this.capabilities['browserstack.key'] as string,
-      this.localOptions,
-    );
+    if (this.capabilities['browserstack.local']) {
+      await registerBrowserstackLocal(
+        this,
+        this.capabilities['browserstack.key'] as string,
+        this.localOptions,
+      );
+    }
     await super.initialize(config);
   }
 
   startSession(sessionId: string, url: string) {
-    return super.startSession(sessionId, url.replace(/(localhost|127\.0\.0\.1)/, localIp));
+    if (url === 'localhost' || url === '127.0.0.1') {
+      if (!this.localIp) {
+        throw new Error('If you want to use a local domain, make sure to enable the browserstack.local capability.');
+      }
+      url = url.replace(/(localhost|127\.0\.0\.1)/, this.localIp)
+    }
+
+    return super.startSession(sessionId, url);
   }
 
   async startDebugSession() {
@@ -55,7 +70,9 @@ export class BrowserstackLauncher extends WebdriverLauncher {
 
   stop() {
     const stopPromise = super.stop();
-    unregisterBrowserstackLocal(this);
+    if (this.capabilities['browserstack.local']) {
+      unregisterBrowserstackLocal(this);
+    }
     return stopPromise;
   }
 }
@@ -79,7 +96,7 @@ export function browserstackLauncher(args: BrowserstackLauncherArgs): BrowserLau
 
   const capabilities = { ...args.capabilities };
   capabilities['timeout'] = 300;
-  capabilities['browserstack.local'] = true;
+  capabilities['browserstack.local'] = args.local ?? true;
   capabilities['browserstack.localIdentifier'] = localId;
 
   // we need to allow popups since we open new windows


### PR DESCRIPTION
## What I did

1. I introduced a top level local options, which allow you to disable the local proxy setup. This is specially useful when you just want to test public reachable domains
2. I have made the internal IP lookup conditional based on the capability.local flag, to make sure that it will only be run in cases it is really needed. This is also useful in CI environments where the ip command may not be available. Event an import of the module has previously crashed such CI runs.
