### PR TITLE
fix(storybook-builder): fix glob-promise security finding

### DIFF
--- a/.changeset/curvy-ducks-destroy.md
+++ b/.changeset/curvy-ducks-destroy.md
@@ -1,0 +1,5 @@
+---
+'@web/storybook-builder': patch
+---
+
+replace glob-promise with glob due to security findings

--- a/package-lock.json
+++ b/package-lock.json
@@ -3035,6 +3035,27 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -7020,6 +7041,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/minimist": {
@@ -16054,35 +16076,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/glob-promise": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-6.0.5.tgz",
-      "integrity": "sha512-uUzvxo60yo/vMLXZHCNAlfdM5U5A07jCnUO8xTK44Z0Vc58poGDXhDx8ju1DmPdprOORh+4Lpog64hl+AJ5piA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/glob": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/ahmadnassri"
-      },
-      "peerDependencies": {
-        "glob": "^8.0.3"
-      }
-    },
-    "node_modules/glob-promise/node_modules/@types/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/minimatch": "^5.1.2",
-        "@types/node": "*"
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
@@ -36738,7 +36731,7 @@
         "cjs-module-lexer": "^1.2.3",
         "es-module-lexer": "^1.2.1",
         "esbuild": "^0.25.0",
-        "glob-promise": "^6.0.3",
+        "glob": "^12.0.0",
         "lodash-es": "^4.17.21",
         "path-browserify": "^1.0.1",
         "rehype-external-links": "^3.0.0",
@@ -36907,11 +36900,50 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "packages/storybook-builder/node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "packages/storybook-builder/node_modules/github-slugger": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "license": "ISC"
+    },
+    "packages/storybook-builder/node_modules/glob": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-12.0.0.tgz",
+      "integrity": "sha512-5Qcll1z7IKgHr5g485ePDdHcNQY0k2dtv/bjYy0iuyGxQw2qSOiiXUXJ+AYQpg3HNoUMHqAruX478Jeev7UULw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "packages/storybook-builder/node_modules/hast-util-heading-rank": {
       "version": "3.0.0",
@@ -37001,6 +37033,30 @@
       "integrity": "sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==",
       "dependencies": {
         "@types/estree": "*"
+      }
+    },
+    "packages/storybook-builder/node_modules/jackspeak": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/storybook-builder/node_modules/lru-cache": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "packages/storybook-builder/node_modules/markdown-extensions": {
@@ -37783,6 +37839,21 @@
       ],
       "license": "MIT"
     },
+    "packages/storybook-builder/node_modules/minimatch": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "packages/storybook-builder/node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -37807,6 +37878,22 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
+    },
+    "packages/storybook-builder/node_modules/path-scurry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "packages/storybook-builder/node_modules/rehype-slug": {
       "version": "6.0.0",
@@ -37884,6 +37971,18 @@
       },
       "peerDependencies": {
         "rollup": "^2.25.0 || ^3.3.0 || ^4.1.4"
+      }
+    },
+    "packages/storybook-builder/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/storybook-builder/node_modules/slash": {

--- a/packages/storybook-builder/package.json
+++ b/packages/storybook-builder/package.json
@@ -63,7 +63,7 @@
     "cjs-module-lexer": "^1.2.3",
     "es-module-lexer": "^1.2.1",
     "esbuild": "^0.25.0",
-    "glob-promise": "^6.0.3",
+    "glob": "^12.0.0",
     "lodash-es": "^4.17.21",
     "path-browserify": "^1.0.1",
     "rehype-external-links": "^3.0.0",


### PR DESCRIPTION
## What I did

1. Our security scanner flagged the old `glob-promise`, so I replaced it with a new `glob` that supports promises out of the box, also it's used by Storybook's own builders. I got some extra fixes from Storybook's codebase which I think are necessary.