### PR TITLE
refactor(dev-server-import-maps): migrate tests to node:test

### DIFF
--- a/packages/dev-server-import-maps/package.json
+++ b/packages/dev-server-import-maps/package.json
@@ -26,9 +26,9 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "mocha \"test/**/*.test.ts\" --require ts-node/register",
     "test:browser": "node ../test-runner/dist/bin.js test-browser/test/**/*.test.{js,html} --config test-browser/web-test-runner.config.mjs",
-    "test:watch": "mocha \"test/**/*.test.ts\" --require ts-node/register --watch --watch-files src,test"
+    "test:node": "node --experimental-strip-types --test --test-force-exit test/**/*.test.ts",
+    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch test/**/*.test.ts"
   },
   "files": [
     "*.d.ts",

--- a/packages/dev-server-import-maps/test/injection.test.ts
+++ b/packages/dev-server-import-maps/test/injection.test.ts
@@ -1,11 +1,12 @@
+import { it } from 'node:test';
 import { createTestServer, expectNotIncludes } from '@web/dev-server-core/test-helpers';
 import { fetchText, expectIncludes, virtualFilesPlugin } from '@web/dev-server-core/test-helpers';
 
-import { importMapsPlugin } from '../src/importMapsPlugin.js';
+import { importMapsPlugin } from '../dist/importMapsPlugin.js';
 
 it('can inject an import map into any page', async () => {
   const { server, host } = await createTestServer({
-    rootDir: __dirname,
+    rootDir: import.meta.dirname,
     plugins: [
       virtualFilesPlugin({
         '/index.html': '<html><body></body></html>',
@@ -28,7 +29,7 @@ it('can inject an import map into any page', async () => {
 
 it('can use an include pattern', async () => {
   const { server, host } = await createTestServer({
-    rootDir: __dirname,
+    rootDir: import.meta.dirname,
     plugins: [
       virtualFilesPlugin({
         '/foo/a.html': '<html><body></body></html>',
@@ -58,7 +59,7 @@ it('can use an include pattern', async () => {
 
 it('can use an exclude pattern', async () => {
   const { server, host } = await createTestServer({
-    rootDir: __dirname,
+    rootDir: import.meta.dirname,
     plugins: [
       virtualFilesPlugin({
         '/foo/a.html': '<html><body></body></html>',
@@ -86,7 +87,7 @@ it('can use an exclude pattern', async () => {
 
 it('treats directory paths with an implicit index.html file', async () => {
   const { server, host } = await createTestServer({
-    rootDir: __dirname,
+    rootDir: import.meta.dirname,
     plugins: [
       {
         name: 'test',
@@ -116,7 +117,7 @@ it('treats directory paths with an implicit index.html file', async () => {
 
 it('merges with an existing import map', async () => {
   const { server, host } = await createTestServer({
-    rootDir: __dirname,
+    rootDir: import.meta.dirname,
     plugins: [
       virtualFilesPlugin({
         '/index.html':
@@ -146,7 +147,7 @@ it('merges with an existing import map', async () => {
 
 it('merges import map scopes', async () => {
   const { server, host } = await createTestServer({
-    rootDir: __dirname,
+    rootDir: import.meta.dirname,
     plugins: [
       virtualFilesPlugin({
         '/index.html':
@@ -176,7 +177,7 @@ it('merges import map scopes', async () => {
 
 it('the import map in the HTML file takes priority over the injected import map', async () => {
   const { server, host } = await createTestServer({
-    rootDir: __dirname,
+    rootDir: import.meta.dirname,
     plugins: [
       virtualFilesPlugin({
         '/index.html':

--- a/packages/dev-server-import-maps/test/resolving.test.ts
+++ b/packages/dev-server-import-maps/test/resolving.test.ts
@@ -1,11 +1,11 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
 import { fetchText, expectIncludes, virtualFilesPlugin } from '@web/dev-server-core/test-helpers';
 import { createTestServer } from '@web/dev-server-core/test-helpers';
-import { expect } from 'chai';
-import { spy } from 'hanbi';
 import path from 'path';
 
-import { importMapsPlugin } from '../src/importMapsPlugin.js';
-import { IMPORT_MAP_PARAM } from '../src/utils.js';
+import { importMapsPlugin } from '../dist/importMapsPlugin.js';
+import { IMPORT_MAP_PARAM } from '../dist/utils.js';
 
 function createHtml(importMap: Record<string, unknown>) {
   return `
@@ -33,7 +33,7 @@ describe('applies import map id', () => {
       '/index.html': createHtml({ foo: './mocked-foo.js' }),
     };
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [virtualFilesPlugin(files), importMapsPlugin()],
     });
 
@@ -48,7 +48,7 @@ describe('applies import map id', () => {
       '/index.html': createHtml({ foo: './mocked-foo.js' }),
     };
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [virtualFilesPlugin(files), importMapsPlugin()],
     });
 
@@ -63,7 +63,7 @@ describe('applies import map id', () => {
       '/index.html': createHtml({ foo: './mocked-foo.js' }),
     };
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [virtualFilesPlugin(files), importMapsPlugin()],
     });
 
@@ -80,7 +80,7 @@ describe('applies import map id', () => {
       '/app.js': 'import "foo"; import foo from "./bar.js";',
     };
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [virtualFilesPlugin(files), importMapsPlugin()],
     });
 
@@ -98,7 +98,7 @@ describe('applies import map id', () => {
       '/app.js': 'import "bar";',
     };
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -124,7 +124,7 @@ describe('applies import map id', () => {
       '/app.js': 'import "bar";',
     };
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -150,7 +150,7 @@ describe('applies import map id', () => {
       '/app.js': 'import "bar?foo=bar";',
     };
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [virtualFilesPlugin(files), importMapsPlugin()],
     });
 
@@ -169,7 +169,7 @@ describe('resolving imports', () => {
       '/app.js': 'import "foo";\nimport bar from "./bar.js";',
     };
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [virtualFilesPlugin(files), importMapsPlugin()],
     });
 
@@ -187,7 +187,7 @@ describe('resolving imports', () => {
       '/x/y/app.js': 'import bar from "../../bar.js";\nimport bar from "../bar.js";',
     };
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [virtualFilesPlugin(files), importMapsPlugin()],
     });
 
@@ -205,7 +205,7 @@ describe('resolving imports', () => {
       '/x/y/app.js': 'import "x";',
     };
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [virtualFilesPlugin(files), importMapsPlugin()],
     });
 
@@ -222,7 +222,7 @@ describe('resolving imports', () => {
       '/x/app.js': 'import "./y/bar.js"; \n import "./bar.js"; \n import "../bar.js";',
     };
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [virtualFilesPlugin(files), importMapsPlugin()],
     });
 
@@ -249,7 +249,7 @@ describe('resolving imports', () => {
       '/x/app.js': 'import "bar";',
     };
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [virtualFilesPlugin(files), importMapsPlugin()],
     });
 
@@ -274,7 +274,7 @@ describe('resolving imports', () => {
       '/x/app.js': 'import "bar";',
     };
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [virtualFilesPlugin(files), importMapsPlugin()],
     });
 
@@ -289,7 +289,7 @@ describe('resolving imports', () => {
     let i = 0;
 
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -329,7 +329,7 @@ describe('resolving imports', () => {
       '/index.html': '<html><body><script src="./app.js"></script></body></html>',
     };
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [virtualFilesPlugin(files), importMapsPlugin()],
     });
 
@@ -351,27 +351,20 @@ describe('resolving imports', () => {
           </body>
         </html>`,
     };
-    const loggerSpies = {
-      log: spy(),
-      debug: spy(),
-      error: spy(),
-      warn: spy(),
-      group: spy(),
-      groupEnd: spy(),
-      logSyntaxError: spy(),
-    };
+    const warnFn = mock.fn();
+    const noopFn = mock.fn();
     const logger = {
-      log: loggerSpies.log.handler,
-      debug: loggerSpies.debug.handler,
-      error: loggerSpies.error.handler,
-      warn: loggerSpies.warn.handler,
-      group: loggerSpies.group.handler,
-      groupEnd: loggerSpies.groupEnd.handler,
-      logSyntaxError: loggerSpies.logSyntaxError.handler,
+      log: noopFn,
+      debug: noopFn,
+      error: noopFn,
+      warn: warnFn,
+      group: noopFn,
+      groupEnd: noopFn,
+      logSyntaxError: noopFn,
     };
     const { server, host } = await createTestServer(
       {
-        rootDir: __dirname,
+        rootDir: import.meta.dirname,
         plugins: [virtualFilesPlugin(files), importMapsPlugin()],
       },
       logger,
@@ -379,8 +372,8 @@ describe('resolving imports', () => {
 
     const text = await fetchText(`${host}/index.html`);
     expectIncludes(text, '<script type="importmap">{</script>');
-    expect(loggerSpies.warn.callCount).to.equal(1);
-    const warning = loggerSpies.warn.getCall(0).args[0];
+    assert.equal(warnFn.mock.callCount(), 1);
+    const warning = warnFn.mock.calls[0].arguments[0];
     expectIncludes(warning, 'Failed to parse import map in "');
     expectIncludes(warning, `test${path.sep}index.html": `);
     server.stop();
@@ -392,7 +385,7 @@ describe('resolving imports', () => {
       '/app.js': 'import "foo";\nimport bar from "./bar.js";',
     };
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [virtualFilesPlugin(files), importMapsPlugin()],
     });
 

--- a/packages/dev-server-import-maps/test/resolving.test.ts
+++ b/packages/dev-server-import-maps/test/resolving.test.ts
@@ -351,16 +351,14 @@ describe('resolving imports', () => {
           </body>
         </html>`,
     };
-    const warnFn = mock.fn();
-    const noopFn = mock.fn();
     const logger = {
-      log: noopFn,
-      debug: noopFn,
-      error: noopFn,
-      warn: warnFn,
-      group: noopFn,
-      groupEnd: noopFn,
-      logSyntaxError: noopFn,
+      log: mock.fn(),
+      debug: mock.fn(),
+      error: mock.fn(),
+      warn: mock.fn(),
+      group: mock.fn(),
+      groupEnd: mock.fn(),
+      logSyntaxError: mock.fn(),
     };
     const { server, host } = await createTestServer(
       {
@@ -372,8 +370,8 @@ describe('resolving imports', () => {
 
     const text = await fetchText(`${host}/index.html`);
     expectIncludes(text, '<script type="importmap">{</script>');
-    assert.equal(warnFn.mock.callCount(), 1);
-    const warning = warnFn.mock.calls[0].arguments[0];
+    assert.equal(logger.warn.mock.callCount(), 1);
+    const warning = logger.warn.mock.calls[0].arguments[0];
     expectIncludes(warning, 'Failed to parse import map in "');
     expectIncludes(warning, `test${path.sep}index.html": `);
     server.stop();


### PR DESCRIPTION
## Summary

- Migrate `@web/dev-server-import-maps` node tests from mocha/chai/hanbi to `node:test` + `node:assert/strict` + `node:test` mock API
- Rename `test` script to `test:node` so root `npm run test:node --workspaces` picks it up
- `test:browser` script unchanged (browser tests still use @web/test-runner-mocha)
- 2 TS test files, imports from `dist/`, `__dirname` -> `import.meta.dirname`
- hanbi `spy()` replaced with `mock.fn()`
- `--experimental-strip-types` added to override CI `NODE_OPTIONS` workaround

## Test plan

- [x] 24/24 tests pass on Node 22.22.3 with `NODE_OPTIONS='--no-experimental-strip-types'`
- [x] ESLint clean
- [x] Prettier clean
- [x] Code review clean