### PR TITLE
feat!: drop support for Node.js 18 and 20

### DIFF
--- a/.changeset/drop-eol-node.md
+++ b/.changeset/drop-eol-node.md
@@ -1,0 +1,42 @@
+---
+'@web/browser-logs': major
+'@web/config-loader': major
+'@web/dev-server-core': major
+'@web/dev-server-esbuild': major
+'@web/dev-server-hmr': major
+'@web/dev-server-import-maps': major
+'@web/dev-server-legacy': major
+'@web/dev-server': major
+'@web/dev-server-polyfill': major
+'@web/dev-server-rollup': major
+'@web/mocks': major
+'@web/parse5-utils': major
+'@web/polyfills-loader': major
+'@web/rollup-plugin-copy': major
+'@web/rollup-plugin-html': major
+'@web/rollup-plugin-import-meta-assets': major
+'@web/rollup-plugin-polyfills-loader': major
+'rollup-plugin-workbox': major
+'@web/storybook-addon-mocks': major
+'@web/storybook-builder': major
+'@web/storybook-framework-web-components': major
+'@web/storybook-utils': major
+'@web/test-runner-browserstack': major
+'@web/test-runner-chrome': major
+'@web/test-runner-cli': major
+'@web/test-runner-commands': major
+'@web/test-runner-core': major
+'@web/test-runner-coverage-v8': major
+'@web/test-runner-junit-reporter': major
+'@web/test-runner-mocha': major
+'@web/test-runner-module-mocking': major
+'@web/test-runner': major
+'@web/test-runner-playwright': major
+'@web/test-runner-puppeteer': major
+'@web/test-runner-saucelabs': major
+'@web/test-runner-selenium': major
+'@web/test-runner-visual-regression': major
+'@web/test-runner-webdriver': major
+---
+
+Drop support for Node.js 18 and 20, which have reached end-of-life. The minimum supported Node.js version is now 22.0.0.

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -18,13 +18,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         env:
           FORCE_COLOR: 0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Setup Node 20
-        uses: actions/setup-node@v4
+      - name: Setup Node 22
+        uses: actions/setup-node@v6
         env:
           FORCE_COLOR: 0
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install Dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,13 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         env:
           FORCE_COLOR: 0
         with:

--- a/.github/workflows/verify-browser.yml
+++ b/.github/workflows/verify-browser.yml
@@ -12,19 +12,19 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # TODO: remove when GitHub fixes this https://github.com/actions/runner-images/issues/10015
       # (this workaround is practically the same what Playwright did in https://github.com/microsoft/playwright/pull/34238/files)
       - name: Workaround for Chrome sandbox issue in Ubuntu 24.04
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
-      - name: Setup Node 20
-        uses: actions/setup-node@v4
+      - name: Setup Node 22
+        uses: actions/setup-node@v6
         env:
           FORCE_COLOR: 0
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install Dependencies

--- a/.github/workflows/verify-node.yml
+++ b/.github/workflows/verify-node.yml
@@ -14,13 +14,13 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - '18'
-          - '20'
           - '22'
+          # TODO: add 'latest' once Playwright fixes yauzl for Node 26
+          # https://github.com/microsoft/playwright/issues/40724
           - '24'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # TODO: remove when GitHub fixes this https://github.com/actions/runner-images/issues/10015
       # (this workaround is practically the same what Playwright did in https://github.com/microsoft/playwright/pull/34238/files)
@@ -28,7 +28,7 @@ jobs:
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         env:
           FORCE_COLOR: 0
         with:
@@ -57,7 +57,8 @@ jobs:
       - name: Test
         run: npm run test:node
         env:
-          NODE_OPTIONS: ${{ (matrix.node-version != '18' && matrix.node-version != '20') && '--no-experimental-strip-types' || '' }}
+          # Node 22.18+ native type stripping preempts ts-node. Remove when mocha is replaced with node:test.
+          NODE_OPTIONS: '--no-experimental-strip-types'
 
   verify-windows:
     timeout-minutes: 30
@@ -69,14 +70,14 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Setup Node '20'
-        uses: actions/setup-node@v4
+      - name: Setup Node '22'
+        uses: actions/setup-node@v6
         env:
           FORCE_COLOR: 0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       # Set up GitHub Actions caching for Wireit.
@@ -97,3 +98,6 @@ jobs:
 
       - name: Test
         run: npm run test:node
+        env:
+          # Node 22.18+ native type stripping preempts ts-node. Remove when mocha is replaced with node:test.
+          NODE_OPTIONS: '--no-experimental-strip-types'

--- a/.github/workflows/verify-storybook-builder.yml
+++ b/.github/workflows/verify-storybook-builder.yml
@@ -14,10 +14,10 @@ jobs:
     env:
       PUPPETEER_SKIP_DOWNLOAD: true # prevent failures due to puppeteer downloading issues, since it's not used here anyway
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         env:
           FORCE_COLOR: 0
         with:
@@ -39,7 +39,7 @@ jobs:
       - name: Run tests
         run: npm run test:storybook-builder
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report-${{ matrix.runs-on }}

--- a/packages/browser-logs/package.json
+++ b/packages/browser-logs/package.json
@@ -22,7 +22,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -16,7 +16,7 @@
   "main": "src/index.js",
   "type": "commonjs",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/dev-server-core/package.json
+++ b/packages/dev-server-core/package.json
@@ -31,7 +31,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/dev-server-esbuild/package.json
+++ b/packages/dev-server-esbuild/package.json
@@ -22,7 +22,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/dev-server-hmr/package.json
+++ b/packages/dev-server-hmr/package.json
@@ -22,7 +22,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/dev-server-import-maps/package.json
+++ b/packages/dev-server-import-maps/package.json
@@ -22,7 +22,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/dev-server-legacy/package.json
+++ b/packages/dev-server-legacy/package.json
@@ -22,7 +22,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/dev-server-polyfill/package.json
+++ b/packages/dev-server-polyfill/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc"

--- a/packages/dev-server-rollup/package.json
+++ b/packages/dev-server-rollup/package.json
@@ -22,7 +22,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "test:node": "mocha \"test/node/**/*.test.ts\" --require ts-node/register --exit --reporter dot",

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -26,7 +26,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "start": "npm run start:syntax",

--- a/packages/parse5-utils/package.json
+++ b/packages/parse5-utils/package.json
@@ -22,7 +22,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/polyfills-loader/package.json
+++ b/packages/polyfills-loader/package.json
@@ -22,7 +22,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/rollup-plugin-copy/package.json
+++ b/packages/rollup-plugin-copy/package.json
@@ -26,7 +26,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "test:node": "mocha test/**/*.test.js --reporter dot",

--- a/packages/rollup-plugin-html/package.json
+++ b/packages/rollup-plugin-html/package.json
@@ -22,7 +22,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "demo:mpa": "rm -rf demo/dist && rollup -c demo/mpa/rollup.config.js --watch & npm run serve-demo",

--- a/packages/rollup-plugin-import-meta-assets/package.json
+++ b/packages/rollup-plugin-import-meta-assets/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "test": "npm run test:node",

--- a/packages/rollup-plugin-polyfills-loader/package.json
+++ b/packages/rollup-plugin-polyfills-loader/package.json
@@ -22,7 +22,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "test:node": "mocha test/**/*.test.ts --require ts-node/register --reporter dot",

--- a/packages/storybook-builder/package.json
+++ b/packages/storybook-builder/package.json
@@ -23,7 +23,7 @@
     "./package.json": "./package.json"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc"

--- a/packages/storybook-framework-web-components/package.json
+++ b/packages/storybook-framework-web-components/package.json
@@ -24,7 +24,7 @@
     "./package.json": "./package.json"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/storybook-utils/package.json
+++ b/packages/storybook-utils/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc"

--- a/packages/test-runner-browserstack/package.json
+++ b/packages/test-runner-browserstack/package.json
@@ -22,7 +22,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-chrome/package.json
+++ b/packages/test-runner-chrome/package.json
@@ -22,7 +22,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-cli/package.json
+++ b/packages/test-runner-cli/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-commands/package.json
+++ b/packages/test-runner-commands/package.json
@@ -26,7 +26,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-core/package.json
+++ b/packages/test-runner-core/package.json
@@ -29,7 +29,7 @@
     "./browser/session.js": "./browser/session.js"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-coverage-v8/package.json
+++ b/packages/test-runner-coverage-v8/package.json
@@ -22,7 +22,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc"

--- a/packages/test-runner-junit-reporter/package.json
+++ b/packages/test-runner-junit-reporter/package.json
@@ -22,7 +22,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-mocha/package.json
+++ b/packages/test-runner-mocha/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/modernweb-dev/web/tree/master/packages/test-runner-mocha",
   "main": "dist/standalone.js",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-module-mocking/package.json
+++ b/packages/test-runner-module-mocking/package.json
@@ -20,7 +20,7 @@
     "./plugin.js": "./dist/moduleMockingPlugin.js"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-playwright/package.json
+++ b/packages/test-runner-playwright/package.json
@@ -22,7 +22,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-puppeteer/package.json
+++ b/packages/test-runner-puppeteer/package.json
@@ -22,7 +22,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-saucelabs/package.json
+++ b/packages/test-runner-saucelabs/package.json
@@ -22,7 +22,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-selenium/package.json
+++ b/packages/test-runner-selenium/package.json
@@ -22,7 +22,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-visual-regression/package.json
+++ b/packages/test-runner-visual-regression/package.json
@@ -26,7 +26,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner-webdriver/package.json
+++ b/packages/test-runner-webdriver/package.json
@@ -22,7 +22,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/test-runner/package.json
+++ b/packages/test-runner/package.json
@@ -31,7 +31,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary

- Minimum supported Node.js version is now **22.0.0**
- Node.js 18 EOL'd April 2025, Node.js 20 EOL'd April 2026
- CI matrix tests on Node 22 and 24
- Bump GitHub Actions to latest (checkout v6, setup-node v6, upload-artifact v7)

## Node 26 / latest

Pinned to 24 instead of `latest` due to [Playwright/yauzl hang on Node 26](https://github.com/microsoft/playwright/issues/40724). Will re-add `latest` once Playwright ships the fix.

## ts-node workaround

Added `NODE_OPTIONS='--no-experimental-strip-types'` to CI test steps. Node 22.18+ enables native type stripping, which preempts ts-node and breaks mocha tests. This workaround will be removed when mocha is replaced with `node:test` in a follow-up PR.

## Test plan

- [ ] CI green on Node 22 and 24 (Linux + Windows)
- [ ] Lint passes
- [ ] Browser tests pass
- [ ] Storybook builder verification passes