### PR TITLE
docs: use better mocha function types

### DIFF
--- a/docs/docs/test-runner/test-frameworks/mocha.md
+++ b/docs/docs/test-runner/test-frameworks/mocha.md
@@ -7,8 +7,8 @@ Test framework implementation of [Mocha](https://mochajs.org/).
 Mocha relies on global variables, in any JS test file `describe` and `it` are available globally and can be used directly:
 
 ```js
-describe('my test', () => {
-  it('foo is bar', () => {
+describe('my test', function () {
+  it('foo is bar', async function () {
     if ('foo' !== 'bar') {
       throw new Error('foo does not equal bar');
     }


### PR DESCRIPTION
If you use arrow functions, you cannot use mocha features like `timeout` and `skip`. The docs make it clear that they're not recommended: https://mochajs.org/#arrow-functions

Also the docs make it clear that you can use async functions in `it` to support async operations, but cannot do so in `describe`: https://mochajs.org/#using-async-await

A lot of people copy the example code and work from there. By using the correct function declarations and including async, you make it a lot easier to get started without encountering weird bugs or having to read a lot of mocha documentation.