### PR TITLE
chore: pin Ubuntu version in GitHub Actions to 22.04

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -12,7 +12,7 @@ jobs:
     # Prevents changesets action from creating a PR on forks
     if: github.repository == 'modernweb-dev/web'
     name: Pre-release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
   linux:
     timeout-minutes: 30
     name: Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     # Prevents changesets action from creating a PR on forks
     if: github.repository == 'modernweb-dev/web'
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/verify-browser.yml
+++ b/.github/workflows/verify-browser.yml
@@ -9,7 +9,7 @@ jobs:
   verify-linux:
     timeout-minutes: 30
     name: Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/verify-node.yml
+++ b/.github/workflows/verify-node.yml
@@ -9,7 +9,7 @@ jobs:
   verify-linux:
     timeout-minutes: 30
     name: Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node-version:

--- a/.github/workflows/verify-storybook-builder.yml
+++ b/.github/workflows/verify-storybook-builder.yml
@@ -6,7 +6,7 @@ jobs:
   verify-storybook-builder-linux:
     timeout-minutes: 60
     name: Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## What I did

1. Pinned Ubuntu version since the `latest` now refers to the `ubuntu-24.04` and that has some problems. See https://github.com/vaadin/web-components/pull/8375 for more context.
