### PR TITLE
refactor(dev-server-legacy): migrate tests to node:test

### DIFF
--- a/packages/dev-server-legacy/package.json
+++ b/packages/dev-server-legacy/package.json
@@ -27,8 +27,8 @@
   "scripts": {
     "build": "tsc",
     "start": "wds --open --config demo/server.config.mjs",
-    "test:node": "node --experimental-strip-types --test --test-force-exit test/**/*.test.ts",
-    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch test/**/*.test.ts"
+    "test:node": "node --experimental-strip-types --test --test-force-exit \"test/**/*.test.ts\"",
+    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch \"test/**/*.test.ts\""
   },
   "files": [
     "*.d.ts",

--- a/packages/dev-server-legacy/package.json
+++ b/packages/dev-server-legacy/package.json
@@ -27,8 +27,8 @@
   "scripts": {
     "build": "tsc",
     "start": "wds --open --config demo/server.config.mjs",
-    "test:node": "node --test --test-force-exit test/**/*.test.ts",
-    "test:watch": "node --test --test-force-exit --watch test/**/*.test.ts"
+    "test:node": "node --experimental-strip-types --test --test-force-exit test/**/*.test.ts",
+    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch test/**/*.test.ts"
   },
   "files": [
     "*.d.ts",

--- a/packages/dev-server-legacy/package.json
+++ b/packages/dev-server-legacy/package.json
@@ -27,8 +27,8 @@
   "scripts": {
     "build": "tsc",
     "start": "wds --open --config demo/server.config.mjs",
-    "test:node": "mocha \"test/**/*.test.ts\" --require ts-node/register --reporter dot",
-    "test:watch": "mocha \"test/**/*.test.ts\" --require ts-node/register --watch --watch-files src,test"
+    "test:node": "node --test --test-force-exit test/**/*.test.ts",
+    "test:watch": "node --test --test-force-exit --watch test/**/*.test.ts"
   },
   "files": [
     "*.d.ts",

--- a/packages/dev-server-legacy/test/transform-html.test.ts
+++ b/packages/dev-server-legacy/test/transform-html.test.ts
@@ -1,9 +1,10 @@
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 import { createTestServer } from '@web/dev-server-core/test-helpers';
 import { fetchText, expectIncludes } from '@web/dev-server-core/test-helpers';
 
-import { legacyPlugin } from '../src/legacyPlugin.js';
-import { modernUserAgents, legacyUserAgents } from './userAgents.js';
+import { legacyPlugin } from '../dist/legacyPlugin.js';
+import { modernUserAgents, legacyUserAgents } from './userAgents.ts';
 
 const htmlBody = `
 <html>
@@ -25,12 +26,10 @@ const inlineScriptHtmlBody = `
 </body>
 </html>`;
 
-describe('legacyPlugin - transform html', function () {
-  this.timeout(10000);
-
+describe('legacyPlugin - transform html', { timeout: 10000 }, () => {
   it(`does not do any work on a modern browser`, async () => {
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -48,13 +47,13 @@ describe('legacyPlugin - transform html', function () {
       headers: { 'user-agent': modernUserAgents['Chrome 78'] },
     });
 
-    expect(text.trim()).to.equal(htmlBody.trim());
+    assert.equal(text.trim(), htmlBody.trim());
     server.stop();
   });
 
   it(`injects polyfills into the HTML page on legacy browsers`, async () => {
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -80,7 +79,7 @@ describe('legacyPlugin - transform html', function () {
 
   it(`injects systemjs param to inline modules`, async () => {
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -104,7 +103,7 @@ describe('legacyPlugin - transform html', function () {
 
   it(`handles inline scripts`, async () => {
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -131,7 +130,7 @@ describe('legacyPlugin - transform html', function () {
 
   it(`can request inline scripts`, async () => {
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -158,7 +157,7 @@ describe('legacyPlugin - transform html', function () {
 
   it(`includes url parameters in inline script key`, async () => {
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',

--- a/packages/dev-server-legacy/test/transform-html.test.ts
+++ b/packages/dev-server-legacy/test/transform-html.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { createTestServer } from '@web/dev-server-core/test-helpers';
 import { fetchText, expectIncludes } from '@web/dev-server-core/test-helpers';
 
+// rewrite to ../src/legacyPlugin.ts when TS 5.7+ / rewriteRelativeImportExtensions
 import { legacyPlugin } from '../dist/legacyPlugin.js';
 import { modernUserAgents, legacyUserAgents } from './userAgents.ts';
 

--- a/packages/dev-server-legacy/test/transform-js.test.ts
+++ b/packages/dev-server-legacy/test/transform-js.test.ts
@@ -1,9 +1,10 @@
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 import { createTestServer } from '@web/dev-server-core/test-helpers';
 import { fetchText, expectIncludes, expectNotIncludes } from '@web/dev-server-core/test-helpers';
 
-import { legacyPlugin } from '../src/legacyPlugin.js';
-import { modernUserAgents, legacyUserAgents } from './userAgents.js';
+import { legacyPlugin } from '../dist/legacyPlugin.js';
+import { modernUserAgents, legacyUserAgents } from './userAgents.ts';
 
 const modernCode = `
 class Foo {
@@ -16,13 +17,11 @@ async function doImport() {
 
 console.log(window?.foo?.bar);`;
 
-describe('legacyPlugin - transform js', function () {
-  this.timeout(10000);
-
+describe('legacyPlugin - transform js', { timeout: 10000 }, () => {
   for (const [name, userAgent] of Object.entries(modernUserAgents)) {
     it(`does not do any work on ${name}`, async () => {
       const { server, host } = await createTestServer({
-        rootDir: __dirname,
+        rootDir: import.meta.dirname,
         plugins: [
           {
             name: 'test',
@@ -39,7 +38,7 @@ describe('legacyPlugin - transform js', function () {
       const text = await fetchText(`${host}/app.js`, {
         headers: { 'user-agent': userAgent },
       });
-      expect(text.trim()).to.equal(modernCode.trim());
+      assert.equal(text.trim(), modernCode.trim());
       server.stop();
     });
   }
@@ -47,7 +46,7 @@ describe('legacyPlugin - transform js', function () {
   for (const [name, userAgent] of Object.entries(legacyUserAgents)) {
     it(`transforms to es5 on ${name}`, async () => {
       const { server, host } = await createTestServer({
-        rootDir: __dirname,
+        rootDir: import.meta.dirname,
         plugins: [
           {
             name: 'test',
@@ -78,7 +77,7 @@ describe('legacyPlugin - transform js', function () {
 
     it(`transforms to SystemJS when systemjs paramater is given ${name}`, async () => {
       const { server, host } = await createTestServer({
-        rootDir: __dirname,
+        rootDir: import.meta.dirname,
         plugins: [
           {
             name: 'test',

--- a/packages/dev-server-legacy/test/transform-js.test.ts
+++ b/packages/dev-server-legacy/test/transform-js.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { createTestServer } from '@web/dev-server-core/test-helpers';
 import { fetchText, expectIncludes, expectNotIncludes } from '@web/dev-server-core/test-helpers';
 
+// rewrite to ../src/legacyPlugin.ts when TS 5.7+ / rewriteRelativeImportExtensions
 import { legacyPlugin } from '../dist/legacyPlugin.js';
 import { modernUserAgents, legacyUserAgents } from './userAgents.ts';
 


### PR DESCRIPTION
## Summary

- Migrate `@web/dev-server-legacy` tests from mocha/chai to `node:test` + `node:assert/strict`
- First TypeScript test migration in the series
- 2 TS test files, imports from `dist/` (compiled output)
- `__dirname` replaced with `import.meta.dirname`
- Local `.js` import paths updated to `.ts`

## Test plan

- [x] 20/20 tests pass on Node 22.22.3
- [x] ESLint clean
- [x] Prettier clean
- [x] Code review clean