### PR TITLE
refactor(config-loader): do not lookup `package.json` with explicit extensions

### DIFF
--- a/.changeset/nice-guests-invent.md
+++ b/.changeset/nice-guests-invent.md
@@ -1,0 +1,9 @@
+---
+'@web/config-loader': patch
+---
+
+Optimizes config loading to not look for `package.json` in file system if the
+config extension is already informing whether CommonJS or ESM is used.
+
+Currently config loading did unnecessarily traverse the file system. This could
+be unnecessary slowness, or cause issues in sandbox environments (like Bazel)

--- a/packages/config-loader/src/importOrRequireConfig.js
+++ b/packages/config-loader/src/importOrRequireConfig.js
@@ -17,7 +17,6 @@ function importConfig(configPath) {
  * @param {string} basedir
  */
 async function importOrRequireConfig(configPath, basedir) {
-  const packageType = await getPackageType(basedir);
   const ext = path.extname(configPath);
 
   switch (ext) {
@@ -26,6 +25,7 @@ async function importOrRequireConfig(configPath, basedir) {
     case '.cjs':
       return requireConfig(configPath);
     default:
+      const packageType = await getPackageType(basedir);
       return packageType === 'module' ? importConfig(configPath) : requireConfig(configPath);
   }
 }


### PR DESCRIPTION
Currently when a config has an explicit extension, the config-loader still tries resolving/traversing for a `package.json` file. This can be slow, and also break in some environments with sandboxing; especially when used in combination with Bazel.

It doesn't seem investigating why the calls are stuck, if the logic should not run in general when an explicit extension is provided.