### PR TITLE
refactor(rollup-plugin-copy): migrate tests to node:test

### DIFF
--- a/packages/rollup-plugin-copy/package.json
+++ b/packages/rollup-plugin-copy/package.json
@@ -29,8 +29,8 @@
     "node": ">=22.0.0"
   },
   "scripts": {
-    "test:node": "mocha test/**/*.test.js --reporter dot",
-    "test:watch": "mocha test/**/*.test.js --watch --watch-files src,test --reporter dot"
+    "test:node": "node --test --test-force-exit test/**/*.test.js",
+    "test:watch": "node --test --test-force-exit --watch test/**/*.test.js"
   },
   "files": [
     "*.d.ts",

--- a/packages/rollup-plugin-copy/test/integration.test.js
+++ b/packages/rollup-plugin-copy/test/integration.test.js
@@ -1,5 +1,6 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
 const path = require('path');
-const { expect } = require('chai');
 const rollup = require('rollup');
 
 const { copy } = require('../src/copy.js');
@@ -12,12 +13,13 @@ describe('rollup-plugin-copy', () => {
     });
     const { output } = await bundle.generate({ format: 'es' });
 
-    expect(output.length).to.equal(5);
-    expect(output.map(x => x.fileName).filter(x => x.endsWith('.svg'))).to.have.members([
-      'a.svg',
-      'b.svg',
-      `sub${path.sep}sub-a.svg`,
-      `sub${path.sep}sub-b.mark.svg`,
-    ]);
+    assert.equal(output.length, 5);
+    assert.deepEqual(
+      output
+        .map(x => x.fileName)
+        .filter(x => x.endsWith('.svg'))
+        .sort(),
+      ['a.svg', 'b.svg', `sub${path.sep}sub-a.svg`, `sub${path.sep}sub-b.mark.svg`].sort(),
+    );
   });
 });

--- a/packages/rollup-plugin-copy/test/listFiles.test.js
+++ b/packages/rollup-plugin-copy/test/listFiles.test.js
@@ -1,32 +1,36 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
 const path = require('path');
-const { expect } = require('chai');
 
 const { listFiles } = require('../src/listFiles.js');
 
 describe('listFiles', () => {
   it('gives a list of files', async () => {
     const files = await listFiles('*.svg', path.resolve(__dirname, './fixture/'));
-    expect(files.length).to.equal(2);
-    expect(files).to.have.members([
-      path.join(__dirname, './fixture/a.svg'),
-      path.join(__dirname, './fixture/b.svg'),
-    ]);
+    assert.equal(files.length, 2);
+    assert.deepEqual(
+      files.sort(),
+      [path.join(__dirname, './fixture/a.svg'), path.join(__dirname, './fixture/b.svg')].sort(),
+    );
   });
 
   it('only gives files and no folders', async () => {
     const files = await listFiles('**/*.svg', path.resolve(__dirname, './fixture/'));
-    expect(files.length).to.equal(4);
-    expect(files).to.have.members([
-      path.join(__dirname, './fixture/a.svg'),
-      path.join(__dirname, './fixture/b.svg'),
-      path.join(__dirname, './fixture/sub/sub-b.mark.svg'),
-      path.join(__dirname, './fixture/sub/sub-a.svg'),
-    ]);
+    assert.equal(files.length, 4);
+    assert.deepEqual(
+      files.sort(),
+      [
+        path.join(__dirname, './fixture/a.svg'),
+        path.join(__dirname, './fixture/b.svg'),
+        path.join(__dirname, './fixture/sub/sub-b.mark.svg'),
+        path.join(__dirname, './fixture/sub/sub-a.svg'),
+      ].sort(),
+    );
   });
 
   it('will copy files inside dot folders', async () => {
     const files = await listFiles('**/*.svg', path.resolve(__dirname, './fixtureDot/'));
-    expect(files.length).to.equal(1);
-    expect(files[0]).to.match(/fixtureDot(\/|\\)\.folder(\/|\\)inside-dot-folder\.svg$/);
+    assert.equal(files.length, 1);
+    assert.match(files[0], /fixtureDot(\/|\\)\.folder(\/|\\)inside-dot-folder\.svg$/);
   });
 });

--- a/packages/rollup-plugin-copy/test/patternsToFiles.test.js
+++ b/packages/rollup-plugin-copy/test/patternsToFiles.test.js
@@ -1,16 +1,17 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
 const path = require('path');
-const { expect } = require('chai');
 
 const { patternsToFiles } = require('../src/patternsToFiles.js');
 
 describe('patternsToFiles', () => {
   it('works with a string', async () => {
     const files = await patternsToFiles('*.svg', path.resolve(__dirname, './fixture/'));
-    expect(files.length).to.equal(2);
-    expect(files).to.have.members([
-      path.join(__dirname, './fixture/a.svg'),
-      path.join(__dirname, './fixture/b.svg'),
-    ]);
+    assert.equal(files.length, 2);
+    assert.deepEqual(
+      files.sort(),
+      [path.join(__dirname, './fixture/a.svg'), path.join(__dirname, './fixture/b.svg')].sort(),
+    );
   });
 
   it('works with an array of strings ', async () => {
@@ -18,11 +19,14 @@ describe('patternsToFiles', () => {
       ['*.svg', 'sub/*.mark.svg'],
       path.resolve(__dirname, './fixture/'),
     );
-    expect(files.length).to.equal(3);
-    expect(files).to.have.members([
-      path.join(__dirname, './fixture/a.svg'),
-      path.join(__dirname, './fixture/b.svg'),
-      path.join(__dirname, './fixture/sub/sub-b.mark.svg'),
-    ]);
+    assert.equal(files.length, 3);
+    assert.deepEqual(
+      files.sort(),
+      [
+        path.join(__dirname, './fixture/a.svg'),
+        path.join(__dirname, './fixture/b.svg'),
+        path.join(__dirname, './fixture/sub/sub-b.mark.svg'),
+      ].sort(),
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Migrate `@web/rollup-plugin-copy` tests from mocha/chai to `node:test` + `node:assert/strict`
- Update `test:node` script from mocha to `node --test --test-force-exit`
- 3 CJS test files, no TypeScript, no import path changes needed
- `expect(x).to.have.members([...])` replaced with `assert.deepEqual(x.sort(), [...].sort())`

## Test plan

- [x] 6/6 tests pass on Node 22.22.3
- [x] ESLint clean
- [x] Prettier clean