### PR TITLE
fix: coverage report with instrumented code

### DIFF
--- a/.changeset/two-poems-learn.md
+++ b/.changeset/two-poems-learn.md
@@ -1,0 +1,5 @@
+---
+'@web/test-runner-playwright': patch
+---
+
+Fixes coverage report collecting test coverage whenever the coverage is executed, not just when using the native instrumentation.

--- a/packages/test-runner-playwright/src/PlaywrightLauncherPage.ts
+++ b/packages/test-runner-playwright/src/PlaywrightLauncherPage.ts
@@ -11,6 +11,7 @@ export class PlaywrightLauncherPage {
   public playwrightContext: BrowserContext;
   public playwrightPage: Page;
   private nativeInstrumentationEnabledOnPage = false;
+  private collectCoverage = false;
 
   constructor(
     config: TestRunnerCoreConfig,
@@ -27,6 +28,8 @@ export class PlaywrightLauncherPage {
   }
 
   async runSession(url: string, coverage: boolean) {
+    this.collectCoverage = coverage;
+
     if (
       coverage &&
       this.product === 'chromium' &&
@@ -44,7 +47,7 @@ export class PlaywrightLauncherPage {
   }
 
   async stopSession(): Promise<SessionResult> {
-    const testCoverage = this.nativeInstrumentationEnabledOnPage
+    const testCoverage = this.collectCoverage
       ? await this.collectTestCoverage(this.config, this.testFiles)
       : undefined;
 
@@ -77,8 +80,8 @@ export class PlaywrightLauncherPage {
     if (config.coverageConfig?.nativeInstrumentation === false) {
       throw new Error(
         'Coverage is enabled with nativeInstrumentation disabled. ' +
-          'Expected coverage provided in the browser as a global __coverage__ variable.' +
-          'Use a plugin like babel-plugin-istanbul to generate the coverage, or enable native instrumentation.',
+        'Expected coverage provided in the browser as a global __coverage__ variable.' +
+        'Use a plugin like babel-plugin-istanbul to generate the coverage, or enable native instrumentation.',
       );
     }
 


### PR DESCRIPTION
## What I did

1. Collects test coverage whenever the coverage is executed, not just when using the native instrumentation.

Fixes #2719 