### PR TITLE
refactor(config-loader): migrate tests to node:test

### DIFF
--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -15,13 +15,20 @@
   "homepage": "https://github.com/modernweb-dev/web/tree/master/packages/config-loader",
   "main": "src/index.js",
   "type": "commonjs",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.mjs",
+      "require": "./src/index.js"
+    }
+  },
   "engines": {
     "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",
-    "test:node": "mocha test/**/*.test.js --reporter dot",
-    "test:watch": "mocha test/**/*.test.js --watch --watch-files .,src,test --reporter dot"
+    "test:node": "node --test --test-force-exit test/**/*.test.js",
+    "test:watch": "node --test --test-force-exit --watch test/**/*.test.js"
   },
   "files": [
     "*.d.ts",
@@ -39,12 +46,5 @@
     "es module"
   ],
   "dependencies": {},
-  "types": "dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./index.d.ts",
-      "import": "./index.mjs",
-      "require": "./src/index.js"
-    }
-  }
+  "types": "dist/index.d.ts"
 }

--- a/packages/config-loader/test/index.test.js
+++ b/packages/config-loader/test/index.test.js
@@ -1,23 +1,11 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
 const path = require('path');
-const { expect } = require('chai');
 const { readConfig } = require('../src/index');
 
 const configName = 'my-project.config';
 const packageCjsPath = path.resolve(__dirname, 'fixtures', 'package-cjs');
 const packageMjsPath = path.resolve(__dirname, 'fixtures', 'package-mjs');
-
-async function expectThrowsOldNodeError(configPath) {
-  let thrown = false;
-  try {
-    await readConfig(configName, undefined, configPath);
-  } catch (error) {
-    thrown = true;
-    expect(error.message).to.include(
-      'You are trying to load a config as es module but your version of node does not support it',
-    );
-  }
-  expect(thrown).to.equal(true);
-}
 
 describe('cjs package', () => {
   it('can load commonjs-in-.cjs', async () => {
@@ -26,7 +14,7 @@ describe('cjs package', () => {
       undefined,
       path.resolve(packageCjsPath, 'commonjs-in-.cjs'),
     );
-    expect(result).to.eql({ foo: 'bar' });
+    assert.deepEqual(result, { foo: 'bar' });
   });
 
   it('can load commonjs-in-.js', async () => {
@@ -35,56 +23,59 @@ describe('cjs package', () => {
       undefined,
       path.resolve(packageCjsPath, 'commonjs-in-.js'),
     );
-    expect(result).to.eql({ foo: 'bar' });
+    assert.deepEqual(result, { foo: 'bar' });
   });
 
-    it('can load module-in-.mjs', async () => {
-      const result = await readConfig(
-        configName,
-        undefined,
-        path.resolve(packageCjsPath, 'module-in-.mjs'),
-      );
-      expect(result).to.eql({ foo: 'bar' });
-    });
+  it('can load module-in-.mjs', async () => {
+    const result = await readConfig(
+      configName,
+      undefined,
+      path.resolve(packageCjsPath, 'module-in-.mjs'),
+    );
+    assert.deepEqual(result, { foo: 'bar' });
+  });
 
   it('throws when loading module-in-.cjs', async () => {
-    let thrown = false;
-    try {
-      await readConfig(configName, undefined, path.resolve(packageCjsPath, 'module-in-.cjs'));
-    } catch (error) {
-      thrown = true;
-      expect(error.message).to.include(
-        'You are using es module syntax in a config loaded as CommonJS module.',
-      );
-    }
-    expect(thrown).to.equal(true);
+    await assert.rejects(
+      () => readConfig(configName, undefined, path.resolve(packageCjsPath, 'module-in-.cjs')),
+      error => {
+        assert.ok(
+          error.message.includes(
+            'You are using es module syntax in a config loaded as CommonJS module.',
+          ),
+        );
+        return true;
+      },
+    );
   });
 
   it('throws when loading module-in-.js', async () => {
-    let thrown = false;
-    try {
-      await readConfig(configName, undefined, path.resolve(packageCjsPath, 'module-in-.js'));
-    } catch (error) {
-      thrown = true;
-      expect(error.message).to.include(
-        'You are using es module syntax in a config loaded as CommonJS module.',
-      );
-    }
-    expect(thrown).to.equal(true);
+    await assert.rejects(
+      () => readConfig(configName, undefined, path.resolve(packageCjsPath, 'module-in-.js')),
+      error => {
+        assert.ok(
+          error.message.includes(
+            'You are using es module syntax in a config loaded as CommonJS module.',
+          ),
+        );
+        return true;
+      },
+    );
   });
 
-    it('throws when loading commonjs-in-.mjs', async () => {
-      let thrown = false;
-      try {
-        await readConfig(configName, undefined, path.resolve(packageCjsPath, 'commonjs-in-.mjs'));
-      } catch (error) {
-        thrown = true;
-        expect(error.message).to.include(
-          'You are using CommonJS syntax such as "require" or "module.exports" in a config loaded as es module.',
+  it('throws when loading commonjs-in-.mjs', async () => {
+    await assert.rejects(
+      () => readConfig(configName, undefined, path.resolve(packageCjsPath, 'commonjs-in-.mjs')),
+      error => {
+        assert.ok(
+          error.message.includes(
+            'You are using CommonJS syntax such as "require" or "module.exports" in a config loaded as es module.',
+          ),
         );
-      }
-      expect(thrown).to.equal(true);
-    });
+        return true;
+      },
+    );
+  });
 });
 
 describe('mjs package', () => {
@@ -94,63 +85,66 @@ describe('mjs package', () => {
       undefined,
       path.resolve(packageMjsPath, 'commonjs-in-.cjs'),
     );
-    expect(result).to.eql({ foo: 'bar' });
+    assert.deepEqual(result, { foo: 'bar' });
   });
 
-    it('throws when loading commonjs-in-.js', async () => {
-      let thrown = false;
-      try {
-        await readConfig(configName, undefined, path.resolve(packageMjsPath, 'commonjs-in-.js'));
-      } catch (error) {
-        thrown = true;
-        expect(error.message).to.include(
-          'You are using CommonJS syntax such as "require" or "module.exports" in a config loaded as es module.',
+  it('throws when loading commonjs-in-.js', async () => {
+    await assert.rejects(
+      () => readConfig(configName, undefined, path.resolve(packageMjsPath, 'commonjs-in-.js')),
+      error => {
+        assert.ok(
+          error.message.includes(
+            'You are using CommonJS syntax such as "require" or "module.exports" in a config loaded as es module.',
+          ),
         );
-      }
-      expect(thrown).to.equal(true);
-    });
+        return true;
+      },
+    );
+  });
 
-    it('throws when loading commonjs-in-.mjs', async () => {
-      let thrown = false;
-      try {
-        await readConfig(configName, undefined, path.resolve(packageMjsPath, 'commonjs-in-.mjs'));
-      } catch (error) {
-        thrown = true;
-        expect(error.message).to.include(
-          'You are using CommonJS syntax such as "require" or "module.exports" in a config loaded as es module.',
+  it('throws when loading commonjs-in-.mjs', async () => {
+    await assert.rejects(
+      () => readConfig(configName, undefined, path.resolve(packageMjsPath, 'commonjs-in-.mjs')),
+      error => {
+        assert.ok(
+          error.message.includes(
+            'You are using CommonJS syntax such as "require" or "module.exports" in a config loaded as es module.',
+          ),
         );
-      }
-      expect(thrown).to.equal(true);
-    });
+        return true;
+      },
+    );
+  });
 
   it('throws when loading module-in-.cjs', async () => {
-    let thrown = false;
-    try {
-      await readConfig(configName, undefined, path.resolve(packageCjsPath, 'module-in-.cjs'));
-    } catch (error) {
-      thrown = true;
-      expect(error.message).to.include(
-        'You are using es module syntax in a config loaded as CommonJS module.',
-      );
-    }
-    expect(thrown).to.equal(true);
+    await assert.rejects(
+      () => readConfig(configName, undefined, path.resolve(packageCjsPath, 'module-in-.cjs')),
+      error => {
+        assert.ok(
+          error.message.includes(
+            'You are using es module syntax in a config loaded as CommonJS module.',
+          ),
+        );
+        return true;
+      },
+    );
   });
 
-    it('can load module-in-.js', async () => {
-      const result = await readConfig(
-        configName,
-        undefined,
-        path.resolve(packageMjsPath, 'module-in-.js'),
-      );
-      expect(result).to.eql({ foo: 'bar' });
-    });
+  it('can load module-in-.js', async () => {
+    const result = await readConfig(
+      configName,
+      undefined,
+      path.resolve(packageMjsPath, 'module-in-.js'),
+    );
+    assert.deepEqual(result, { foo: 'bar' });
+  });
 
-    it('can load module-in-.mjs', async () => {
-      const result = await readConfig(
-        configName,
-        undefined,
-        path.resolve(packageMjsPath, 'module-in-.mjs'),
-      );
-      expect(result).to.eql({ foo: 'bar' });
-    });
+  it('can load module-in-.mjs', async () => {
+    const result = await readConfig(
+      configName,
+      undefined,
+      path.resolve(packageMjsPath, 'module-in-.mjs'),
+    );
+    assert.deepEqual(result, { foo: 'bar' });
+  });
 });

--- a/packages/config-loader/test/index.test.js
+++ b/packages/config-loader/test/index.test.js
@@ -14,7 +14,7 @@ describe('cjs package', () => {
       undefined,
       path.resolve(packageCjsPath, 'commonjs-in-.cjs'),
     );
-    assert.deepEqual(result, { foo: 'bar' });
+    assert.deepStrictEqual(result, { foo: 'bar' });
   });
 
   it('can load commonjs-in-.js', async () => {
@@ -23,7 +23,7 @@ describe('cjs package', () => {
       undefined,
       path.resolve(packageCjsPath, 'commonjs-in-.js'),
     );
-    assert.deepEqual(result, { foo: 'bar' });
+    assert.deepStrictEqual(result, { foo: 'bar' });
   });
 
   it('can load module-in-.mjs', async () => {
@@ -32,7 +32,7 @@ describe('cjs package', () => {
       undefined,
       path.resolve(packageCjsPath, 'module-in-.mjs'),
     );
-    assert.deepEqual(result, { foo: 'bar' });
+    assert.deepStrictEqual(result, { foo: 'bar' });
   });
 
   it('throws when loading module-in-.cjs', async () => {
@@ -64,7 +64,7 @@ describe('mjs package', () => {
       undefined,
       path.resolve(packageMjsPath, 'commonjs-in-.cjs'),
     );
-    assert.deepEqual(result, { foo: 'bar' });
+    assert.deepStrictEqual(result, { foo: 'bar' });
   });
 
   it('throws when loading commonjs-in-.js', async () => {
@@ -94,7 +94,7 @@ describe('mjs package', () => {
       undefined,
       path.resolve(packageMjsPath, 'module-in-.js'),
     );
-    assert.deepEqual(result, { foo: 'bar' });
+    assert.deepStrictEqual(result, { foo: 'bar' });
   });
 
   it('can load module-in-.mjs', async () => {
@@ -103,6 +103,6 @@ describe('mjs package', () => {
       undefined,
       path.resolve(packageMjsPath, 'module-in-.mjs'),
     );
-    assert.deepEqual(result, { foo: 'bar' });
+    assert.deepStrictEqual(result, { foo: 'bar' });
   });
 });

--- a/packages/config-loader/test/index.test.js
+++ b/packages/config-loader/test/index.test.js
@@ -38,42 +38,21 @@ describe('cjs package', () => {
   it('throws when loading module-in-.cjs', async () => {
     await assert.rejects(
       () => readConfig(configName, undefined, path.resolve(packageCjsPath, 'module-in-.cjs')),
-      error => {
-        assert.ok(
-          error.message.includes(
-            'You are using es module syntax in a config loaded as CommonJS module.',
-          ),
-        );
-        return true;
-      },
+      /You are using es module syntax in a config loaded as CommonJS module./,
     );
   });
 
   it('throws when loading module-in-.js', async () => {
     await assert.rejects(
       () => readConfig(configName, undefined, path.resolve(packageCjsPath, 'module-in-.js')),
-      error => {
-        assert.ok(
-          error.message.includes(
-            'You are using es module syntax in a config loaded as CommonJS module.',
-          ),
-        );
-        return true;
-      },
+      /You are using es module syntax in a config loaded as CommonJS module./,
     );
   });
 
   it('throws when loading commonjs-in-.mjs', async () => {
     await assert.rejects(
       () => readConfig(configName, undefined, path.resolve(packageCjsPath, 'commonjs-in-.mjs')),
-      error => {
-        assert.ok(
-          error.message.includes(
-            'You are using CommonJS syntax such as "require" or "module.exports" in a config loaded as es module.',
-          ),
-        );
-        return true;
-      },
+      /You are using CommonJS syntax such as "require" or "module.exports" in a config loaded as es module./,
     );
   });
 });
@@ -91,42 +70,21 @@ describe('mjs package', () => {
   it('throws when loading commonjs-in-.js', async () => {
     await assert.rejects(
       () => readConfig(configName, undefined, path.resolve(packageMjsPath, 'commonjs-in-.js')),
-      error => {
-        assert.ok(
-          error.message.includes(
-            'You are using CommonJS syntax such as "require" or "module.exports" in a config loaded as es module.',
-          ),
-        );
-        return true;
-      },
+      /You are using CommonJS syntax such as "require" or "module.exports" in a config loaded as es module./,
     );
   });
 
   it('throws when loading commonjs-in-.mjs', async () => {
     await assert.rejects(
       () => readConfig(configName, undefined, path.resolve(packageMjsPath, 'commonjs-in-.mjs')),
-      error => {
-        assert.ok(
-          error.message.includes(
-            'You are using CommonJS syntax such as "require" or "module.exports" in a config loaded as es module.',
-          ),
-        );
-        return true;
-      },
+      /You are using CommonJS syntax such as "require" or "module.exports" in a config loaded as es module./,
     );
   });
 
   it('throws when loading module-in-.cjs', async () => {
     await assert.rejects(
       () => readConfig(configName, undefined, path.resolve(packageCjsPath, 'module-in-.cjs')),
-      error => {
-        assert.ok(
-          error.message.includes(
-            'You are using es module syntax in a config loaded as CommonJS module.',
-          ),
-        );
-        return true;
-      },
+      /You are using es module syntax in a config loaded as CommonJS module./,
     );
   });
 


### PR DESCRIPTION
## Summary

- Migrate `@web/config-loader` tests from mocha/chai to `node:test` + `node:assert/strict`
- Update `test:node` script from mocha to `node --test --test-force-exit`
- CJS test file, no TypeScript, no import path changes needed
- Replaced manual try/catch error assertions with `assert.rejects`
- Removed unused `expectThrowsOldNodeError` helper

## Test plan

- [x] 12/12 tests pass on Node 22.22.3
- [x] ESLint clean
- [x] Prettier clean