### PR TITLE
chore: migrate from deprecated upload-artifact

### DIFF
--- a/.github/workflows/verify-storybook-builder.yml
+++ b/.github/workflows/verify-storybook-builder.yml
@@ -3,19 +3,23 @@ name: Verify Storybook Builder
 on: pull_request
 
 jobs:
-  verify-storybook-builder-linux:
+  verify-storybook-builder:
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-22.04, windows-2022]
+    runs-on: ${{ matrix.runs-on }}
+    name: ${{ matrix.runs-on }}
     timeout-minutes: 60
-    name: Linux
-    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node 20
+      - name: Setup Node 22
         uses: actions/setup-node@v4
         env:
           FORCE_COLOR: 0
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install Dependencies
@@ -33,46 +37,9 @@ jobs:
       - name: Run tests
         run: npm run test:storybook-builder
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report
-          path: packages/storybook-framework-web-components/playwright-report/
-          retention-days: 30
-
-  verify-storybook-builder-windows:
-    timeout-minutes: 60
-    name: Windows
-    runs-on: windows-2022
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node 20
-        uses: actions/setup-node@v4
-        env:
-          FORCE_COLOR: 0
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install Dependencies
-        run: npm ci
-
-      - name: Build packages
-        run: npm run build
-
-      - name: Symlink built packages binaries (e.g. "wds")
-        run: npm ci
-
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
-
-      - name: Run tests
-        run: npm run test:storybook-builder
-
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.runs-on }}
           path: packages/storybook-framework-web-components/playwright-report/
           retention-days: 30


### PR DESCRIPTION
## What I did

1. Migrated from `upload-artifact@v3` to `upload-artifact@v4`, it contains breaking changes, so I updated accordingly
  `upload-artifact@v3` was deprecated in November 2024 and completely stopped working in one of recent PRs failing the build, so I needed to do that to bring Storybook Builder tests back to a working state
3. Combined Linux & Windows builds of Storybook Builder into a matrix, just saw an example how to do that keeping the flow the same, so DRYed it
4. Bumped Node to 22 in Storybook Builder tests
