### PR TITLE
fix: test on Node 22 explicitely

### DIFF
--- a/.github/workflows/verify-node.yml
+++ b/.github/workflows/verify-node.yml
@@ -15,6 +15,7 @@ jobs:
         node-version:
           - '18'
           - '20'
+          - '22'
           - 'latest'
 
     steps:


### PR DESCRIPTION
## What I did

1. While Node 23 and 24 are being relesed, we start getting errors on them and we lost Node 22 testing which is probably most important at the moment, so I added it to the suite explicitely.

Node 18 is still required since it's in official maintenance until 2025-04-30
https://nodejs.org/en/about/previous-releases
https://github.com/nodejs/release#release-schedule
