### PR TITLE
fix(test-runner-saucelabs): use correct SauceLabsCapabilities type

### DIFF
--- a/.changeset/chatty-rings-tease.md
+++ b/.changeset/chatty-rings-tease.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-saucelabs': patch
+---
+
+Use correct type for providing SauceLabsCapabilities object in createSauceLabsLauncher

--- a/packages/test-runner-saucelabs/src/createSauceLabsLauncher.ts
+++ b/packages/test-runner-saucelabs/src/createSauceLabsLauncher.ts
@@ -7,7 +7,7 @@ import { SauceLabsLauncherManager } from './SauceLabsLauncherManager.js';
 
 export function createSauceLabsLauncher(
   saucelabsOptions: SauceLabsOptions,
-  saucelabsCapabilities?: WebdriverIO.Capabilities,
+  saucelabsCapabilities?: WebdriverIO.Capabilities['sauce:options'],
   sauceConnectOptions?: SauceConnectOptions,
 ) {
   if (saucelabsOptions == null) {


### PR DESCRIPTION
## What I did

1. Fixed type for providing a `SauceLabsCapabilities` object to `createSauceLabsLauncher`

## Notes

The parameter is specifically for providing SauceLabs capabilities and is destructured into `sauce:options` in the final capabilities object:
https://github.com/modernweb-dev/web/blob/12d0de49e05f38db32745448ec06f5033b07b431/packages/test-runner-saucelabs/src/createSauceLabsLauncher.ts#L48-L51

Thus the type should also reflect that the parameter should contain Sauce Labs capabilities and not all Web Driver capabilities. You can see this being an issue in `packages/test-runner-saucelabs/test-remote/saucelabsLauncher.test.ts` for example, which doesn't compile ATM.