### PR TITLE
fix: try to prevent npm update issue

### DIFF
--- a/.changeset/spicy-dragons-search.md
+++ b/.changeset/spicy-dragons-search.md
@@ -1,0 +1,6 @@
+---
+'@web/storybook-utils': patch
+'@web/mocks': patch
+---
+
+try to prevent npm update issue "Could not resolve dependency" between Storybook 7 and 8

--- a/package-lock.json
+++ b/package-lock.json
@@ -5929,7 +5929,6 @@
       "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.5.5.tgz",
       "integrity": "sha512-QDquWLfIBIGfaEwHfwzMhvSntiIiWNkn7D6a6OWDcPXBWAfQcuMf5jX1ngysrJseefmPJQQ2dSQDSrtrYGDhTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
@@ -36587,6 +36586,8 @@
       "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
+        "@storybook/manager-api": "^7.0.0 || ^8.0.0",
+        "@storybook/preview-api": "^7.0.0 || ^8.0.0",
         "@web/storybook-prebuilt": "^0.1.37",
         "@web/storybook-utils": "^1.1.0",
         "lit": "^2.7.5 || ^3.0.0",
@@ -36595,10 +36596,6 @@
       "devDependencies": {
         "@web/dev-server": "^0.4.6",
         "@web/dev-server-storybook": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@storybook/manager-api": "^7.0.0 || ^8.0.0",
-        "@storybook/preview-api": "^7.0.0 || ^8.0.0"
       }
     },
     "packages/mocks/node_modules/@mswjs/interceptors": {
@@ -38486,6 +38483,9 @@
       "name": "@web/storybook-utils",
       "version": "1.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@storybook/core-events": "^7.0.0 || ^8.0.0"
+      },
       "devDependencies": {
         "react": "^18.0.0"
       },
@@ -38493,7 +38493,6 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@storybook/core-events": "^7.0.0 || ^8.0.0",
         "react": "^18.0.0"
       }
     },

--- a/packages/mocks/package.json
+++ b/packages/mocks/package.json
@@ -63,11 +63,9 @@
     "mocks",
     "msw"
   ],
-  "peerDependencies": {
-    "@storybook/manager-api": "^7.0.0 || ^8.0.0",
-    "@storybook/preview-api": "^7.0.0 || ^8.0.0"
-  },
   "dependencies": {
+    "@storybook/manager-api": "^7.0.0 || ^8.0.0",
+    "@storybook/preview-api": "^7.0.0 || ^8.0.0",
     "@web/storybook-prebuilt": "^0.1.37",
     "@web/storybook-utils": "^1.1.0",
     "lit": "^2.7.5 || ^3.0.0",

--- a/packages/storybook-utils/package.json
+++ b/packages/storybook-utils/package.json
@@ -40,8 +40,10 @@
     "utils"
   ],
   "peerDependencies": {
-    "@storybook/core-events": "^7.0.0 || ^8.0.0",
     "react": "^18.0.0"
+  },
+  "dependencies": {
+    "@storybook/core-events": "^7.0.0 || ^8.0.0"
   },
   "devDependencies": {
     "react": "^18.0.0"


### PR DESCRIPTION
## What I did

I'm entering a dangerous zone here, but some things is needed and testing it with local `npm link` I think is not a good idea.
Supporting both Storybook 7 and 8 within the same package with `peerDependencies` is not working.

`npm update` gives an error currently in a project where Storybook 7 is used with `@web/mocks` and `@web/storybook-builder`

So now trying with normal dependencies, which is actually even logical, because storybook doesn't really have to install the packages itself, it's more for the addons to do since they use them, so using peer deps was not a good idea too.

```
npm error Found: storybook@7.6.20
npm error node_modules/storybook
npm error   dev storybook@"^7.6.20" from the root project
npm error
npm error Could not resolve dependency:
npm error peer storybook@"^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0" from @storybook/manager-api@8.5.6
npm error node_modules/@storybook/manager-api
npm error   peer @storybook/manager-api@"^7.0.0 || ^8.0.0" from @web/mocks@1.3.0
npm error   node_modules/@web/mocks
npm error     dev @web/mocks@"^1.2.3" from the root project
npm error
```