### PR TITLE
chore(test-runner-playwright): bump playwright

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13508,9 +13508,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001607",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001607.tgz",
-      "integrity": "sha512-WcvhVRjXLKFB/kmOFVwELtMxyhq3iM/MvmXcyCe2PNf166c39mptscOc/45TTS96n2gpNV2z7+NakArTWZCQ3w==",
+      "version": "1.0.30001697",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001697.tgz",
+      "integrity": "sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -13524,7 +13524,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/capital-case": {
       "version": "1.0.4",
@@ -28603,6 +28604,7 @@
       "version": "1.36.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.36.1.tgz",
       "integrity": "sha512-2ZqHpD0U0COKR8bqR3W5IkyIAAM0mT9FgGJB9xWCI1qAUkqLxJskA1ueeQOTH2Qfz3+oxdwwf2EzdOX+RkZmmQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -28619,6 +28621,7 @@
       "version": "1.36.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.36.1.tgz",
       "integrity": "sha512-7+tmPuMcEW4xeCL9cp9KxmYpQYHKkyjwoXRnoeTowaeNat8PoBMk/HwCYhqkH2fRkshfKEOiVus/IhID2Pg8kg==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -39843,6 +39846,21 @@
         "node": ">=18.0.0"
       }
     },
+    "packages/test-runner-commands/node_modules/@web/test-runner-playwright": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-playwright/-/test-runner-playwright-0.11.0.tgz",
+      "integrity": "sha512-s+f43DSAcssKYVOD9SuzueUcctJdHzq1by45gAnSCKa9FQcaTbuYe8CzmxA21g+NcL5+ayo4z+MA9PO4H+PssQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@web/test-runner-core": "^0.13.0",
+        "@web/test-runner-coverage-v8": "^0.8.0",
+        "playwright": "^1.22.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "packages/test-runner-commands/node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -40049,6 +40067,21 @@
         "node": ">=18.0.0"
       }
     },
+    "packages/test-runner-junit-reporter/node_modules/@web/test-runner-playwright": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-playwright/-/test-runner-playwright-0.11.0.tgz",
+      "integrity": "sha512-s+f43DSAcssKYVOD9SuzueUcctJdHzq1by45gAnSCKa9FQcaTbuYe8CzmxA21g+NcL5+ayo4z+MA9PO4H+PssQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@web/test-runner-core": "^0.13.0",
+        "@web/test-runner-coverage-v8": "^0.8.0",
+        "playwright": "^1.22.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "packages/test-runner-mocha": {
       "name": "@web/test-runner-mocha",
       "version": "0.9.0",
@@ -40088,12 +40121,12 @@
     },
     "packages/test-runner-playwright": {
       "name": "@web/test-runner-playwright",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "@web/test-runner-core": "^0.13.0",
         "@web/test-runner-coverage-v8": "^0.8.0",
-        "playwright": "^1.22.2"
+        "playwright": "^1.50.0"
       },
       "devDependencies": {
         "@web/test-runner-mocha": "^0.9.0",
@@ -40101,6 +40134,36 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "packages/test-runner-playwright/node_modules/playwright": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
+      "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.50.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "packages/test-runner-playwright/node_modules/playwright-core": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
+      "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/test-runner-puppeteer": {
@@ -41083,6 +41146,21 @@
         "@web/test-runner-playwright": "^0.11.0",
         "@web/test-runner-webdriver": "^0.9.0",
         "mocha": "^10.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/test-runner-visual-regression/node_modules/@web/test-runner-playwright": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-playwright/-/test-runner-playwright-0.11.0.tgz",
+      "integrity": "sha512-s+f43DSAcssKYVOD9SuzueUcctJdHzq1by45gAnSCKa9FQcaTbuYe8CzmxA21g+NcL5+ayo4z+MA9PO4H+PssQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@web/test-runner-core": "^0.13.0",
+        "@web/test-runner-coverage-v8": "^0.8.0",
+        "playwright": "^1.22.2"
       },
       "engines": {
         "node": ">=18.0.0"

--- a/packages/test-runner-playwright/package.json
+++ b/packages/test-runner-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web/test-runner-playwright",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "publishConfig": {
     "access": "public"
   },
@@ -48,7 +48,7 @@
   "dependencies": {
     "@web/test-runner-core": "^0.13.0",
     "@web/test-runner-coverage-v8": "^0.8.0",
-    "playwright": "^1.22.2"
+    "playwright": "^1.50.0"
   },
   "devDependencies": {
     "@web/test-runner-mocha": "^0.9.0",


### PR DESCRIPTION
### Summary

@web/test-runner-playwright uses old version of Playwright, which causes problems on Ubuntu 24.04 internally. 

This issue shows the situation well: https://github.com/microsoft/playwright/issues/33051.

### Consideration

- Some other packages are depending on this @web/test-runner-playwright. I'm going to post another PR after this is merged.
- This is my first issue on the project. If I missed something, please let me know :D

