### PR TITLE
refactor: use import type for type-only imports

### DIFF
--- a/.github/workflows/verify-node.yml
+++ b/.github/workflows/verify-node.yml
@@ -17,7 +17,7 @@ jobs:
           - '18'
           - '20'
           - '22'
-          - 'latest'
+          - '24'
 
     steps:
       - uses: actions/checkout@v4
@@ -56,6 +56,8 @@ jobs:
 
       - name: Test
         run: npm run test:node
+        env:
+          NODE_OPTIONS: ${{ (matrix.node-version != '18' && matrix.node-version != '20') && '--no-experimental-strip-types' || '' }}
 
   verify-windows:
     timeout-minutes: 30

--- a/packages/dev-server-core/src/plugins/Plugin.ts
+++ b/packages/dev-server-core/src/plugins/Plugin.ts
@@ -1,9 +1,9 @@
 import { FSWatcher } from 'chokidar';
 import Koa, { Context } from 'koa';
-import { Server } from 'net';
+import { type Server } from 'net';
 
-import { DevServerCoreConfig } from '../server/DevServerCoreConfig';
-import { Logger } from '../logger/Logger';
+import type { DevServerCoreConfig } from '../server/DevServerCoreConfig';
+import type { Logger } from '../logger/Logger';
 import { WebSocketsManager } from '../web-sockets/WebSocketsManager';
 
 export type ServeResult =

--- a/packages/dev-server-core/src/server/createServer.ts
+++ b/packages/dev-server-core/src/server/createServer.ts
@@ -6,9 +6,9 @@ import http2Server from 'http2';
 import fs from 'fs';
 import net, { Server, Socket, ListenOptions } from 'net';
 
-import { DevServerCoreConfig } from './DevServerCoreConfig.js';
+import type { DevServerCoreConfig } from './DevServerCoreConfig.js';
 import { createMiddleware } from './createMiddleware.js';
-import { Logger } from '../logger/Logger.js';
+import type { Logger } from '../logger/Logger.js';
 import { addPlugins } from './addPlugins.js';
 
 /**

--- a/packages/dev-server-rollup/src/index.ts
+++ b/packages/dev-server-rollup/src/index.ts
@@ -1,4 +1,4 @@
-export { RollupNodeResolveOptions, nodeResolve } from '@rollup/plugin-node-resolve';
+export { type RollupNodeResolveOptions, nodeResolve } from '@rollup/plugin-node-resolve';
 export { fromRollup } from './fromRollup.js';
 export { rollupAdapter } from './rollupAdapter.js';
 export { rollupBundlePlugin } from './rollupBundlePlugin.js';

--- a/packages/dev-server/src/config/DevServerConfig.ts
+++ b/packages/dev-server/src/config/DevServerConfig.ts
@@ -1,5 +1,5 @@
-import { DevServerCoreConfig } from '@web/dev-server-core';
-import { RollupNodeResolveOptions } from '@web/dev-server-rollup';
+import { type DevServerCoreConfig } from '@web/dev-server-core';
+import { type RollupNodeResolveOptions } from '@web/dev-server-rollup';
 
 export interface DevServerConfig extends DevServerCoreConfig {
   /**

--- a/packages/dev-server/src/config/mergeConfigs.ts
+++ b/packages/dev-server/src/config/mergeConfigs.ts
@@ -1,4 +1,4 @@
-import { DevServerConfig } from './DevServerConfig.js';
+import { type DevServerConfig } from './DevServerConfig.js';
 
 const arrayKeys = ['plugins', 'middleware'];
 

--- a/packages/dev-server/src/config/parseConfig.ts
+++ b/packages/dev-server/src/config/parseConfig.ts
@@ -1,9 +1,9 @@
 import { getPortPromise } from 'portfinder';
 import path from 'path';
 
-import { DevServerCliArgs } from './readCliArgs.js';
+import { type DevServerCliArgs } from './readCliArgs.js';
 import { mergeConfigs } from './mergeConfigs.js';
-import { DevServerConfig } from './DevServerConfig.js';
+import { type DevServerConfig } from './DevServerConfig.js';
 import { esbuildPlugin } from '../plugins/esbuildPlugin.js';
 import { watchPlugin } from '../plugins/watchPlugin.js';
 import { nodeResolvePlugin } from '../plugins/nodeResolvePlugin.js';

--- a/packages/dev-server/src/config/readCliArgs.ts
+++ b/packages/dev-server/src/config/readCliArgs.ts
@@ -1,7 +1,7 @@
 import commandLineArgs from 'command-line-args';
 import commandLineUsage, { OptionDefinition } from 'command-line-usage';
 import camelCase from 'camelcase';
-import { DevServerConfig } from './DevServerConfig.js';
+import { type DevServerConfig } from './DevServerConfig.js';
 
 export interface DevServerCliArgs
   extends Partial<

--- a/packages/dev-server/src/logger/DevServerLogger.ts
+++ b/packages/dev-server/src/logger/DevServerLogger.ts
@@ -1,4 +1,4 @@
-import { Logger, PluginSyntaxError } from '@web/dev-server-core';
+import { type Logger, PluginSyntaxError } from '@web/dev-server-core';
 import { codeFrameColumns } from '@babel/code-frame';
 import path from 'path';
 import { red, cyan } from 'nanocolors';

--- a/packages/dev-server/src/logger/createLogger.ts
+++ b/packages/dev-server/src/logger/createLogger.ts
@@ -1,4 +1,4 @@
-import { Plugin } from '@web/dev-server-core';
+import { type Plugin } from '@web/dev-server-core';
 import { DevServerLogger } from './DevServerLogger.js';
 import { logStartMessage } from './logStartMessage.js';
 

--- a/packages/dev-server/src/logger/logStartMessage.ts
+++ b/packages/dev-server/src/logger/logStartMessage.ts
@@ -1,5 +1,5 @@
-import { DevServerConfig } from '../config/DevServerConfig';
-import { Logger } from '@web/dev-server-core';
+import { type DevServerConfig } from '../config/DevServerConfig';
+import { type Logger } from '@web/dev-server-core';
 import internalIp from 'internal-ip';
 import { bold, cyan, white } from 'nanocolors';
 

--- a/packages/dev-server/src/plugins/nodeResolvePlugin.ts
+++ b/packages/dev-server/src/plugins/nodeResolvePlugin.ts
@@ -1,5 +1,5 @@
-import { nodeResolve, rollupAdapter, RollupNodeResolveOptions } from '@web/dev-server-rollup';
-import { Plugin } from '@web/dev-server-core';
+import { nodeResolve, rollupAdapter, type RollupNodeResolveOptions } from '@web/dev-server-rollup';
+import { type Plugin } from '@web/dev-server-core';
 import deepmerge from 'deepmerge';
 
 export function nodeResolvePlugin(

--- a/packages/dev-server/src/plugins/watchPlugin.ts
+++ b/packages/dev-server/src/plugins/watchPlugin.ts
@@ -1,4 +1,4 @@
-import { Plugin } from '@web/dev-server-core';
+import { type Plugin } from '@web/dev-server-core';
 import debounce from 'debounce';
 
 export function watchPlugin(): Plugin {

--- a/packages/rollup-plugin-html/src/assets/utils.ts
+++ b/packages/rollup-plugin-html/src/assets/utils.ts
@@ -1,4 +1,4 @@
-import { Document, Element } from 'parse5';
+import type { Document, Element } from 'parse5';
 import path from 'path';
 import picomatch from 'picomatch';
 import { findElements, getTagName, getAttribute } from '@web/parse5-utils';

--- a/packages/rollup-plugin-html/src/index.ts
+++ b/packages/rollup-plugin-html/src/index.ts
@@ -1,6 +1,6 @@
-import { rollupPluginHTML, RollupPluginHtml } from './rollupPluginHTML.js';
+import { rollupPluginHTML, type RollupPluginHtml } from './rollupPluginHTML.js';
 
-export {
+export type {
   InputHTMLOptions,
   RollupPluginHTMLOptions,
   GeneratedBundle,
@@ -10,5 +10,5 @@ export {
   TransformAssetFunction,
 } from './RollupPluginHTMLOptions.js';
 
-export { rollupPluginHTML, RollupPluginHtml };
+export { rollupPluginHTML, type RollupPluginHtml };
 export default rollupPluginHTML;

--- a/packages/rollup-plugin-html/src/input/extract/extractAssets.ts
+++ b/packages/rollup-plugin-html/src/input/extract/extractAssets.ts
@@ -1,7 +1,7 @@
-import { Document, serialize } from 'parse5';
+import { type Document, serialize } from 'parse5';
 import fs from 'fs';
 import path from 'path';
-import { InputAsset } from '../InputData.js';
+import { type InputAsset } from '../InputData.js';
 import {
   findAssets,
   getSourcePaths,

--- a/packages/rollup-plugin-html/src/input/extract/extractModules.ts
+++ b/packages/rollup-plugin-html/src/input/extract/extractModules.ts
@@ -1,10 +1,10 @@
 import { findElements, getAttribute, getTagName, getTextContent, remove } from '@web/parse5-utils';
-import { Document, Attribute } from 'parse5';
+import { type Document, type Attribute } from 'parse5';
 import path from 'path';
 import crypto from 'crypto';
 import { resolveAssetFilePath } from '../../assets/utils.js';
 import { getAttributes } from '@web/parse5-utils';
-import { ScriptModuleTag } from '../../RollupPluginHTMLOptions.js';
+import { type ScriptModuleTag } from '../../RollupPluginHTMLOptions.js';
 
 export interface ExtractModulesParams {
   document: Document;

--- a/packages/rollup-plugin-html/src/output/hashInlineScripts.ts
+++ b/packages/rollup-plugin-html/src/output/hashInlineScripts.ts
@@ -1,4 +1,4 @@
-import { Document, Element, ParentNode } from 'parse5';
+import type { Document, Element, ParentNode } from 'parse5';
 import {
   findElement,
   findElements,

--- a/packages/rollup-plugin-html/src/output/injectAbsoluteBaseUrl.ts
+++ b/packages/rollup-plugin-html/src/output/injectAbsoluteBaseUrl.ts
@@ -1,4 +1,4 @@
-import { Document, Element } from 'parse5';
+import type { Document, Element } from 'parse5';
 import { findElements, getTagName, getAttribute, setAttribute } from '@web/parse5-utils';
 
 function isAbsoluteableNode(node: Element) {

--- a/packages/rollup-plugin-html/src/output/injectBundles.ts
+++ b/packages/rollup-plugin-html/src/output/injectBundles.ts
@@ -1,7 +1,7 @@
-import { Document, Attribute } from 'parse5';
+import type { Document, Attribute } from 'parse5';
 import { createScript, findElement, getTagName, appendChild } from '@web/parse5-utils';
 
-import { EntrypointBundle } from '../RollupPluginHTMLOptions.js';
+import { type EntrypointBundle } from '../RollupPluginHTMLOptions.js';
 import { createError } from '../utils.js';
 
 export function createLoadScript(src: string, format: string, attributes?: Attribute[]) {

--- a/packages/rollup-plugin-html/src/output/injectServiceWorkerRegistration.ts
+++ b/packages/rollup-plugin-html/src/output/injectServiceWorkerRegistration.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { Document } from 'parse5';
+import type { Document } from 'parse5';
 import {
   findElement,
   getTagName,

--- a/packages/rollup-plugin-html/src/output/injectedUpdatedAssetPaths.ts
+++ b/packages/rollup-plugin-html/src/output/injectedUpdatedAssetPaths.ts
@@ -1,5 +1,5 @@
 import { getAttribute, setAttribute } from '@web/parse5-utils';
-import { Document } from 'parse5';
+import type { Document } from 'parse5';
 import path from 'path';
 
 import {
@@ -10,9 +10,9 @@ import {
   resolveAssetFilePath,
   createAssetPicomatchMatcher,
 } from '../assets/utils.js';
-import { InputData } from '../input/InputData.js';
+import { type InputData } from '../input/InputData.js';
 import { createError } from '../utils.js';
-import { EmittedAssets } from './emitAssets.js';
+import { type EmittedAssets } from './emitAssets.js';
 import { toBrowserPath } from './utils.js';
 
 export interface InjectUpdatedAssetPathsArgs {

--- a/packages/rollup-plugin-polyfills-loader/src/types.d.ts
+++ b/packages/rollup-plugin-polyfills-loader/src/types.d.ts
@@ -1,4 +1,4 @@
-import { PolyfillsConfig, FileType } from '@web/polyfills-loader';
+import { PolyfillsConfig, type FileType } from '@web/polyfills-loader';
 
 export interface OutputConfig {
   name: string;

--- a/packages/test-runner-commands/test/execute-server-command/executeServerCommand.test.ts
+++ b/packages/test-runner-commands/test/execute-server-command/executeServerCommand.test.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { runTests } from '@web/test-runner-core/test-helpers';
 import { chromeLauncher } from '@web/test-runner-chrome';
-import { Logger } from '@web/dev-server-core';
+import type { Logger } from '@web/dev-server-core';
 
 describe('executeServerCommand', function test() {
   this.timeout(20000);

--- a/packages/test-runner-core/src/browser-launcher/BrowserLauncher.ts
+++ b/packages/test-runner-core/src/browser-launcher/BrowserLauncher.ts
@@ -1,6 +1,6 @@
-import { CoverageMapData } from 'istanbul-lib-coverage';
-import { TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig';
-import { TestResultError } from '../test-session/TestSession';
+import type { CoverageMapData } from 'istanbul-lib-coverage';
+import { type TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig';
+import { type TestResultError } from '../test-session/TestSession';
 
 export interface SessionResult {
   testCoverage?: CoverageMapData;

--- a/packages/test-runner-core/src/cli/BufferedLogger.ts
+++ b/packages/test-runner-core/src/cli/BufferedLogger.ts
@@ -1,4 +1,4 @@
-import { Logger, ErrorWithLocation } from '../logger/Logger';
+import { type Logger, type ErrorWithLocation } from '../logger/Logger';
 
 export class BufferedLogger implements Logger {
   public buffer: { method: keyof Logger; args?: any[] }[] = [];

--- a/packages/test-runner-core/src/cli/TestRunnerCli.ts
+++ b/packages/test-runner-core/src/cli/TestRunnerCli.ts
@@ -10,12 +10,12 @@ import { DynamicTerminal } from './terminal/DynamicTerminal.js';
 import { BufferedLogger } from './BufferedLogger.js';
 import { getManualDebugMenu } from './getManualDebugMenu.js';
 import { ErrorWithLocation } from '../logger/Logger.js';
-import { TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig.js';
-import { TestSessionManager } from '../test-session/TestSessionManager.js';
+import { type TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig.js';
+import { type TestSessionManager } from '../test-session/TestSessionManager.js';
 import { SESSION_STATUS } from '../test-session/TestSessionStatus.js';
-import { Logger } from '../logger/Logger.js';
+import { type Logger } from '../logger/Logger.js';
 import { TestRunner } from '../runner/TestRunner.js';
-import { TestCoverage } from '../coverage/getTestCoverage.js';
+import { type TestCoverage } from '../coverage/getTestCoverage.js';
 
 export type MenuType = 'none' | 'overview' | 'focus' | 'debug' | 'manual-debug';
 

--- a/packages/test-runner-core/src/cli/getManualDebugMenu.ts
+++ b/packages/test-runner-core/src/cli/getManualDebugMenu.ts
@@ -1,7 +1,7 @@
 import { cyan, gray } from 'nanocolors';
 import internalIp from 'internal-ip';
 
-import { TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig';
+import { type TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig';
 
 export function getManualDebugMenu(config: TestRunnerCoreConfig): string[] {
   const localAddress = `${config.protocol}//${config.hostname}:${config.port}/`;

--- a/packages/test-runner-core/src/cli/writeCoverageReport.ts
+++ b/packages/test-runner-core/src/cli/writeCoverageReport.ts
@@ -1,8 +1,8 @@
 import reports from 'istanbul-reports';
 import libReport from 'istanbul-lib-report';
 
-import { CoverageConfig } from '../config/TestRunnerCoreConfig';
-import { TestCoverage } from '../coverage/getTestCoverage';
+import { type CoverageConfig } from '../config/TestRunnerCoreConfig';
+import { type TestCoverage } from '../coverage/getTestCoverage';
 
 export function writeCoverageReport(testCoverage: TestCoverage, config: CoverageConfig) {
   // create a context for report generation

--- a/packages/test-runner-core/src/config/TestRunnerCoreConfig.ts
+++ b/packages/test-runner-core/src/config/TestRunnerCoreConfig.ts
@@ -1,11 +1,11 @@
-import { Middleware } from '@web/dev-server-core';
-import { BrowserLauncher } from '../browser-launcher/BrowserLauncher.js';
-import { TestFramework } from '../test-framework/TestFramework.js';
-import { TestSession } from '../test-session/TestSession.js';
-import { Reporter } from '../reporter/Reporter.js';
-import { Logger } from '../logger/Logger.js';
-import { TestRunnerPlugin } from '../server/TestRunnerPlugin.js';
-import { ReportType } from 'istanbul-reports';
+import { type Middleware } from '@web/dev-server-core';
+import { type BrowserLauncher } from '../browser-launcher/BrowserLauncher.js';
+import { type TestFramework } from '../test-framework/TestFramework.js';
+import { type TestSession } from '../test-session/TestSession.js';
+import { type Reporter } from '../reporter/Reporter.js';
+import { type Logger } from '../logger/Logger.js';
+import { type TestRunnerPlugin } from '../server/TestRunnerPlugin.js';
+import type { ReportType } from 'istanbul-reports';
 
 export interface CoverageThresholdConfig {
   statements: number;

--- a/packages/test-runner-core/src/config/TestRunnerGroupConfig.ts
+++ b/packages/test-runner-core/src/config/TestRunnerGroupConfig.ts
@@ -1,5 +1,5 @@
-import { BrowserLauncher } from '../browser-launcher/BrowserLauncher';
-import { TestRunnerCoreConfig } from './TestRunnerCoreConfig.js';
+import { type BrowserLauncher } from '../browser-launcher/BrowserLauncher';
+import { type TestRunnerCoreConfig } from './TestRunnerCoreConfig.js';
 
 export interface TestRunnerGroupConfig {
   name: string;

--- a/packages/test-runner-core/src/coverage/getTestCoverage.ts
+++ b/packages/test-runner-core/src/coverage/getTestCoverage.ts
@@ -1,15 +1,15 @@
 import {
   createCoverageMap,
-  CoverageSummaryData,
-  CoverageMap,
-  CoverageMapData,
-  BranchMapping,
-  FunctionMapping,
-  Location,
-  Range,
+  type CoverageSummaryData,
+  type CoverageMap,
+  type CoverageMapData,
+  type BranchMapping,
+  type FunctionMapping,
+  type Location,
+  type Range,
 } from 'istanbul-lib-coverage';
-import { TestSession } from '../test-session/TestSession';
-import { CoverageConfig } from '../config/TestRunnerCoreConfig';
+import { type TestSession } from '../test-session/TestSession';
+import { type CoverageConfig } from '../config/TestRunnerCoreConfig';
 
 export const coverageTypes: (keyof CoverageSummaryData)[] = [
   'lines',

--- a/packages/test-runner-core/src/reporter/Reporter.ts
+++ b/packages/test-runner-core/src/reporter/Reporter.ts
@@ -1,9 +1,9 @@
-import { TestSession } from '../test-session/TestSession';
-import { TestSessionManager } from '../test-session/TestSessionManager';
-import { TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig';
-import { TestCoverage } from '../coverage/getTestCoverage';
-import { Logger } from '../logger/Logger';
-import { BrowserLauncher } from '../browser-launcher/BrowserLauncher';
+import { type TestSession } from '../test-session/TestSession';
+import { type TestSessionManager } from '../test-session/TestSessionManager';
+import { type TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig';
+import { type TestCoverage } from '../coverage/getTestCoverage';
+import { type Logger } from '../logger/Logger';
+import { type BrowserLauncher } from '../browser-launcher/BrowserLauncher';
 
 export interface ReporterArgs {
   config: TestRunnerCoreConfig;

--- a/packages/test-runner-core/src/runner/TestRunner.ts
+++ b/packages/test-runner-core/src/runner/TestRunner.ts
@@ -1,7 +1,7 @@
-import { TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig.js';
+import { type TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig.js';
 import { createTestSessions } from './createSessionGroups.js';
-import { TestSession } from '../test-session/TestSession.js';
-import { getTestCoverage, TestCoverage } from '../coverage/getTestCoverage.js';
+import { type TestSession } from '../test-session/TestSession.js';
+import { getTestCoverage, type TestCoverage } from '../coverage/getTestCoverage.js';
 import { TestScheduler } from './TestScheduler.js';
 import { TestSessionManager } from '../test-session/TestSessionManager.js';
 import { SESSION_STATUS } from '../test-session/TestSessionStatus.js';
@@ -9,8 +9,8 @@ import { EventEmitter } from '../utils/EventEmitter.js';
 import { createSessionUrl } from './createSessionUrl.js';
 import { createDebugSessions } from './createDebugSessions.js';
 import { TestRunnerServer } from '../server/TestRunnerServer.js';
-import { BrowserLauncher } from '../browser-launcher/BrowserLauncher.js';
-import { TestRunnerGroupConfig } from '../config/TestRunnerGroupConfig.js';
+import { type BrowserLauncher } from '../browser-launcher/BrowserLauncher.js';
+import { type TestRunnerGroupConfig } from '../config/TestRunnerGroupConfig.js';
 
 interface EventMap {
   'test-run-started': { testRun: number };

--- a/packages/test-runner-core/src/runner/TestScheduler.ts
+++ b/packages/test-runner-core/src/runner/TestScheduler.ts
@@ -1,11 +1,11 @@
 import { createSessionUrl } from './createSessionUrl.js';
-import { TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig.js';
-import { TestSessionManager } from '../test-session/TestSessionManager.js';
-import { TestSession, TestResultError } from '../test-session/TestSession.js';
+import { type TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig.js';
+import { type TestSessionManager } from '../test-session/TestSessionManager.js';
+import { type TestSession, type TestResultError } from '../test-session/TestSession.js';
 import { SESSION_STATUS } from '../test-session/TestSessionStatus.js';
 import { withTimeout } from '../utils/async.js';
 import { TestSessionTimeoutHandler } from './TestSessionTimeoutHandler.js';
-import { BrowserLauncher } from '../browser-launcher/BrowserLauncher.js';
+import { type BrowserLauncher } from '../browser-launcher/BrowserLauncher.js';
 
 export class TestScheduler {
   private config: TestRunnerCoreConfig;

--- a/packages/test-runner-core/src/runner/TestSessionTimeoutHandler.ts
+++ b/packages/test-runner-core/src/runner/TestSessionTimeoutHandler.ts
@@ -1,6 +1,6 @@
-import { TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig.js';
-import { TestSessionManager } from '../test-session/TestSessionManager.js';
-import { TestSession, TestResultError } from '../test-session/TestSession.js';
+import { type TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig.js';
+import { type TestSessionManager } from '../test-session/TestSessionManager.js';
+import { type TestSession, type TestResultError } from '../test-session/TestSession.js';
 import { SESSION_STATUS } from '../test-session/TestSessionStatus.js';
 import { TestScheduler } from './TestScheduler.js';
 

--- a/packages/test-runner-core/src/runner/createDebugSessions.ts
+++ b/packages/test-runner-core/src/runner/createDebugSessions.ts
@@ -1,6 +1,6 @@
 import { nanoid } from 'nanoid';
-import { DebugTestSession } from '../test-session/DebugTestSession';
-import { TestSession } from '../test-session/TestSession';
+import { type DebugTestSession } from '../test-session/DebugTestSession';
+import { type TestSession } from '../test-session/TestSession';
 
 export function createDebugSessions(sessions: TestSession[]): DebugTestSession[] {
   const debugSessions = [];

--- a/packages/test-runner-core/src/runner/createSessionGroups.ts
+++ b/packages/test-runner-core/src/runner/createSessionGroups.ts
@@ -2,12 +2,12 @@ import { nanoid } from 'nanoid';
 import path from 'path';
 
 import { SESSION_STATUS } from '../test-session/TestSessionStatus.js';
-import { TestSession } from '../test-session/TestSession.js';
-import { TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig.js';
-import { TestRunnerGroupConfig } from '../config/TestRunnerGroupConfig.js';
-import { BrowserLauncher } from '../browser-launcher/BrowserLauncher.js';
+import { type TestSession } from '../test-session/TestSession.js';
+import { type TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig.js';
+import { type TestRunnerGroupConfig } from '../config/TestRunnerGroupConfig.js';
+import { type BrowserLauncher } from '../browser-launcher/BrowserLauncher.js';
 import { collectTestFiles } from './collectTestFiles.js';
-import { TestSessionGroup } from '../test-session/TestSessionGroup.js';
+import { type TestSessionGroup } from '../test-session/TestSessionGroup.js';
 
 interface GroupConfigWithoutOptionals extends TestRunnerGroupConfig {
   name: string;

--- a/packages/test-runner-core/src/runner/createSessionUrl.ts
+++ b/packages/test-runner-core/src/runner/createSessionUrl.ts
@@ -1,7 +1,7 @@
 import path from 'path';
-import { TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig.js';
+import { type TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig.js';
 import { PARAM_SESSION_ID } from '../utils/constants.js';
-import { BasicTestSession } from '../test-session/BasicTestSession.js';
+import { type BasicTestSession } from '../test-session/BasicTestSession.js';
 
 const toBrowserPathRegExp = new RegExp(path.sep === '\\' ? '\\\\' : path.sep, 'g');
 

--- a/packages/test-runner-core/src/server/TestRunnerPlugin.ts
+++ b/packages/test-runner-core/src/server/TestRunnerPlugin.ts
@@ -1,5 +1,5 @@
-import { Plugin } from '@web/dev-server-core';
-import { BasicTestSession } from '../test-session/BasicTestSession';
+import { type Plugin } from '@web/dev-server-core';
+import { type BasicTestSession } from '../test-session/BasicTestSession';
 
 export type ExecuteCommandResult = void | unknown | Promise<void> | Promise<unknown>;
 

--- a/packages/test-runner-core/src/server/TestRunnerServer.ts
+++ b/packages/test-runner-core/src/server/TestRunnerServer.ts
@@ -1,13 +1,13 @@
-import { DevServer, Plugin } from '@web/dev-server-core';
+import { DevServer, type Plugin } from '@web/dev-server-core';
 import chokidar from 'chokidar';
 
-import { RunSessions, watchFilesMiddleware } from './middleware/watchFilesMiddleware.js';
+import { type RunSessions, watchFilesMiddleware } from './middleware/watchFilesMiddleware.js';
 import { cacheMiddleware } from './middleware/cacheMiddleware.js';
 import { serveTestRunnerHtmlPlugin } from './plugins/serveTestRunnerHtmlPlugin.js';
 import { serveTestFrameworkPlugin } from './plugins/serveTestFrameworkPlugin.js';
 import { testRunnerApiPlugin } from './plugins/api/testRunnerApiPlugin.js';
-import { TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig';
-import { TestSessionManager } from '../test-session/TestSessionManager';
+import { type TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig';
+import { type TestSessionManager } from '../test-session/TestSessionManager';
 import { TestRunner } from '../runner/TestRunner';
 
 const CACHED_PATTERNS = [

--- a/packages/test-runner-core/src/server/middleware/cacheMiddleware.ts
+++ b/packages/test-runner-core/src/server/middleware/cacheMiddleware.ts
@@ -1,4 +1,4 @@
-import { Middleware } from '@web/dev-server-core';
+import { type Middleware } from '@web/dev-server-core';
 import path from 'path';
 
 export function cacheMiddleware(cachedPatterns: string[], watch: boolean): Middleware {

--- a/packages/test-runner-core/src/server/middleware/watchFilesMiddleware.ts
+++ b/packages/test-runner-core/src/server/middleware/watchFilesMiddleware.ts
@@ -1,12 +1,12 @@
-import { Middleware, Context } from '@web/dev-server-core';
+import { type Middleware, type Context } from '@web/dev-server-core';
 import { DepGraph } from 'dependency-graph';
 import debounce from 'debounce';
 import path from 'path';
 import { FSWatcher } from 'chokidar';
 
-import { TestSessionManager } from '../../test-session/TestSessionManager.js';
+import { type TestSessionManager } from '../../test-session/TestSessionManager.js';
 import { constants } from '../../index.js';
-import { TestSession } from '../../test-session/TestSession.js';
+import { type TestSession } from '../../test-session/TestSession.js';
 
 const IGNORED_404s = ['favicon.ico'];
 const { PARAM_SESSION_ID } = constants;

--- a/packages/test-runner-core/src/server/plugins/api/createSourceMapFunction.ts
+++ b/packages/test-runner-core/src/server/plugins/api/createSourceMapFunction.ts
@@ -1,9 +1,9 @@
 import path from 'path';
-import { SourceMapConverter } from 'convert-source-map';
+import type { SourceMapConverter } from 'convert-source-map';
 import { SourceMapConsumer } from 'source-map';
 
 import { fetchSourceMap } from '../../../utils/fetchSourceMap.js';
-import { StackLocation } from '@web/browser-logs';
+import { type StackLocation } from '@web/browser-logs';
 
 export type SourceMapFunction = (
   loc: StackLocation,

--- a/packages/test-runner-core/src/server/plugins/api/parseBrowserErrors.ts
+++ b/packages/test-runner-core/src/server/plugins/api/parseBrowserErrors.ts
@@ -1,12 +1,12 @@
 import { MapStackLocation, parseStackTrace } from '@web/browser-logs';
-import { MapBrowserUrl } from '@web/browser-logs';
+import { type MapBrowserUrl } from '@web/browser-logs';
 
-import { TestRunnerCoreConfig } from '../../../config/TestRunnerCoreConfig.js';
+import { type TestRunnerCoreConfig } from '../../../config/TestRunnerCoreConfig.js';
 import {
-  TestResult,
-  TestResultError,
-  TestSession,
-  TestSuiteResult,
+  type TestResult,
+  type TestResultError,
+  type TestSession,
+  type TestSuiteResult,
 } from '../../../test-session/TestSession.js';
 import { forEachAsync } from '../../../utils/async.js';
 

--- a/packages/test-runner-core/src/server/plugins/api/parseBrowserLogs.ts
+++ b/packages/test-runner-core/src/server/plugins/api/parseBrowserLogs.ts
@@ -1,8 +1,8 @@
 import { deserialize, MapStackLocation } from '@web/browser-logs';
-import { MapBrowserUrl } from '@web/browser-logs';
+import { type MapBrowserUrl } from '@web/browser-logs';
 
-import { TestRunnerCoreConfig } from '../../../config/TestRunnerCoreConfig.js';
-import { TestSession } from '../../../test-session/TestSession.js';
+import { type TestRunnerCoreConfig } from '../../../config/TestRunnerCoreConfig.js';
+import { type TestSession } from '../../../test-session/TestSession.js';
 import { mapAsync } from '../../../utils/async.js';
 
 interface BrowserLog {

--- a/packages/test-runner-core/src/server/plugins/api/parseBrowserResult.ts
+++ b/packages/test-runner-core/src/server/plugins/api/parseBrowserResult.ts
@@ -1,8 +1,8 @@
-import { MapStackLocation, StackLocation, MapBrowserUrl } from '@web/browser-logs';
+import { type MapStackLocation, type StackLocation, type MapBrowserUrl } from '@web/browser-logs';
 
-import { TestRunnerCoreConfig } from '../../../config/TestRunnerCoreConfig';
-import { TestSession } from '../../../test-session/TestSession';
-import { SourceMapFunction } from './createSourceMapFunction.js';
+import { type TestRunnerCoreConfig } from '../../../config/TestRunnerCoreConfig';
+import { type TestSession } from '../../../test-session/TestSession';
+import { type SourceMapFunction } from './createSourceMapFunction.js';
 import { parseSessionErrors, parseTestResults } from './parseBrowserErrors.js';
 import { parseBrowserLogs } from './parseBrowserLogs.js';
 

--- a/packages/test-runner-core/src/server/plugins/api/testRunnerApiPlugin.ts
+++ b/packages/test-runner-core/src/server/plugins/api/testRunnerApiPlugin.ts
@@ -1,17 +1,22 @@
-import { Context, getRequestFilePath, ServerStartParams, WebSocket } from '@web/dev-server-core';
-import { MapBrowserUrl } from '@web/browser-logs';
+import {
+  type Context,
+  getRequestFilePath,
+  type ServerStartParams,
+  WebSocket,
+} from '@web/dev-server-core';
+import { type MapBrowserUrl } from '@web/browser-logs';
 import parse from 'co-body';
 
-import { TestRunnerCoreConfig } from '../../../config/TestRunnerCoreConfig.js';
-import { TestSessionManager } from '../../../test-session/TestSessionManager.js';
+import { type TestRunnerCoreConfig } from '../../../config/TestRunnerCoreConfig.js';
+import { type TestSessionManager } from '../../../test-session/TestSessionManager.js';
 import { PARAM_SESSION_ID } from '../../../utils/constants.js';
-import { TestRunnerPlugin } from '../../TestRunnerPlugin.js';
+import { type TestRunnerPlugin } from '../../TestRunnerPlugin.js';
 import { SESSION_STATUS } from '../../../test-session/TestSessionStatus.js';
-import { TestSession } from '../../../test-session/TestSession.js';
+import { type TestSession } from '../../../test-session/TestSession.js';
 import { parseBrowserResult } from './parseBrowserResult.js';
 import { TestRunner } from '../../../runner/TestRunner.js';
-import { createSourceMapFunction, SourceMapFunction } from './createSourceMapFunction.js';
-import { DebugTestSession } from '../../../test-session/DebugTestSession.js';
+import { createSourceMapFunction, type SourceMapFunction } from './createSourceMapFunction.js';
+import { type DebugTestSession } from '../../../test-session/DebugTestSession.js';
 
 interface SessionMessage extends Record<string, unknown> {
   sessionId: string;

--- a/packages/test-runner-core/src/server/plugins/serveTestFrameworkPlugin.ts
+++ b/packages/test-runner-core/src/server/plugins/serveTestFrameworkPlugin.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 import { promisify } from 'util';
-import { Plugin } from '@web/dev-server-core';
-import { TestFramework } from '../../test-framework/TestFramework';
+import { type Plugin } from '@web/dev-server-core';
+import { type TestFramework } from '../../test-framework/TestFramework';
 
 const TEST_FRAMEWORK_IMPORT_ROOT = '/__web-test-runner__/test-framework/';
 

--- a/packages/test-runner-core/src/server/plugins/serveTestRunnerHtmlPlugin.ts
+++ b/packages/test-runner-core/src/server/plugins/serveTestRunnerHtmlPlugin.ts
@@ -1,11 +1,11 @@
-import { Context, getRequestFilePath } from '@web/dev-server-core';
+import { type Context, getRequestFilePath } from '@web/dev-server-core';
 
 import { PARAM_SESSION_ID, PARAM_TEST_FILE } from '../../utils/constants.js';
-import { TestRunnerCoreConfig } from '../../config/TestRunnerCoreConfig.js';
+import { type TestRunnerCoreConfig } from '../../config/TestRunnerCoreConfig.js';
 import { createTestFileImportPath } from '../utils.js';
 import { trackBrowserLogs } from './trackBrowserLogs.js';
-import { TestSessionManager } from '../../test-session/TestSessionManager.js';
-import { TestRunnerGroupConfig } from '../../config/TestRunnerGroupConfig.js';
+import { type TestSessionManager } from '../../test-session/TestSessionManager.js';
+import { type TestRunnerGroupConfig } from '../../config/TestRunnerGroupConfig.js';
 
 const iframeModePage = `
 <!DOCTYPE html>

--- a/packages/test-runner-core/src/server/utils.ts
+++ b/packages/test-runner-core/src/server/utils.ts
@@ -1,6 +1,6 @@
 import path from 'path';
-import { Context } from '@web/dev-server-core';
-import { TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig.js';
+import { type Context } from '@web/dev-server-core';
+import { type TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig.js';
 import { PARAM_SESSION_ID, PARAM_MANUAL_SESSION } from '../utils/constants.js';
 
 const toBrowserPathRegExp = new RegExp(path.sep === '\\' ? '\\\\' : path.sep, 'g');

--- a/packages/test-runner-core/src/test-session/BasicTestSession.ts
+++ b/packages/test-runner-core/src/test-session/BasicTestSession.ts
@@ -1,5 +1,5 @@
-import { BrowserLauncher } from '../browser-launcher/BrowserLauncher';
-import { TestSessionGroup } from './TestSessionGroup.js';
+import { type BrowserLauncher } from '../browser-launcher/BrowserLauncher';
+import { type TestSessionGroup } from './TestSessionGroup.js';
 
 export interface BasicTestSession {
   id: string;

--- a/packages/test-runner-core/src/test-session/DebugTestSession.ts
+++ b/packages/test-runner-core/src/test-session/DebugTestSession.ts
@@ -1,4 +1,4 @@
-import { BasicTestSession } from './BasicTestSession.js';
+import { type BasicTestSession } from './BasicTestSession.js';
 
 export interface DebugTestSession extends BasicTestSession {
   debug: true;

--- a/packages/test-runner-core/src/test-session/TestSession.ts
+++ b/packages/test-runner-core/src/test-session/TestSession.ts
@@ -1,6 +1,6 @@
-import { CoverageMapData } from 'istanbul-lib-coverage';
-import { TestSessionStatus } from './TestSessionStatus.js';
-import { BasicTestSession } from './BasicTestSession.js';
+import type { CoverageMapData } from 'istanbul-lib-coverage';
+import { type TestSessionStatus } from './TestSessionStatus.js';
+import { type BasicTestSession } from './BasicTestSession.js';
 
 export interface TestResultError {
   message: string;

--- a/packages/test-runner-core/src/test-session/TestSessionGroup.ts
+++ b/packages/test-runner-core/src/test-session/TestSessionGroup.ts
@@ -1,6 +1,6 @@
-import { BrowserLauncher } from '../browser-launcher/BrowserLauncher';
-import { TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig';
-import { TestRunnerGroupConfig } from '../config/TestRunnerGroupConfig';
+import { type BrowserLauncher } from '../browser-launcher/BrowserLauncher';
+import { type TestRunnerCoreConfig } from '../config/TestRunnerCoreConfig';
+import { type TestRunnerGroupConfig } from '../config/TestRunnerGroupConfig';
 
 export interface TestSessionGroup {
   name: string;

--- a/packages/test-runner-core/src/test-session/TestSessionManager.ts
+++ b/packages/test-runner-core/src/test-session/TestSessionManager.ts
@@ -1,9 +1,9 @@
-import { TestSession } from './TestSession.js';
-import { TestSessionStatus } from './TestSessionStatus.js';
+import { type TestSession } from './TestSession.js';
+import { type TestSessionStatus } from './TestSessionStatus.js';
 import { EventEmitter } from '../utils/EventEmitter.js';
-import { DebugTestSession } from './DebugTestSession.js';
-import { TestSessionGroup } from './TestSessionGroup.js';
-import { BrowserLauncher } from '../browser-launcher/BrowserLauncher.js';
+import { type DebugTestSession } from './DebugTestSession.js';
+import { type TestSessionGroup } from './TestSessionGroup.js';
+import { type BrowserLauncher } from '../browser-launcher/BrowserLauncher.js';
 
 interface EventMap {
   'session-status-updated': TestSession;

--- a/packages/test-runner-core/src/utils/fetchSourceMap.ts
+++ b/packages/test-runner-core/src/utils/fetchSourceMap.ts
@@ -1,6 +1,11 @@
-import { mapFileCommentRegex, fromSource, SourceMapConverter, fromJSON } from 'convert-source-map';
+import {
+  mapFileCommentRegex,
+  fromSource,
+  type SourceMapConverter,
+  fromJSON,
+} from 'convert-source-map';
 import path from 'path';
-import { RequestOptions } from 'http';
+import { type RequestOptions } from 'http';
 
 import { request } from './request.js';
 

--- a/packages/test-runner-core/src/utils/request.ts
+++ b/packages/test-runner-core/src/utils/request.ts
@@ -1,5 +1,5 @@
-import { request as httpRequest, RequestOptions, IncomingMessage } from 'http';
-import { request as httpsRequest, RequestOptions as HttpsRequestOptions } from 'https';
+import { request as httpRequest, type RequestOptions, IncomingMessage } from 'http';
+import { request as httpsRequest, type RequestOptions as HttpsRequestOptions } from 'https';
 
 export interface Response {
   response: IncomingMessage;

--- a/packages/test-runner/src/config/TestRunnerConfig.ts
+++ b/packages/test-runner/src/config/TestRunnerConfig.ts
@@ -1,5 +1,9 @@
-import { TestFramework, TestRunnerCoreConfig, TestRunnerGroupConfig } from '@web/test-runner-core';
-import { RollupNodeResolveOptions } from '@web/dev-server';
+import {
+  type TestFramework,
+  type TestRunnerCoreConfig,
+  type TestRunnerGroupConfig,
+} from '@web/test-runner-core';
+import { type RollupNodeResolveOptions } from '@web/dev-server';
 
 export interface TestRunnerConfig extends Omit<TestRunnerCoreConfig, 'testFramework'> {
   groups?: string | string[] | TestRunnerGroupConfig[];

--- a/packages/test-runner/src/config/collectGroupConfigs.ts
+++ b/packages/test-runner/src/config/collectGroupConfigs.ts
@@ -1,4 +1,4 @@
-import { TestRunnerGroupConfig } from '@web/test-runner-core';
+import { type TestRunnerGroupConfig } from '@web/test-runner-core';
 import { readConfig, ConfigLoaderError } from '@web/config-loader';
 import globby from 'globby';
 import { TestRunnerStartError } from '../TestRunnerStartError.js';

--- a/packages/test-runner/src/config/mergeConfigs.ts
+++ b/packages/test-runner/src/config/mergeConfigs.ts
@@ -1,4 +1,4 @@
-import { TestRunnerConfig } from './TestRunnerConfig.js';
+import { type TestRunnerConfig } from './TestRunnerConfig.js';
 
 const arrayKeys = ['plugins', 'middleware'];
 

--- a/packages/test-runner/src/config/parseConfig.ts
+++ b/packages/test-runner/src/config/parseConfig.ts
@@ -1,4 +1,8 @@
-import { CoverageConfig, TestRunnerCoreConfig, TestRunnerGroupConfig } from '@web/test-runner-core';
+import {
+  type CoverageConfig,
+  type TestRunnerCoreConfig,
+  type TestRunnerGroupConfig,
+} from '@web/test-runner-core';
 import { chromeLauncher } from '@web/test-runner-chrome';
 import {
   emulateMediaPlugin,
@@ -14,9 +18,9 @@ import { getPortPromise } from 'portfinder';
 import path from 'path';
 import { cpus } from 'os';
 
-import { TestRunnerCliArgs } from './readCliArgs.js';
+import { type TestRunnerCliArgs } from './readCliArgs.js';
 import { mergeConfigs } from './mergeConfigs.js';
-import { TestRunnerConfig } from './TestRunnerConfig.js';
+import { type TestRunnerConfig } from './TestRunnerConfig.js';
 import { esbuildPlugin, nodeResolvePlugin } from '@web/dev-server';
 import { TestRunnerStartError } from '../TestRunnerStartError.js';
 import { collectGroupConfigs } from './collectGroupConfigs.js';

--- a/packages/test-runner/src/config/readCliArgs.ts
+++ b/packages/test-runner/src/config/readCliArgs.ts
@@ -2,7 +2,7 @@ import commandLineArgs from 'command-line-args';
 import commandLineUsage, { OptionDefinition } from 'command-line-usage';
 import camelCase from 'camelcase';
 
-import { TestRunnerConfig } from './TestRunnerConfig.js';
+import { type TestRunnerConfig } from './TestRunnerConfig.js';
 
 export interface TestRunnerCliArgs
   extends Partial<

--- a/packages/test-runner/src/logger/TestRunnerLogger.ts
+++ b/packages/test-runner/src/logger/TestRunnerLogger.ts
@@ -1,4 +1,4 @@
-import { Logger, ErrorWithLocation } from '@web/test-runner-core';
+import { type Logger, type ErrorWithLocation } from '@web/test-runner-core';
 
 export class TestRunnerLogger implements Logger {
   loggedSyntaxErrors = new Map<string, ErrorWithLocation[]>();

--- a/packages/test-runner/src/reporter/defaultReporter.ts
+++ b/packages/test-runner/src/reporter/defaultReporter.ts
@@ -1,4 +1,9 @@
-import { Logger, Reporter, ReporterArgs, BufferedLogger } from '@web/test-runner-core';
+import {
+  type Logger,
+  type Reporter,
+  type ReporterArgs,
+  type BufferedLogger,
+} from '@web/test-runner-core';
 
 import { reportTestFileResults } from './reportTestFileResults.js';
 import { getTestProgressReport } from './getTestProgress.js';

--- a/packages/test-runner/src/reporter/getCodeCoverage.ts
+++ b/packages/test-runner/src/reporter/getCodeCoverage.ts
@@ -1,4 +1,8 @@
-import { CoverageThresholdConfig, TestCoverage, CoverageConfig } from '@web/test-runner-core';
+import {
+  type CoverageThresholdConfig,
+  type TestCoverage,
+  type CoverageConfig,
+} from '@web/test-runner-core';
 import path from 'path';
 import { bold, green, red, underline } from 'nanocolors';
 

--- a/packages/test-runner/src/reporter/getTestProgress.ts
+++ b/packages/test-runner/src/reporter/getTestProgress.ts
@@ -1,10 +1,10 @@
 import {
-  TestRunnerCoreConfig,
-  TestSessionManager,
+  type TestRunnerCoreConfig,
+  type TestSessionManager,
   SESSION_STATUS,
-  TestCoverage,
-  CoverageConfig,
-  BrowserLauncher,
+  type TestCoverage,
+  type CoverageConfig,
+  type BrowserLauncher,
 } from '@web/test-runner-core';
 import { bold, gray, green, red } from 'nanocolors';
 

--- a/packages/test-runner/src/reporter/reportBrowserLogs.ts
+++ b/packages/test-runner/src/reporter/reportBrowserLogs.ts
@@ -1,4 +1,4 @@
-import { TestSession, Logger } from '@web/test-runner-core';
+import { type TestSession, type Logger } from '@web/test-runner-core';
 
 export function reportBrowserLogs(logger: Logger, sessions: TestSession[]) {
   const commonLogs: any[] = [];

--- a/packages/test-runner/src/reporter/reportRequest404s.ts
+++ b/packages/test-runner/src/reporter/reportRequest404s.ts
@@ -1,4 +1,4 @@
-import { TestSession, Logger } from '@web/test-runner-core';
+import { type TestSession, type Logger } from '@web/test-runner-core';
 import { bold, gray } from 'nanocolors';
 
 export function reportRequest404s(logger: Logger, sessions: TestSession[]) {

--- a/packages/test-runner/src/reporter/reportTestFileErrors.ts
+++ b/packages/test-runner/src/reporter/reportTestFileErrors.ts
@@ -1,4 +1,4 @@
-import { TestSession, TestResultError, Logger } from '@web/test-runner-core';
+import { type TestSession, type TestResultError, type Logger } from '@web/test-runner-core';
 import { gray, red } from 'nanocolors';
 
 import { getFailedOnBrowsers } from './utils/getFailedOnBrowsers.js';

--- a/packages/test-runner/src/reporter/reportTestFileResults.ts
+++ b/packages/test-runner/src/reporter/reportTestFileResults.ts
@@ -1,4 +1,4 @@
-import { TestSession, BufferedLogger } from '@web/test-runner-core';
+import { type TestSession, type BufferedLogger } from '@web/test-runner-core';
 import { bold, cyan } from 'nanocolors';
 import { relative } from 'path';
 

--- a/packages/test-runner/src/reporter/reportTestsErrors.ts
+++ b/packages/test-runner/src/reporter/reportTestsErrors.ts
@@ -1,4 +1,4 @@
-import { TestResultError, TestSession, Logger } from '@web/test-runner-core';
+import { type TestResultError, type TestSession, type Logger } from '@web/test-runner-core';
 import { gray, green, red } from 'nanocolors';
 import * as diff from 'diff';
 

--- a/packages/test-runner/src/reporter/utils/getFlattenedTestResults.ts
+++ b/packages/test-runner/src/reporter/utils/getFlattenedTestResults.ts
@@ -1,4 +1,4 @@
-import { TestResult, TestSuiteResult } from '@web/test-runner-core';
+import { type TestResult, type TestSuiteResult } from '@web/test-runner-core';
 
 export function getFlattenedTestResults(testResults: TestSuiteResult) {
   const flattened: TestResult[] = [];

--- a/packages/test-runner/src/reporter/utils/getPassedFailedSkippedCount.ts
+++ b/packages/test-runner/src/reporter/utils/getPassedFailedSkippedCount.ts
@@ -1,4 +1,4 @@
-import { TestResult, TestSuiteResult } from '@web/test-runner-core';
+import { type TestResult, type TestSuiteResult } from '@web/test-runner-core';
 
 export function getPassedFailedSkippedCount(testResults: TestSuiteResult) {
   let passed = 0;


### PR DESCRIPTION
## Summary

Add `import type` / `export type` annotations to type-only imports across 85 source files. No runtime effect.

PR 1/4 in the Node 24 migration:
1. **#3052** -- `import type` annotations
2. #3043 -- TS 5.9, nodenext, `.ts` imports
3. #3049 -- node:test, ESM output, Node 24
4. #3046 -- parse5 v8, JSDoc->TS, koa 3, ws 8