### PR TITLE
docs: use better mocha function types

### DIFF
--- a/docs/docs/test-runner/writing-tests/html-tests.md
+++ b/docs/docs/test-runner/writing-tests/html-tests.md
@@ -13,8 +13,8 @@ With mocha, you need to define your tests inside the `runTests` function:
 
       runTests(async () => {
         // write your tests inline
-        describe('HTML tests', () => {
-          it('works', () => {
+        describe('HTML tests', function () {
+          it('works', async function () {
             expect('foo').to.equal('foo');
           });
         });


### PR DESCRIPTION
If you use arrow functions, you cannot use mocha features like `timeout` and `skip`. The docs make it clear that they're not recommended: https://mochajs.org/#arrow-functions

Also the docs make it clear that you can use async functions in `it` to support async operations, but cannot do so in `describe`: https://mochajs.org/#using-async-await

A lot of people copy the example code and work from there. By using the correct function declarations and including async, you make it a lot easier to get started without encountering weird bugs or having to read a lot of mocha documentation.