### PR TITLE
feat(test-runner-junit-reporter): Add support for flat test files to junit-reporter

### DIFF
--- a/.changeset/rotten-brooms-carry.md
+++ b/.changeset/rotten-brooms-carry.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-junit-reporter': minor
+---
+
+chore: Add support for flat test files to junit reporter

--- a/packages/test-runner-junit-reporter/src/junitReporter.ts
+++ b/packages/test-runner-junit-reporter/src/junitReporter.ts
@@ -69,7 +69,7 @@ interface TestSuiteXMLAttributes {
 const assignSessionAndSuitePropertiesToTests = ({
   testResults,
   ...rest
-}: TestSession): TestResultWithMetadata[] => {
+}: TestSession, rootDir: string): TestResultWithMetadata[] => {
   const assignToTest =
     (parentSuiteName: string) =>
     (test: TestResult): TestResultWithMetadata => {
@@ -87,7 +87,11 @@ const assignSessionAndSuitePropertiesToTests = ({
 
   const suites = testResults?.suites ?? [];
 
-  return suites.flatMap(assignToSuite(''));
+  const testsWithoutSuite = testResults?.tests ?? [];
+
+  const suiteName = `${rest.browser.name}_${rest.browser.type}_${rest.testFile.replace(rootDir, '')}`;
+
+  return [...suites.flatMap(assignToSuite('')), ...testsWithoutSuite.flatMap(assignToTest(suiteName))];
 };
 
 const toResultsWithMetadataByBrowserTestFileName = (
@@ -291,7 +295,7 @@ function getTestRunXML({
 }): string {
   const testsuites = Object.entries(
     sessions
-      .flatMap(assignSessionAndSuitePropertiesToTests)
+      .flatMap(s => assignSessionAndSuitePropertiesToTests(s, rootDir))
       .reduce(
         toResultsWithMetadataByBrowserTestFileName,
         {} as TestResultsWithMetadataByBrowserTestFileName,

--- a/packages/test-runner-junit-reporter/test/fixtures/flat/expected.xml
+++ b/packages/test-runner-junit-reporter/test/fixtures/flat/expected.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="Chrome_puppeteer_/packages/test-runner-junit-reporter/test/fixtures/flat/flat-test.js" id="0" tests="5" skipped="1" errors="1" failures="1" time="<<computed>>">
+    <properties>
+      <property name="test.fileName" value="packages/test-runner-junit-reporter/test/fixtures/flat/flat-test.js"/>
+      <property name="browser.name" value="Chrome"/>
+      <property name="browser.launcher" value="puppeteer"/>
+    </properties>
+    <testcase name="under addition" time="<<computed>>" classname="Chrome_puppeteer_/packages/test-runner-junit-reporter/test/fixtures/flat/flat-test.js" file="packages/test-runner-junit-reporter/test/fixtures/flat/flat-test.js"/>
+    <testcase name="null hypothesis" time="<<computed>>" classname="Chrome_puppeteer_/packages/test-runner-junit-reporter/test/fixtures/flat/flat-test.js" file="packages/test-runner-junit-reporter/test/fixtures/flat/flat-test.js"/>
+    <testcase name="asserts error" time="<<computed>>" classname="Chrome_puppeteer_/packages/test-runner-junit-reporter/test/fixtures/flat/flat-test.js" file="packages/test-runner-junit-reporter/test/fixtures/flat/flat-test.js" line="12">
+      <failure message="expected false to be true" type="AssertionError"><![CDATA[AssertionError: expected false to be true
+  at <<anonymous>> (packages/test-runner-junit-reporter/test/fixtures/flat/flat-test.js:12:27)]]></failure>
+    </testcase>
+    <testcase name="tbd: confirm true positive" time="<<computed>>" classname="Chrome_puppeteer_/packages/test-runner-junit-reporter/test/fixtures/flat/flat-test.js" file="packages/test-runner-junit-reporter/test/fixtures/flat/flat-test.js">
+      <skipped/>
+    </testcase>
+    <testcase name="reports logs to JUnit" time="<<computed>>" classname="Chrome_puppeteer_/packages/test-runner-junit-reporter/test/fixtures/flat/flat-test.js" file="packages/test-runner-junit-reporter/test/fixtures/flat/flat-test.js"/>
+  </testsuite>
+</testsuites>

--- a/packages/test-runner-junit-reporter/test/fixtures/flat/flat-test.js
+++ b/packages/test-runner-junit-reporter/test/fixtures/flat/flat-test.js
@@ -1,0 +1,23 @@
+import '../../../../../node_modules/chai/chai.js';
+
+it('under addition', function () {
+  chai.expect(1 + 1).to.equal(2);
+});
+
+it('null hypothesis', function () {
+  chai.expect(true).to.be.true;
+});
+
+it('asserts error', function () {
+  chai.expect(false).to.be.true;
+});
+
+it.skip('tbd: confirm true positive', function () {
+  chai.expect(false).to.be.false;
+});
+
+it('reports logs to JUnit', function () {
+  const actual = '🤷‍♂️';
+  console.log('actual is ', actual);
+  chai.expect(typeof actual).to.equal('string');
+});

--- a/packages/test-runner-junit-reporter/test/fixtures/multiple/expected.xml
+++ b/packages/test-runner-junit-reporter/test/fixtures/multiple/expected.xml
@@ -1,5 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
+  <testsuite name="Chrome_puppeteer_/packages/test-runner-junit-reporter/test/fixtures/multiple/flat-test.js" id="0" tests="5" skipped="1" errors="1" failures="1" time="<<computed>>">
+    <properties>
+      <property name="test.fileName" value="packages/test-runner-junit-reporter/test/fixtures/multiple/flat-test.js"/>
+      <property name="browser.name" value="Chrome"/>
+      <property name="browser.launcher" value="puppeteer"/>
+    </properties>
+    <testcase name="under addition" time="<<computed>>" classname="Chrome_puppeteer_/packages/test-runner-junit-reporter/test/fixtures/multiple/flat-test.js" file="packages/test-runner-junit-reporter/test/fixtures/multiple/flat-test.js"/>
+    <testcase name="null hypothesis" time="<<computed>>" classname="Chrome_puppeteer_/packages/test-runner-junit-reporter/test/fixtures/multiple/flat-test.js" file="packages/test-runner-junit-reporter/test/fixtures/multiple/flat-test.js"/>
+    <testcase name="asserts error" time="<<computed>>" classname="Chrome_puppeteer_/packages/test-runner-junit-reporter/test/fixtures/multiple/flat-test.js" file="packages/test-runner-junit-reporter/test/fixtures/multiple/flat-test.js" line="12">
+      <failure message="expected false to be true" type="AssertionError"><![CDATA[AssertionError: expected false to be true
+  at <<anonymous>> (packages/test-runner-junit-reporter/test/fixtures/multiple/flat-test.js:12:27)]]></failure>
+    </testcase>
+    <testcase name="tbd: confirm true positive" time="<<computed>>" classname="Chrome_puppeteer_/packages/test-runner-junit-reporter/test/fixtures/multiple/flat-test.js" file="packages/test-runner-junit-reporter/test/fixtures/multiple/flat-test.js">
+      <skipped/>
+    </testcase>
+    <testcase name="reports logs to JUnit" time="<<computed>>" classname="Chrome_puppeteer_/packages/test-runner-junit-reporter/test/fixtures/multiple/flat-test.js" file="packages/test-runner-junit-reporter/test/fixtures/multiple/flat-test.js"/>
+  </testsuite>
   <testsuite name="Chrome_puppeteer_/packages/test-runner-junit-reporter/test/fixtures/multiple/nested-test.js" id="0" tests="1" skipped="0" errors="0" failures="0" time="<<computed>>">
     <properties>
       <property name="test.fileName" value="packages/test-runner-junit-reporter/test/fixtures/multiple/nested-test.js"/>

--- a/packages/test-runner-junit-reporter/test/fixtures/multiple/flat-test.js
+++ b/packages/test-runner-junit-reporter/test/fixtures/multiple/flat-test.js
@@ -1,0 +1,23 @@
+import '../../../../../node_modules/chai/chai.js';
+
+it('under addition', function () {
+  chai.expect(1 + 1).to.equal(2);
+});
+
+it('null hypothesis', function () {
+  chai.expect(true).to.be.true;
+});
+
+it('asserts error', function () {
+  chai.expect(false).to.be.true;
+});
+
+it.skip('tbd: confirm true positive', function () {
+  chai.expect(false).to.be.false;
+});
+
+it('reports logs to JUnit', function () {
+  const actual = '🤷‍♂️';
+  console.log('actual is ', actual);
+  chai.expect(typeof actual).to.equal('string');
+});

--- a/packages/test-runner-junit-reporter/test/junitReporter.test.ts
+++ b/packages/test-runner-junit-reporter/test/junitReporter.test.ts
@@ -95,4 +95,12 @@ describe('junitReporter', function () {
       expect(actual).to.equal(expected);
     });
   });
+
+  describe('for flat test files', function () {
+    const fixtureDir = path.join(__dirname, 'fixtures/flat');
+    it('produces expected results', async function () {
+      const { actual, expected } = await run(fixtureDir);
+      expect(actual).to.equal(expected);
+    });
+  });
 });


### PR DESCRIPTION
## What I did

Add support for test files that do not use a `describe` block (aka "flat") to the junit-reporter. 

A file like this would now be included in the report, where before it would not:
```typescript
it('under addition', function () {
  chai.expect(1 + 1).to.equal(2);
});

it('null hypothesis', function () {
  chai.expect(true).to.be.true;
});

it('asserts error', function () {
  chai.expect(false).to.be.true;
});
```

As for what to call the Test Suite - I followed the same pattern that the `toResultsWithMetadataByBrowserTestFileName` function was using. So each of these test suites will be named based on the browser + file being tested.

This should be a non-breaking change from my testing - it is only intended to detect some test cases that wouldn't be included previously!

closes #2901 
