### PR TITLE
fix: prevent puppeteer download issues from blocking storybook-builder tests

### DIFF
--- a/.github/workflows/verify-storybook-builder.yml
+++ b/.github/workflows/verify-storybook-builder.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     name: ${{ matrix.runs-on }}
     timeout-minutes: 60
+    env:
+      PUPPETEER_SKIP_DOWNLOAD: true # prevent failures due to puppeteer downloading issues, since it's not used here anyway
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## What I did

1. prevent puppeteer download issues from blocking storybook-builder tests

puppeteer is not used in storybook-builder tests anyway, so no need to download it, and it's probably better for perf also

Issues look like this, I could only found that it's probably due to some server availability where puppeteer binaries are downloaded from, I saw these multiple times lately, often 2nd restart helped to resolve, so this proves the theory.

![image](https://github.com/user-attachments/assets/9bce30c3-fad0-468a-9bc4-0a61a8d4a29c)

