### PR TITLE
fix(summaryReporter): add back broken error reporting and make log reporting optional for summaryReporter

### DIFF
--- a/.changeset/tiny-apes-protect.md
+++ b/.changeset/tiny-apes-protect.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner': patch
+---
+
+Fixed error reporting and made browser logs optional in summary reporter

--- a/.changeset/tiny-apes-protect.md
+++ b/.changeset/tiny-apes-protect.md
@@ -2,4 +2,4 @@
 '@web/test-runner': patch
 ---
 
-Fixed error reporting and made browser logs optional in summary reporter
+Summary Reporter - re-enabled error reporting and made option to disable browser logs and error reporting in this reporter

--- a/packages/test-runner/src/reporter/summaryReporter.ts
+++ b/packages/test-runner/src/reporter/summaryReporter.ts
@@ -29,7 +29,7 @@ const dim = color([2, 0]);
 
 /** Test reporter that summarizes all test for a given run */
 export function summaryReporter(opts: Options): Reporter {
-  const { flatten = false, reportTestLogs = true, reportTestErrors = false } = opts ?? {};
+  const { flatten = false, reportTestLogs = true, reportTestErrors = true } = opts ?? {};
   let args: ReporterArgs;
   let favoriteBrowser: string;
 

--- a/packages/test-runner/src/reporter/summaryReporter.ts
+++ b/packages/test-runner/src/reporter/summaryReporter.ts
@@ -9,10 +9,13 @@ import type {
 import { reportTestsErrors } from './reportTestsErrors.js';
 import { reportTestFileErrors } from './reportTestFileErrors.js';
 
+import { TestRunnerLogger } from '../logger/TestRunnerLogger.js';
 import { reportBrowserLogs } from './reportBrowserLogs.js';
 
 interface Options {
   flatten?: boolean;
+  reportTestLogs?: boolean;
+  reportTestErrors?: boolean;
 }
 
 const color =
@@ -26,9 +29,11 @@ const dim = color([2, 0]);
 
 /** Test reporter that summarizes all test for a given run */
 export function summaryReporter(opts: Options): Reporter {
-  const { flatten = false } = opts ?? {};
+  const { flatten = false, reportTestLogs = true, reportTestErrors = false } = opts ?? {};
   let args: ReporterArgs;
   let favoriteBrowser: string;
+
+  const testLogger = new TestRunnerLogger();
 
   function log(
     logger: Logger,
@@ -80,7 +85,6 @@ export function summaryReporter(opts: Options): Reporter {
     logResults(logger, suite, pref, browser);
   }
 
-  let cachedLogger: Logger;
   return {
     start(_args) {
       args = _args;
@@ -92,26 +96,27 @@ export function summaryReporter(opts: Options): Reporter {
     },
 
     reportTestFileResults({ logger, sessionsForTestFile }) {
-      cachedLogger = logger;
       for (const session of sessionsForTestFile) {
         logResults(logger, session.testResults, '', session.browser);
         logger.log('');
       }
-      reportBrowserLogs(logger, sessionsForTestFile);
+      if (reportTestLogs) reportBrowserLogs(logger, sessionsForTestFile);
     },
 
     onTestRunFinished({ sessions }) {
-      const failedSessions = sessions.filter(s => !s.passed);
-      if (failedSessions.length > 0) {
-        cachedLogger.log('\n\nErrors Reported in Tests:\n\n');
-        reportTestsErrors(cachedLogger, args.browserNames, favoriteBrowser, failedSessions);
-        reportTestFileErrors(
-          cachedLogger,
-          args.browserNames,
-          favoriteBrowser,
-          failedSessions,
-          true,
-        );
+      if (reportTestErrors) {
+        const failedSessions = sessions.filter(s => !s.passed);
+        if (failedSessions.length > 0) {
+          testLogger.log('\n\nErrors Reported in Tests:\n\n');
+          reportTestsErrors(testLogger, args.browserNames, favoriteBrowser, failedSessions);
+          reportTestFileErrors(
+            testLogger,
+            args.browserNames,
+            favoriteBrowser,
+            failedSessions,
+            true,
+          );
+        }
       }
     },
   };


### PR DESCRIPTION
## What I did

1. Added back support for reporting a summary of errors in summaryReporter
2. Added option to turn off error reporting in summaryReporter
3. Added option to turn off log reporting in summaryReporter

I found that in #2126 the option to add log reporting was enabled but it also replaced the logger with the reportTestFileResults BufferedLogger. However this logger flushes its log buffer as soon as reportTestFileResults stage finishes and then this logger is used for Error reporting in onTestRunFinished() and this reporting now just goes to a buffer that is never flushed.  I resolved this issue by moving the error reporting logging back to TestRunnerLogger. This change could be a breaking change to some users who have worked around the lack of error reporting so I have added a flag so it can be turned off if needed but have set error reporting to enabled by default to match the original older working behaviour.

Also it is often useful to combine multiple reporters and if other reporters have log reporting like the defaultReporter it can double up log reporting in some combinations so I added a flag to optionally turn this off if needed.


