### PR TITLE
fix(storybook-utils): allow React 19 and test with it

### DIFF
--- a/.changeset/hungry-sheep-live.md
+++ b/.changeset/hungry-sheep-live.md
@@ -1,0 +1,5 @@
+---
+'@web/storybook-utils': patch
+---
+
+allow React 19 and test with it

--- a/package-lock.json
+++ b/package-lock.json
@@ -5653,16 +5653,6 @@
         "storybook": "^8.6.12"
       }
     },
-    "node_modules/@storybook/addon-docs/node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@storybook/addon-docs/node_modules/react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
@@ -21093,19 +21083,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/loupe": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
@@ -26503,14 +26480,11 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -36287,7 +36261,7 @@
     },
     "packages/mocks": {
       "name": "@web/mocks",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "@storybook/manager-api": "^7.0.0 || ^8.0.0",
@@ -38162,17 +38136,6 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta"
       }
     },
-    "packages/storybook-framework-web-components/node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "packages/storybook-framework-web-components/node_modules/react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
@@ -38195,13 +38158,13 @@
         "@storybook/core-events": "^7.0.0 || ^8.0.0"
       },
       "devDependencies": {
-        "react": "^18.0.0"
+        "react": "^19.0.0"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "packages/test-runner": {

--- a/packages/storybook-utils/package.json
+++ b/packages/storybook-utils/package.json
@@ -40,12 +40,12 @@
     "utils"
   ],
   "peerDependencies": {
-    "react": "^18.0.0"
+    "react": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
     "@storybook/core-events": "^7.0.0 || ^8.0.0"
   },
   "devDependencies": {
-    "react": "^18.0.0"
+    "react": "^19.0.0"
   }
 }


### PR DESCRIPTION
## What I did

1. allow React 19 storybook-utils, not only React 18, since Storybook allows it and we support both too
2. test everything with React 19

This will simplify the dependencies graph, because currently due to how dependencies are resolve, most `@storybook/*` packages will install React 19, so our `@web/storybook-utils` will unnecessarily required React 18 to be installed in nested node_modules, however this is not really needed and we can rely on the root React 19 too.