### PR TITLE
chore: continue tests on other Node versions if one fails

### DIFF
--- a/.github/workflows/verify-node.yml
+++ b/.github/workflows/verify-node.yml
@@ -11,6 +11,7 @@ jobs:
     name: Linux
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         node-version:
           - '18'


### PR DESCRIPTION
## What I did

1. when Node 23 fails now, we still want to know if others work, but now if Node 23 fails earlier than others, everything stops and we don't know the result
