### PR TITLE
summaryReporter: Add missing `cachedLogger.logBufferedMessages()` call in onTestRunFinished

### DIFF
--- a/.changeset/fix-buffered-logging-summery-reporter.md
+++ b/.changeset/fix-buffered-logging-summery-reporter.md
@@ -1,0 +1,9 @@
+---
+'@web/test-runner': patch
+---
+
+summaryReporter: Add missing `cachedLogger.logBufferedMessages()` call in onTestRunFinished
+
+Since the move to buffered logging in https://github.com/modernweb-dev/web/commit/b2c857362d894a9eceb36516af84a800209f187b. A call to `cachedLogger.logBufferedMessages();` was missing. We fix this by adding it. We call `cachedLogger.logBufferedMessages();` after reportTestFileResults but before onTestRunFinished. So the logging we do in summaryReporter. onTestRunFinished gets missed.
+
+Fixes #2936

--- a/packages/test-runner/src/reporter/summaryReporter.ts
+++ b/packages/test-runner/src/reporter/summaryReporter.ts
@@ -1,5 +1,6 @@
 import type {
   BrowserLauncher,
+  BufferedLogger,
   Logger,
   Reporter,
   ReporterArgs,
@@ -80,7 +81,7 @@ export function summaryReporter(opts: Options): Reporter {
     logResults(logger, suite, pref, browser);
   }
 
-  let cachedLogger: Logger;
+  let cachedLogger: BufferedLogger;
   return {
     start(_args) {
       args = _args;
@@ -92,7 +93,7 @@ export function summaryReporter(opts: Options): Reporter {
     },
 
     reportTestFileResults({ logger, sessionsForTestFile }) {
-      cachedLogger = logger;
+      cachedLogger = logger as BufferedLogger;
       for (const session of sessionsForTestFile) {
         logResults(logger, session.testResults, '', session.browser);
         logger.log('');
@@ -112,6 +113,7 @@ export function summaryReporter(opts: Options): Reporter {
           failedSessions,
           true,
         );
+        cachedLogger.logBufferedMessages();
       }
     },
   };


### PR DESCRIPTION
Since the move to buffered logging in https://github.com/modernweb-dev/web/commit/b2c857362d894a9eceb36516af84a800209f187b. A call to `cachedLogger.logBufferedMessages();` was missing. We fix this by adding it. We call `cachedLogger.logBufferedMessages();` after reportTestFileResults but before onTestRunFinished. So the logging we do in summaryReporter. onTestRunFinished gets missed.

Fixes #2936