### PR TITLE
refactor(test-runner-mocha): migrate tests to node:test

### DIFF
--- a/packages/test-runner-mocha/package.json
+++ b/packages/test-runner-mocha/package.json
@@ -20,8 +20,8 @@
   "scripts": {
     "build": "tsc",
     "build:production": "rimraf dist && rollup -c ./rollup.config.mjs",
-    "test": "mocha test/**/*.test.js --reporter dot",
-    "test:watch": "mocha test/**/*.test.js --watch --watch-files src,test"
+    "test:node": "node --test --test-force-exit test/**/*.test.js",
+    "test:watch": "node --test --test-force-exit --watch test/**/*.test.js"
   },
   "files": [
     "dist"

--- a/packages/test-runner-mocha/test/autorun.test.js
+++ b/packages/test-runner-mocha/test/autorun.test.js
@@ -1,11 +1,10 @@
+const { it } = require('node:test');
+const assert = require('node:assert/strict');
 const { runTests } = require('@web/test-runner-core/test-helpers');
 const { chromeLauncher } = require('@web/test-runner-chrome');
 const { resolve } = require('path');
-const { expect } = require('chai');
 
-it('can run tests with autorun', async function () {
-  this.timeout(50000);
-
+it('can run tests with autorun', { timeout: 50000 }, async () => {
   const { sessions } = await runTests(
     {
       files: [resolve(__dirname, 'fixtures', 'autorun.js')],
@@ -16,28 +15,28 @@ it('can run tests with autorun', async function () {
     { allowFailure: true, reportErrors: false },
   );
 
-  expect(sessions.length).to.equal(1);
-  expect(sessions[0].passed).to.equal(false);
+  assert.equal(sessions.length, 1);
+  assert.equal(sessions[0].passed, false);
 
-  expect(sessions[0].testResults.tests.length).to.equal(2);
-  expect(sessions[0].testResults.tests[0].name).to.equal('test 1');
-  expect(sessions[0].testResults.tests[0].passed).to.equal(true);
-  expect(sessions[0].testResults.tests[1].name).to.equal('test 2');
-  expect(sessions[0].testResults.tests[1].passed).to.equal(false);
-  expect(sessions[0].testResults.tests[1].error.message).to.equal('test 2 error');
+  assert.equal(sessions[0].testResults.tests.length, 2);
+  assert.equal(sessions[0].testResults.tests[0].name, 'test 1');
+  assert.equal(sessions[0].testResults.tests[0].passed, true);
+  assert.equal(sessions[0].testResults.tests[1].name, 'test 2');
+  assert.equal(sessions[0].testResults.tests[1].passed, false);
+  assert.equal(sessions[0].testResults.tests[1].error.message, 'test 2 error');
 
-  expect(sessions[0].testResults.suites.length).to.equal(1);
-  expect(sessions[0].testResults.suites[0].tests.length).to.equal(2);
-  expect(sessions[0].testResults.suites[0].tests[0].name).to.equal('test a 1');
-  expect(sessions[0].testResults.suites[0].tests[0].passed).to.equal(true);
-  expect(sessions[0].testResults.suites[0].tests[1].name).to.equal('test a 2');
-  expect(sessions[0].testResults.suites[0].tests[1].passed).to.equal(false);
-  expect(sessions[0].testResults.suites[0].tests[1].error.message).to.equal('test a 2 error');
+  assert.equal(sessions[0].testResults.suites.length, 1);
+  assert.equal(sessions[0].testResults.suites[0].tests.length, 2);
+  assert.equal(sessions[0].testResults.suites[0].tests[0].name, 'test a 1');
+  assert.equal(sessions[0].testResults.suites[0].tests[0].passed, true);
+  assert.equal(sessions[0].testResults.suites[0].tests[1].name, 'test a 2');
+  assert.equal(sessions[0].testResults.suites[0].tests[1].passed, false);
+  assert.equal(sessions[0].testResults.suites[0].tests[1].error.message, 'test a 2 error');
 
-  expect(sessions[0].testResults.suites[0].suites.length).to.equal(1);
-  expect(sessions[0].testResults.suites[0].suites[0].tests.length).to.equal(2);
-  expect(sessions[0].testResults.suites[0].suites[0].tests[0].name).to.equal('test b 1');
-  expect(sessions[0].testResults.suites[0].suites[0].tests[0].passed).to.equal(true);
-  expect(sessions[0].testResults.suites[0].suites[0].tests[1].name).to.equal('test b 2');
-  expect(sessions[0].testResults.suites[0].suites[0].tests[1].passed).to.equal(true);
+  assert.equal(sessions[0].testResults.suites[0].suites.length, 1);
+  assert.equal(sessions[0].testResults.suites[0].suites[0].tests.length, 2);
+  assert.equal(sessions[0].testResults.suites[0].suites[0].tests[0].name, 'test b 1');
+  assert.equal(sessions[0].testResults.suites[0].suites[0].tests[0].passed, true);
+  assert.equal(sessions[0].testResults.suites[0].suites[0].tests[1].name, 'test b 2');
+  assert.equal(sessions[0].testResults.suites[0].suites[0].tests[1].passed, true);
 });

--- a/packages/test-runner-mocha/test/standalone.test.js
+++ b/packages/test-runner-mocha/test/standalone.test.js
@@ -1,11 +1,10 @@
+const { it } = require('node:test');
+const assert = require('node:assert/strict');
 const { runTests } = require('@web/test-runner-core/test-helpers');
 const { chromeLauncher } = require('@web/test-runner-chrome');
 const { resolve } = require('path');
-const { expect } = require('chai');
 
-it('can run tests with standalone', async function () {
-  this.timeout(50000);
-
+it('can run tests with standalone', { timeout: 50000 }, async () => {
   const { sessions } = await runTests(
     {
       files: [resolve(__dirname, 'fixtures', 'standalone.html')],
@@ -16,35 +15,33 @@ it('can run tests with standalone', async function () {
     { allowFailure: true, reportErrors: false },
   );
 
-  expect(sessions.length).to.equal(1);
-  expect(sessions[0].passed).to.equal(false);
+  assert.equal(sessions.length, 1);
+  assert.equal(sessions[0].passed, false);
 
-  expect(sessions[0].testResults.tests.length).to.equal(2);
-  expect(sessions[0].testResults.tests[0].name).to.equal('test 1');
-  expect(sessions[0].testResults.tests[0].passed).to.equal(true);
-  expect(sessions[0].testResults.tests[1].name).to.equal('test 2');
-  expect(sessions[0].testResults.tests[1].passed).to.equal(false);
-  expect(sessions[0].testResults.tests[1].error.message).to.equal('test 2 error');
+  assert.equal(sessions[0].testResults.tests.length, 2);
+  assert.equal(sessions[0].testResults.tests[0].name, 'test 1');
+  assert.equal(sessions[0].testResults.tests[0].passed, true);
+  assert.equal(sessions[0].testResults.tests[1].name, 'test 2');
+  assert.equal(sessions[0].testResults.tests[1].passed, false);
+  assert.equal(sessions[0].testResults.tests[1].error.message, 'test 2 error');
 
-  expect(sessions[0].testResults.suites.length).to.equal(1);
-  expect(sessions[0].testResults.suites[0].tests.length).to.equal(2);
-  expect(sessions[0].testResults.suites[0].tests[0].name).to.equal('test a 1');
-  expect(sessions[0].testResults.suites[0].tests[0].passed).to.equal(true);
-  expect(sessions[0].testResults.suites[0].tests[1].name).to.equal('test a 2');
-  expect(sessions[0].testResults.suites[0].tests[1].passed).to.equal(false);
-  expect(sessions[0].testResults.suites[0].tests[1].error.message).to.equal('test a 2 error');
+  assert.equal(sessions[0].testResults.suites.length, 1);
+  assert.equal(sessions[0].testResults.suites[0].tests.length, 2);
+  assert.equal(sessions[0].testResults.suites[0].tests[0].name, 'test a 1');
+  assert.equal(sessions[0].testResults.suites[0].tests[0].passed, true);
+  assert.equal(sessions[0].testResults.suites[0].tests[1].name, 'test a 2');
+  assert.equal(sessions[0].testResults.suites[0].tests[1].passed, false);
+  assert.equal(sessions[0].testResults.suites[0].tests[1].error.message, 'test a 2 error');
 
-  expect(sessions[0].testResults.suites[0].suites.length).to.equal(1);
-  expect(sessions[0].testResults.suites[0].suites[0].tests.length).to.equal(2);
-  expect(sessions[0].testResults.suites[0].suites[0].tests[0].name).to.equal('test b 1');
-  expect(sessions[0].testResults.suites[0].suites[0].tests[0].passed).to.equal(true);
-  expect(sessions[0].testResults.suites[0].suites[0].tests[1].name).to.equal('test b 2');
-  expect(sessions[0].testResults.suites[0].suites[0].tests[1].passed).to.equal(true);
+  assert.equal(sessions[0].testResults.suites[0].suites.length, 1);
+  assert.equal(sessions[0].testResults.suites[0].suites[0].tests.length, 2);
+  assert.equal(sessions[0].testResults.suites[0].suites[0].tests[0].name, 'test b 1');
+  assert.equal(sessions[0].testResults.suites[0].suites[0].tests[0].passed, true);
+  assert.equal(sessions[0].testResults.suites[0].suites[0].tests[1].name, 'test b 2');
+  assert.equal(sessions[0].testResults.suites[0].suites[0].tests[1].passed, true);
 });
 
-it('captures errors during setup', async function () {
-  this.timeout(50000);
-
+it('captures errors during setup', { timeout: 50000 }, async () => {
   const { sessions } = await runTests(
     {
       files: [resolve(__dirname, 'fixtures', 'standalone-setup-fail.html')],
@@ -55,8 +52,8 @@ it('captures errors during setup', async function () {
     { allowFailure: true, reportErrors: false },
   );
 
-  expect(sessions.length).to.equal(1);
-  expect(sessions[0].passed).to.equal(false);
-  expect(sessions[0].errors.length).to.equal(1);
-  expect(sessions[0].errors[0].message).to.equal('error during setup');
+  assert.equal(sessions.length, 1);
+  assert.equal(sessions[0].passed, false);
+  assert.equal(sessions[0].errors.length, 1);
+  assert.equal(sessions[0].errors[0].message, 'error during setup');
 });


### PR DESCRIPTION
## Summary

- Migrate `@web/test-runner-mocha` tests from mocha/chai to `node:test` + `node:assert/strict`
- Rename `test` script to `test:node` so root `npm run test:node --workspaces` picks it up
- 2 CJS test files, no TypeScript, no import path changes needed
- `this.timeout(50000)` replaced with `{ timeout: 50000 }` option
- mocha stays as devDependency (this package wraps mocha for browser use)

## Test plan

- [x] 3/3 tests pass on Node 22.22.3 with Chrome
- [x] ESLint clean
- [x] Prettier clean
- [x] Code review clean