### PR TITLE
feat(rollup-plugin-html): suport transform on input html

### DIFF
--- a/.changeset/light-comics-provide.md
+++ b/.changeset/light-comics-provide.md
@@ -1,0 +1,5 @@
+---
+'@web/rollup-plugin-html': minor
+---
+
+support transform on input html

--- a/packages/rollup-plugin-html/src/output/createHTMLOutput.ts
+++ b/packages/rollup-plugin-html/src/output/createHTMLOutput.ts
@@ -15,7 +15,8 @@ export interface CreateHTMLAssetParams {
   input: InputData;
   emittedAssets: EmittedAssets;
   generatedBundles: GeneratedBundle[];
-  externalTransformHtmlFns: TransformHtmlFunction[];
+  inputExternalTransformHtmlFns: TransformHtmlFunction[];
+  outputExternalTransformHtmlFns: TransformHtmlFunction[];
   pluginOptions: RollupPluginHTMLOptions;
   defaultInjectDisabled: boolean;
   serviceWorkerPath: string;
@@ -30,7 +31,8 @@ export async function createHTMLAsset(params: CreateHTMLAssetParams): Promise<Em
     input,
     emittedAssets,
     generatedBundles,
-    externalTransformHtmlFns,
+    inputExternalTransformHtmlFns,
+    outputExternalTransformHtmlFns,
     pluginOptions,
     defaultInjectDisabled,
     serviceWorkerPath,
@@ -57,7 +59,8 @@ export async function createHTMLAsset(params: CreateHTMLAssetParams): Promise<Em
     input,
     outputDir,
     emittedAssets,
-    externalTransformHtmlFns,
+    inputExternalTransformHtmlFns,
+    outputExternalTransformHtmlFns,
     defaultInjectDisabled,
     serviceWorkerPath,
     injectServiceWorker,
@@ -73,7 +76,8 @@ export interface CreateHTMLAssetsParams {
   inputs: InputData[];
   emittedAssets: EmittedAssets;
   generatedBundles: GeneratedBundle[];
-  externalTransformHtmlFns: TransformHtmlFunction[];
+  inputExternalTransformHtmlFns: TransformHtmlFunction[];
+  outputExternalTransformHtmlFns: TransformHtmlFunction[];
   pluginOptions: RollupPluginHTMLOptions;
   defaultInjectDisabled: boolean;
   serviceWorkerPath: string;

--- a/packages/rollup-plugin-html/src/rollupPluginHTML.ts
+++ b/packages/rollup-plugin-html/src/rollupPluginHTML.ts
@@ -18,7 +18,10 @@ import { emitAssets } from './output/emitAssets.js';
 export interface RollupPluginHtml extends Plugin {
   api: {
     getInputs(): InputData[];
-    addHtmlTransformer(transformHtmlFunction: TransformHtmlFunction): void;
+    addHtmlTransformer(
+      transformHtmlFunction: TransformHtmlFunction,
+      transformStage?: 'input' | 'output',
+    ): void;
     disableDefaultInject(): void;
     addOutput(name: string): Plugin;
   };
@@ -28,7 +31,8 @@ export function rollupPluginHTML(pluginOptions: RollupPluginHTMLOptions = {}): R
   const multiOutputNames: string[] = [];
   let inputs: InputData[] = [];
   let generatedBundles: GeneratedBundle[] = [];
-  let externalTransformHtmlFns: TransformHtmlFunction[] = [];
+  let inputExternalTransformHtmlFns: TransformHtmlFunction[] = [];
+  let outputExternalTransformHtmlFns: TransformHtmlFunction[] = [];
   let defaultInjectDisabled = false;
   let serviceWorkerPath = '';
   let injectServiceWorker = false;
@@ -38,7 +42,8 @@ export function rollupPluginHTML(pluginOptions: RollupPluginHTMLOptions = {}): R
   function reset() {
     inputs = [];
     generatedBundles = [];
-    externalTransformHtmlFns = [];
+    inputExternalTransformHtmlFns = [];
+    outputExternalTransformHtmlFns = [];
   }
 
   return {
@@ -146,7 +151,8 @@ export function rollupPluginHTML(pluginOptions: RollupPluginHTMLOptions = {}): R
         inputs,
         emittedAssets,
         generatedBundles,
-        externalTransformHtmlFns,
+        inputExternalTransformHtmlFns,
+        outputExternalTransformHtmlFns,
         pluginOptions,
         defaultInjectDisabled,
         serviceWorkerPath,
@@ -165,8 +171,15 @@ export function rollupPluginHTML(pluginOptions: RollupPluginHTMLOptions = {}): R
         return inputs;
       },
 
-      addHtmlTransformer(transformHtmlFunction: TransformHtmlFunction) {
-        externalTransformHtmlFns.push(transformHtmlFunction);
+      addHtmlTransformer(
+        transformHtmlFunction: TransformHtmlFunction,
+        transformStage: 'input' | 'output' = 'output',
+      ) {
+        if (transformStage === 'input') {
+          inputExternalTransformHtmlFns.push(transformHtmlFunction);
+        } else {
+          outputExternalTransformHtmlFns.push(transformHtmlFunction);
+        }
       },
 
       disableDefaultInject() {
@@ -205,7 +218,8 @@ export function rollupPluginHTML(pluginOptions: RollupPluginHTMLOptions = {}): R
                 inputs,
                 emittedAssets,
                 generatedBundles,
-                externalTransformHtmlFns,
+                inputExternalTransformHtmlFns,
+                outputExternalTransformHtmlFns,
                 pluginOptions,
                 defaultInjectDisabled,
                 serviceWorkerPath,

--- a/packages/rollup-plugin-html/test/rollup-plugin-html.test.ts
+++ b/packages/rollup-plugin-html/test/rollup-plugin-html.test.ts
@@ -626,7 +626,16 @@ describe('rollup-plugin-html', () => {
               return false;
             });
             plugin!.api.addHtmlTransformer((html: string) =>
-              html.replace('</body>', '<!-- injected --></body>'),
+              html.replace('</body>', '<!-- injected to output --></body>'),
+            );
+            plugin!.api.addHtmlTransformer(
+              (html: string) =>
+                html.replace('<!-- injected to output -->', '<!-- injected to output 2 -->'),
+              'output',
+            );
+            plugin!.api.addHtmlTransformer(
+              (html: string) => html.replace('</body>', '<!-- injected to input --></body>'),
+              'input',
             );
           },
         } as Plugin,
@@ -641,9 +650,10 @@ describe('rollup-plugin-html', () => {
     expect(entryB).to.include("console.log('entrypoint-b.js');");
     expect(stripNewlines(getAsset(output, 'index.html').source)).to.equal(
       '<html><head></head><body><h1>hello world</h1>' +
+        '<!-- injected to input -->' +
         '<script type="module" src="./entrypoint-a.js"></script>' +
         '<script type="module" src="./entrypoint-b.js"></script>' +
-        '<!-- injected --></body></html>',
+        '<!-- injected to output 2 --></body></html>',
     );
   });
 

--- a/packages/rollup-plugin-html/test/src/output/getOutputHTML.test.ts
+++ b/packages/rollup-plugin-html/test/src/output/getOutputHTML.test.ts
@@ -105,14 +105,14 @@ describe('getOutputHTML()', () => {
     );
   });
 
-  it('can combine external and regular transform functions', async () => {
+  it('can combine external and regular output transform functions', async () => {
     const output = await getOutputHTML({
       ...defaultOptions,
       pluginOptions: {
         ...defaultOptions.pluginOptions,
         transformHtml: html => html.replace('Input HTML', 'Transformed Input HTML'),
       },
-      externalTransformHtmlFns: [html => html.replace(/h1/g, 'h2')],
+      outputExternalTransformHtmlFns: [html => html.replace(/h1/g, 'h2')],
     });
 
     expect(output).to.equal(


### PR DESCRIPTION
## What I did

1. Add 2nd param to "plugin.api.addHtmlTransformer" to specify the stage of the transform - "input" or "output"
2. By default keep it "output" as before, for backwards compatibility
3. When "input" is set, it will apply to the input HTML instead of output HTML, allowing to add assets and stuff like that that later will go through the pipeline

**GOOD TO MENTION**: Do not confuse with Vite's "order", their transforms always apply to the HTML before it goes through the pipeline, and the "order" only defines the priority of transform functions. If we need to add smth like this in the future, we gonna use a 3rd param, e.g. "priority", for that, but this PR has nothing to do with that, just my 2 cents.