### PR TITLE
fix: avoid browser crashes when serializing browser logs of complex objects

### DIFF
--- a/.changeset/three-gifts-clap.md
+++ b/.changeset/three-gifts-clap.md
@@ -1,0 +1,14 @@
+---
+'@web/browser-logs': patch
+---
+
+Avoid browser crashes when serializing browser logs of complex objects
+
+If we are seeing too many object iterations, we know something is off. This can
+happen when we are seeing e.g. large linked lists where every element recursively
+has access to the full list again. This will not quickly yield circular early bail-outs,
+but instead result in the stringification to take LOTS of processing time and results
+in browser crashes. We should limit object iterations for this reason, and instead expect
+people to inspect such logs in the browser directly.
+
+Related #2798.


### PR DESCRIPTION
If we are seeing too many object iterations, we know something is off. This can happen when we are seeing e.g. large linked lists where every element recursively has access to the full list again. This will not quickly yield circular early bail-outs, but instead result in the stringification to take LOTS of processing time and results in browser crashes. We should limit object iterations for this reason, and instead expect people to inspect such logs in the browser directly.

Without having looked too much into this, I believe this also is confirmed by the issue reported below; where attaching to `document.body` causes the crashes & CPU consumption. The DOM is basically a similarly structured object that can result in many repetitions of "linked lists" that aren't necessarily circular in the current "serialization path".

Related #2798.