### PR TITLE
refactor(dev-server-esbuild): migrate tests to node:test

### DIFF
--- a/packages/dev-server-esbuild/package.json
+++ b/packages/dev-server-esbuild/package.json
@@ -28,8 +28,8 @@
     "build": "tsc",
     "start:demo:jsx": "es-dev-server --config demo/jsx/server.config.js",
     "start:demo:ts": "es-dev-server --config demo/ts/server.config.js",
-    "test:node": "mocha \"test/**/*.test.ts\" --require ts-node/register --reporter dot",
-    "test:watch": "mocha \"test/**/*.test.ts\" --require ts-node/register --watch --watch-files src,test"
+    "test:node": "node --experimental-strip-types --test --test-force-exit test/**/*.test.ts",
+    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch test/**/*.test.ts"
   },
   "files": [
     "*.d.ts",

--- a/packages/dev-server-esbuild/test/banner-footer.test.ts
+++ b/packages/dev-server-esbuild/test/banner-footer.test.ts
@@ -1,15 +1,14 @@
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 import { createTestServer } from '@web/dev-server-core/test-helpers';
 import { expectIncludes } from '@web/dev-server-core/test-helpers';
 
-import { esbuildPlugin } from '../src/index.js';
+import { esbuildPlugin } from '../dist/index.js';
 
-describe('esbuildPlugin banner/footers', function () {
-  this.timeout(5000);
-
+describe('esbuildPlugin banner/footers', { timeout: 5000 }, () => {
   it('prepends custom banner', async () => {
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -31,7 +30,7 @@ describe('esbuildPlugin banner/footers', function () {
       const indexOfBanner = text.indexOf('/* hello there */');
 
       expectIncludes(text, '/* hello there */');
-      expect(indexOfExpr).to.be.greaterThan(indexOfBanner);
+      assert.ok(indexOfExpr > indexOfBanner);
     } finally {
       server.stop();
     }
@@ -39,7 +38,7 @@ describe('esbuildPlugin banner/footers', function () {
 
   it('appends custom footer', async () => {
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -61,7 +60,7 @@ describe('esbuildPlugin banner/footers', function () {
       const indexOfFooter = text.indexOf('/* hello there */');
 
       expectIncludes(text, '/* hello there */');
-      expect(indexOfFooter).to.be.greaterThan(indexOfExpr);
+      assert.ok(indexOfFooter > indexOfExpr);
     } finally {
       server.stop();
     }

--- a/packages/dev-server-esbuild/test/browser-targets.test.ts
+++ b/packages/dev-server-esbuild/test/browser-targets.test.ts
@@ -8,70 +8,94 @@ const { browsers } = bcd;
 describe('isLatestModernBrowser', () => {
   it('returns true for latest Chrome', async () => {
     const latest = getLatestStableMajor(browsers.chrome.releases)!;
-    assert.equal(isLatestModernBrowser({ name: 'Chrome', version: String(latest) }), true);
+    assert.strictEqual(isLatestModernBrowser({ name: 'Chrome', version: String(latest) }), true);
   });
 
   it('returns true for latest Chrome -1', async () => {
     const latest = getLatestStableMajor(browsers.chrome.releases)!;
-    assert.equal(isLatestModernBrowser({ name: 'Chrome', version: String(latest - 1) }), true);
+    assert.strictEqual(
+      isLatestModernBrowser({ name: 'Chrome', version: String(latest - 1) }),
+      true,
+    );
   });
 
   it('returns true for future version of Chrome', async () => {
     const latest = getLatestStableMajor(browsers.chrome.releases)!;
-    assert.equal(isLatestModernBrowser({ name: 'Chrome', version: String(latest + 1) }), true);
+    assert.strictEqual(
+      isLatestModernBrowser({ name: 'Chrome', version: String(latest + 1) }),
+      true,
+    );
   });
 
   it('returns true for unknown version of Chrome', async () => {
-    assert.equal(isLatestModernBrowser({ name: 'Chrome', version: '9999999' }), true);
+    assert.strictEqual(isLatestModernBrowser({ name: 'Chrome', version: '9999999' }), true);
   });
 
   it('returns false for latest Chrome -2', async () => {
     const latest = getLatestStableMajor(browsers.chrome.releases)!;
-    assert.equal(isLatestModernBrowser({ name: 'Chrome', version: String(latest - 2) }), false);
+    assert.strictEqual(
+      isLatestModernBrowser({ name: 'Chrome', version: String(latest - 2) }),
+      false,
+    );
   });
 
   it('returns false for latest Chrome -3', async () => {
     const latest = getLatestStableMajor(browsers.chrome.releases)!;
-    assert.equal(isLatestModernBrowser({ name: 'Chrome', version: String(latest - 3) }), false);
+    assert.strictEqual(
+      isLatestModernBrowser({ name: 'Chrome', version: String(latest - 3) }),
+      false,
+    );
   });
 
   it('returns true for latest Chrome Headless', async () => {
     const latest = getLatestStableMajor(browsers.chrome.releases)!;
-    assert.equal(isLatestModernBrowser({ name: 'Chrome Headless', version: String(latest) }), true);
+    assert.strictEqual(
+      isLatestModernBrowser({ name: 'Chrome Headless', version: String(latest) }),
+      true,
+    );
   });
 
   it('returns true for latest chromium', async () => {
     const latest = getLatestStableMajor(browsers.chrome.releases)!;
-    assert.equal(isLatestModernBrowser({ name: 'Chromium', version: String(latest) }), true);
+    assert.strictEqual(isLatestModernBrowser({ name: 'Chromium', version: String(latest) }), true);
   });
 
   it('returns true for latest Firefox', async () => {
     const latest = getLatestStableMajor(browsers.firefox.releases)!;
-    assert.equal(isLatestModernBrowser({ name: 'Firefox', version: String(latest) }), true);
+    assert.strictEqual(isLatestModernBrowser({ name: 'Firefox', version: String(latest) }), true);
   });
 
   it('returns false for latest Firefox -1', async () => {
     const latest = getLatestStableMajor(browsers.firefox.releases)!;
-    assert.equal(isLatestModernBrowser({ name: 'Firefox', version: String(latest - 1) }), false);
+    assert.strictEqual(
+      isLatestModernBrowser({ name: 'Firefox', version: String(latest - 1) }),
+      false,
+    );
   });
 
   it('returns false for latest Firefox -2', async () => {
     const latest = getLatestStableMajor(browsers.firefox.releases)!;
-    assert.equal(isLatestModernBrowser({ name: 'Firefox', version: String(latest - 2) }), false);
+    assert.strictEqual(
+      isLatestModernBrowser({ name: 'Firefox', version: String(latest - 2) }),
+      false,
+    );
   });
 
   it('returns true for latest Edge', async () => {
     const latest = getLatestStableMajor(browsers.edge.releases)!;
-    assert.equal(isLatestModernBrowser({ name: 'Edge', version: String(latest) }), true);
+    assert.strictEqual(isLatestModernBrowser({ name: 'Edge', version: String(latest) }), true);
   });
 
   it('returns true for latest Edge -1', async () => {
     const latest = getLatestStableMajor(browsers.edge.releases)!;
-    assert.equal(isLatestModernBrowser({ name: 'Edge', version: String(latest - 1) }), true);
+    assert.strictEqual(isLatestModernBrowser({ name: 'Edge', version: String(latest - 1) }), true);
   });
 
   it('returns false for latest Edge -2', async () => {
     const latest = getLatestStableMajor(browsers.edge.releases)!;
-    assert.equal(isLatestModernBrowser({ name: 'Chrome', version: String(latest - 2) }), false);
+    assert.strictEqual(
+      isLatestModernBrowser({ name: 'Chrome', version: String(latest - 2) }),
+      false,
+    );
   });
 });

--- a/packages/dev-server-esbuild/test/browser-targets.test.ts
+++ b/packages/dev-server-esbuild/test/browser-targets.test.ts
@@ -1,74 +1,77 @@
-import { expect } from 'chai';
-import { browsers } from '@mdn/browser-compat-data';
-import { isLatestModernBrowser, getLatestStableMajor } from '../src/browser-targets.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import bcd from '@mdn/browser-compat-data';
+import { isLatestModernBrowser, getLatestStableMajor } from '../dist/browser-targets.js';
+
+const { browsers } = bcd;
 
 describe('isLatestModernBrowser', () => {
   it('returns true for latest Chrome', async () => {
     const latest = getLatestStableMajor(browsers.chrome.releases)!;
-    expect(isLatestModernBrowser({ name: 'Chrome', version: String(latest) })).to.be.true;
+    assert.equal(isLatestModernBrowser({ name: 'Chrome', version: String(latest) }), true);
   });
 
   it('returns true for latest Chrome -1', async () => {
     const latest = getLatestStableMajor(browsers.chrome.releases)!;
-    expect(isLatestModernBrowser({ name: 'Chrome', version: String(latest - 1) })).to.be.true;
+    assert.equal(isLatestModernBrowser({ name: 'Chrome', version: String(latest - 1) }), true);
   });
 
   it('returns true for future version of Chrome', async () => {
     const latest = getLatestStableMajor(browsers.chrome.releases)!;
-    expect(isLatestModernBrowser({ name: 'Chrome', version: String(latest + 1) })).to.be.true;
+    assert.equal(isLatestModernBrowser({ name: 'Chrome', version: String(latest + 1) }), true);
   });
 
   it('returns true for unknown version of Chrome', async () => {
-    expect(isLatestModernBrowser({ name: 'Chrome', version: '9999999' })).to.be.true;
+    assert.equal(isLatestModernBrowser({ name: 'Chrome', version: '9999999' }), true);
   });
 
   it('returns false for latest Chrome -2', async () => {
     const latest = getLatestStableMajor(browsers.chrome.releases)!;
-    expect(isLatestModernBrowser({ name: 'Chrome', version: String(latest - 2) })).to.be.false;
+    assert.equal(isLatestModernBrowser({ name: 'Chrome', version: String(latest - 2) }), false);
   });
 
   it('returns false for latest Chrome -3', async () => {
     const latest = getLatestStableMajor(browsers.chrome.releases)!;
-    expect(isLatestModernBrowser({ name: 'Chrome', version: String(latest - 3) })).to.be.false;
+    assert.equal(isLatestModernBrowser({ name: 'Chrome', version: String(latest - 3) }), false);
   });
 
   it('returns true for latest Chrome Headless', async () => {
     const latest = getLatestStableMajor(browsers.chrome.releases)!;
-    expect(isLatestModernBrowser({ name: 'Chrome Headless', version: String(latest) })).to.be.true;
+    assert.equal(isLatestModernBrowser({ name: 'Chrome Headless', version: String(latest) }), true);
   });
 
   it('returns true for latest chromium', async () => {
     const latest = getLatestStableMajor(browsers.chrome.releases)!;
-    expect(isLatestModernBrowser({ name: 'Chromium', version: String(latest) })).to.be.true;
+    assert.equal(isLatestModernBrowser({ name: 'Chromium', version: String(latest) }), true);
   });
 
   it('returns true for latest Firefox', async () => {
     const latest = getLatestStableMajor(browsers.firefox.releases)!;
-    expect(isLatestModernBrowser({ name: 'Firefox', version: String(latest) })).to.be.true;
+    assert.equal(isLatestModernBrowser({ name: 'Firefox', version: String(latest) }), true);
   });
 
   it('returns false for latest Firefox -1', async () => {
     const latest = getLatestStableMajor(browsers.firefox.releases)!;
-    expect(isLatestModernBrowser({ name: 'Firefox', version: String(latest - 1) })).to.be.false;
+    assert.equal(isLatestModernBrowser({ name: 'Firefox', version: String(latest - 1) }), false);
   });
 
   it('returns false for latest Firefox -2', async () => {
     const latest = getLatestStableMajor(browsers.firefox.releases)!;
-    expect(isLatestModernBrowser({ name: 'Firefox', version: String(latest - 2) })).to.be.false;
+    assert.equal(isLatestModernBrowser({ name: 'Firefox', version: String(latest - 2) }), false);
   });
 
   it('returns true for latest Edge', async () => {
     const latest = getLatestStableMajor(browsers.edge.releases)!;
-    expect(isLatestModernBrowser({ name: 'Edge', version: String(latest) })).to.be.true;
+    assert.equal(isLatestModernBrowser({ name: 'Edge', version: String(latest) }), true);
   });
 
   it('returns true for latest Edge -1', async () => {
     const latest = getLatestStableMajor(browsers.edge.releases)!;
-    expect(isLatestModernBrowser({ name: 'Edge', version: String(latest - 1) })).to.be.true;
+    assert.equal(isLatestModernBrowser({ name: 'Edge', version: String(latest - 1) }), true);
   });
 
   it('returns false for latest Edge -2', async () => {
     const latest = getLatestStableMajor(browsers.edge.releases)!;
-    expect(isLatestModernBrowser({ name: 'Chrome', version: String(latest - 2) })).to.be.false;
+    assert.equal(isLatestModernBrowser({ name: 'Chrome', version: String(latest - 2) }), false);
   });
 });

--- a/packages/dev-server-esbuild/test/json.test.ts
+++ b/packages/dev-server-esbuild/test/json.test.ts
@@ -25,8 +25,11 @@ describe('esbuildPlugin JSON', () => {
       const response = await fetch(`${host}/foo.json`);
       const text = await response.text();
 
-      assert.equal(response.status, 200);
-      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(
+        response.headers.get('content-type'),
+        'application/javascript; charset=utf-8',
+      );
       expectIncludes(text, 'var foo = "bar";');
       expectIncludes(text, 'var foo_default = { foo };');
       expectIncludes(text, 'export {');

--- a/packages/dev-server-esbuild/test/json.test.ts
+++ b/packages/dev-server-esbuild/test/json.test.ts
@@ -1,12 +1,13 @@
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 import { expectIncludes, createTestServer } from '@web/dev-server-core/test-helpers';
 
-import { esbuildPlugin } from '../src/index.js';
+import { esbuildPlugin } from '../dist/index.js';
 
-describe('esbuildPlugin JSON', function () {
+describe('esbuildPlugin JSON', () => {
   it('transforms .json files', async () => {
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -24,10 +25,8 @@ describe('esbuildPlugin JSON', function () {
       const response = await fetch(`${host}/foo.json`);
       const text = await response.text();
 
-      expect(response.status).to.equal(200);
-      expect(response.headers.get('content-type')).to.equal(
-        'application/javascript; charset=utf-8',
-      );
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
       expectIncludes(text, 'var foo = "bar";');
       expectIncludes(text, 'var foo_default = { foo };');
       expectIncludes(text, 'export {');

--- a/packages/dev-server-esbuild/test/jsx.test.ts
+++ b/packages/dev-server-esbuild/test/jsx.test.ts
@@ -1,12 +1,13 @@
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 import { expectIncludes, createTestServer } from '@web/dev-server-core/test-helpers';
 
-import { esbuildPlugin } from '../src/index.js';
+import { esbuildPlugin } from '../dist/index.js';
 
-describe('esbuildPlugin JSX', function () {
+describe('esbuildPlugin JSX', () => {
   it('transforms .jsx files', async () => {
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -28,10 +29,8 @@ export function foo(bar) {
       const response = await fetch(`${host}/foo.jsx`);
       const text = await response.text();
 
-      expect(response.status).to.equal(200);
-      expect(response.headers.get('content-type')).to.equal(
-        'application/javascript; charset=utf-8',
-      );
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
       expectIncludes(text, 'React.createElement("div", {');
       expectIncludes(text, 'id: "myDiv"');
       expectIncludes(text, 'React.createElement(MyElement, {');
@@ -43,7 +42,7 @@ export function foo(bar) {
 
   it('can set the JSX factory', async () => {
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -65,10 +64,8 @@ export function foo(bar) {
       const response = await fetch(`${host}/foo.jsx`);
       const text = await response.text();
 
-      expect(response.status).to.equal(200);
-      expect(response.headers.get('content-type')).to.equal(
-        'application/javascript; charset=utf-8',
-      );
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
       expectIncludes(text, 'h("div", {');
       expectIncludes(text, 'id: "myDiv"');
       expectIncludes(text, 'h(MyElement, {');

--- a/packages/dev-server-esbuild/test/jsx.test.ts
+++ b/packages/dev-server-esbuild/test/jsx.test.ts
@@ -29,8 +29,11 @@ export function foo(bar) {
       const response = await fetch(`${host}/foo.jsx`);
       const text = await response.text();
 
-      assert.equal(response.status, 200);
-      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(
+        response.headers.get('content-type'),
+        'application/javascript; charset=utf-8',
+      );
       expectIncludes(text, 'React.createElement("div", {');
       expectIncludes(text, 'id: "myDiv"');
       expectIncludes(text, 'React.createElement(MyElement, {');
@@ -64,8 +67,11 @@ export function foo(bar) {
       const response = await fetch(`${host}/foo.jsx`);
       const text = await response.text();
 
-      assert.equal(response.status, 200);
-      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(
+        response.headers.get('content-type'),
+        'application/javascript; charset=utf-8',
+      );
       expectIncludes(text, 'h("div", {');
       expectIncludes(text, 'id: "myDiv"');
       expectIncludes(text, 'h(MyElement, {');

--- a/packages/dev-server-esbuild/test/target.test.ts
+++ b/packages/dev-server-esbuild/test/target.test.ts
@@ -367,8 +367,8 @@ describe('esbuildPlugin target', () => {
 
       assert.equal(response.status, 200);
       assert.equal(response.headers.get('content-type'), 'text/html; charset=utf-8');
-      assert.ok(text.includes(importmapString));
-      assert.ok(text.includes(jsonString));
+      expectIncludes(text, importmapString);
+      expectIncludes(text, jsonString);
     } finally {
       server.stop();
     }

--- a/packages/dev-server-esbuild/test/target.test.ts
+++ b/packages/dev-server-esbuild/test/target.test.ts
@@ -1,7 +1,8 @@
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 import { createTestServer, expectIncludes } from '@web/dev-server-core/test-helpers';
 
-import { esbuildPlugin } from '../src/index.js';
+import { esbuildPlugin } from '../dist/index.js';
 
 const modernJs = `
 class MyClass {
@@ -58,10 +59,10 @@ const transformedSyntax = {
   ],
 };
 
-describe('esbuildPlugin target', function () {
+describe('esbuildPlugin target', () => {
   it('does not transform anything when set to esnext', async () => {
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -79,10 +80,8 @@ describe('esbuildPlugin target', function () {
       const response = await fetch(`${host}/foo.js`);
       const text = await response.text();
 
-      expect(response.status).to.equal(200);
-      expect(response.headers.get('content-type')).to.equal(
-        'application/javascript; charset=utf-8',
-      );
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
 
       expectIncludes(text, syntax.classes);
       for (const e of syntax.classFields) {
@@ -103,7 +102,7 @@ describe('esbuildPlugin target', function () {
 
   it('can transform to es2020', async () => {
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -121,10 +120,8 @@ describe('esbuildPlugin target', function () {
       const response = await fetch(`${host}/foo.js`);
       const text = await response.text();
 
-      expect(response.status).to.equal(200);
-      expect(response.headers.get('content-type')).to.equal(
-        'application/javascript; charset=utf-8',
-      );
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
 
       expectIncludes(text, syntax.classes);
       for (const e of transformedSyntax.classFields) {
@@ -145,7 +142,7 @@ describe('esbuildPlugin target', function () {
 
   it('can transform to es2019', async () => {
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -163,10 +160,8 @@ describe('esbuildPlugin target', function () {
       const response = await fetch(`${host}/foo.js`);
       const text = await response.text();
 
-      expect(response.status).to.equal(200);
-      expect(response.headers.get('content-type')).to.equal(
-        'application/javascript; charset=utf-8',
-      );
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
 
       expectIncludes(text, syntax.classes);
       for (const e of transformedSyntax.classFields) {
@@ -187,7 +182,7 @@ describe('esbuildPlugin target', function () {
 
   it('can transform to es2018', async () => {
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -205,10 +200,8 @@ describe('esbuildPlugin target', function () {
       const response = await fetch(`${host}/foo.js`);
       const text = await response.text();
 
-      expect(response.status).to.equal(200);
-      expect(response.headers.get('content-type')).to.equal(
-        'application/javascript; charset=utf-8',
-      );
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
 
       expectIncludes(text, syntax.classes);
       for (const e of transformedSyntax.classFields) {
@@ -229,7 +222,7 @@ describe('esbuildPlugin target', function () {
 
   it('can transform to es2017', async () => {
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -247,10 +240,8 @@ describe('esbuildPlugin target', function () {
       const response = await fetch(`${host}/foo.js`);
       const text = await response.text();
 
-      expect(response.status).to.equal(200);
-      expect(response.headers.get('content-type')).to.equal(
-        'application/javascript; charset=utf-8',
-      );
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
 
       expectIncludes(text, syntax.classes);
       for (const e of transformedSyntax.classFields) {
@@ -269,7 +260,7 @@ describe('esbuildPlugin target', function () {
 
   it('can transform to es2016', async () => {
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -287,10 +278,8 @@ describe('esbuildPlugin target', function () {
       const response = await fetch(`${host}/foo.js`);
       const text = await response.text();
 
-      expect(response.status).to.equal(200);
-      expect(response.headers.get('content-type')).to.equal(
-        'application/javascript; charset=utf-8',
-      );
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
 
       expectIncludes(text, syntax.classes);
       for (const e of transformedSyntax.classFields) {
@@ -309,7 +298,7 @@ describe('esbuildPlugin target', function () {
 
   it('can transform inline scripts', async () => {
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -331,8 +320,8 @@ describe('esbuildPlugin target', function () {
       const response = await fetch(`${host}/index.html`);
       const text = await response.text();
 
-      expect(response.status).to.equal(200);
-      expect(response.headers.get('content-type')).to.equal('text/html; charset=utf-8');
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get('content-type'), 'text/html; charset=utf-8');
 
       expectIncludes(text, syntax.classes);
       for (const e of transformedSyntax.classFields) {
@@ -353,7 +342,7 @@ describe('esbuildPlugin target', function () {
     const importmapString = '{"imports":{"foo":"./bar.js"}}';
     const jsonString = '{test:1}';
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -376,10 +365,10 @@ describe('esbuildPlugin target', function () {
       const response = await fetch(`${host}/index.html`);
       const text = await response.text();
 
-      expect(response.status).to.equal(200);
-      expect(response.headers.get('content-type')).to.equal('text/html; charset=utf-8');
-      expect(text).to.include(importmapString);
-      expect(text).to.include(jsonString);
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get('content-type'), 'text/html; charset=utf-8');
+      assert.ok(text.includes(importmapString));
+      assert.ok(text.includes(jsonString));
     } finally {
       server.stop();
     }

--- a/packages/dev-server-esbuild/test/target.test.ts
+++ b/packages/dev-server-esbuild/test/target.test.ts
@@ -80,8 +80,11 @@ describe('esbuildPlugin target', () => {
       const response = await fetch(`${host}/foo.js`);
       const text = await response.text();
 
-      assert.equal(response.status, 200);
-      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(
+        response.headers.get('content-type'),
+        'application/javascript; charset=utf-8',
+      );
 
       expectIncludes(text, syntax.classes);
       for (const e of syntax.classFields) {
@@ -120,8 +123,11 @@ describe('esbuildPlugin target', () => {
       const response = await fetch(`${host}/foo.js`);
       const text = await response.text();
 
-      assert.equal(response.status, 200);
-      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(
+        response.headers.get('content-type'),
+        'application/javascript; charset=utf-8',
+      );
 
       expectIncludes(text, syntax.classes);
       for (const e of transformedSyntax.classFields) {
@@ -160,8 +166,11 @@ describe('esbuildPlugin target', () => {
       const response = await fetch(`${host}/foo.js`);
       const text = await response.text();
 
-      assert.equal(response.status, 200);
-      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(
+        response.headers.get('content-type'),
+        'application/javascript; charset=utf-8',
+      );
 
       expectIncludes(text, syntax.classes);
       for (const e of transformedSyntax.classFields) {
@@ -200,8 +209,11 @@ describe('esbuildPlugin target', () => {
       const response = await fetch(`${host}/foo.js`);
       const text = await response.text();
 
-      assert.equal(response.status, 200);
-      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(
+        response.headers.get('content-type'),
+        'application/javascript; charset=utf-8',
+      );
 
       expectIncludes(text, syntax.classes);
       for (const e of transformedSyntax.classFields) {
@@ -240,8 +252,11 @@ describe('esbuildPlugin target', () => {
       const response = await fetch(`${host}/foo.js`);
       const text = await response.text();
 
-      assert.equal(response.status, 200);
-      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(
+        response.headers.get('content-type'),
+        'application/javascript; charset=utf-8',
+      );
 
       expectIncludes(text, syntax.classes);
       for (const e of transformedSyntax.classFields) {
@@ -278,8 +293,11 @@ describe('esbuildPlugin target', () => {
       const response = await fetch(`${host}/foo.js`);
       const text = await response.text();
 
-      assert.equal(response.status, 200);
-      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(
+        response.headers.get('content-type'),
+        'application/javascript; charset=utf-8',
+      );
 
       expectIncludes(text, syntax.classes);
       for (const e of transformedSyntax.classFields) {
@@ -320,8 +338,8 @@ describe('esbuildPlugin target', () => {
       const response = await fetch(`${host}/index.html`);
       const text = await response.text();
 
-      assert.equal(response.status, 200);
-      assert.equal(response.headers.get('content-type'), 'text/html; charset=utf-8');
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(response.headers.get('content-type'), 'text/html; charset=utf-8');
 
       expectIncludes(text, syntax.classes);
       for (const e of transformedSyntax.classFields) {
@@ -365,8 +383,8 @@ describe('esbuildPlugin target', () => {
       const response = await fetch(`${host}/index.html`);
       const text = await response.text();
 
-      assert.equal(response.status, 200);
-      assert.equal(response.headers.get('content-type'), 'text/html; charset=utf-8');
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(response.headers.get('content-type'), 'text/html; charset=utf-8');
       expectIncludes(text, importmapString);
       expectIncludes(text, jsonString);
     } finally {

--- a/packages/dev-server-esbuild/test/ts.test.ts
+++ b/packages/dev-server-esbuild/test/ts.test.ts
@@ -1,18 +1,17 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 import path from 'path';
-import { expect } from 'chai';
 import { createTestServer } from '@web/dev-server-core/test-helpers';
 import { expectIncludes, expectNotIncludes } from '@web/dev-server-core/test-helpers';
-import { Plugin as RollupPlugin } from 'rollup';
+import type { Plugin as RollupPlugin } from 'rollup';
 import { fromRollup } from '@web/dev-server-rollup';
 
-import { esbuildPlugin } from '../src/index.js';
+import { esbuildPlugin } from '../dist/index.js';
 
-describe('esbuildPlugin TS', function () {
-  this.timeout(5000);
-
+describe('esbuildPlugin TS', { timeout: 5000 }, () => {
   it('transforms .ts files', async () => {
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -39,10 +38,8 @@ describe('esbuildPlugin TS', function () {
     try {
       const response = await fetch(`${host}/foo.ts`);
       const text = await response.text();
-      expect(response.status).to.equal(200);
-      expect(response.headers.get('content-type')).to.equal(
-        'application/javascript; charset=utf-8',
-      );
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
       expectIncludes(text, 'export function foo(a, b) {');
       expectIncludes(text, 'return a + b;');
       expectIncludes(text, '}');
@@ -55,7 +52,7 @@ describe('esbuildPlugin TS', function () {
 
   it('transforms TS decorators', async () => {
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -72,7 +69,11 @@ class Bar {
         },
         esbuildPlugin({
           ts: true,
-          tsconfig: path.join(__dirname, 'fixture', 'tsconfig-with-experimental-decorators.json'),
+          tsconfig: path.join(
+            import.meta.dirname,
+            'fixture',
+            'tsconfig-with-experimental-decorators.json',
+          ),
         }),
       ],
     });
@@ -81,10 +82,8 @@ class Bar {
       const response = await fetch(`${host}/foo.ts`);
       const text = await response.text();
 
-      expect(response.status).to.equal(200);
-      expect(response.headers.get('content-type')).to.equal(
-        'application/javascript; charset=utf-8',
-      );
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
       expectIncludes(text, '__decorate');
       expectIncludes(text, '__publicField(this, "x", "y");');
       expectIncludes(
@@ -106,7 +105,7 @@ class Bar {
 
   it('resolves relative ending with .js to .ts files', async () => {
     const { server, host } = await createTestServer({
-      rootDir: path.join(__dirname, 'fixture'),
+      rootDir: path.join(import.meta.dirname, 'fixture'),
       plugins: [
         {
           name: 'test',
@@ -119,10 +118,8 @@ class Bar {
       const response = await fetch(`${host}/a/b/foo.ts`);
       const text = await response.text();
 
-      expect(response.status).to.equal(200);
-      expect(response.headers.get('content-type')).to.equal(
-        'application/javascript; charset=utf-8',
-      );
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
       expectIncludes(text, 'import "../../x.ts";');
       expectIncludes(text, 'import "../y.ts";');
       expectIncludes(text, 'import "./z.ts";');
@@ -133,7 +130,7 @@ class Bar {
 
   it('does not change imports where the TS file does not exist', async () => {
     const { server, host } = await createTestServer({
-      rootDir: path.join(__dirname, 'fixture'),
+      rootDir: path.join(import.meta.dirname, 'fixture'),
       plugins: [
         {
           name: 'test',
@@ -146,10 +143,8 @@ class Bar {
       const response = await fetch(`${host}/a/b/foo.ts`);
       const text = await response.text();
 
-      expect(response.status).to.equal(200);
-      expect(response.headers.get('content-type')).to.equal(
-        'application/javascript; charset=utf-8',
-      );
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
       expectIncludes(text, 'import "../../1.js";');
       expectIncludes(text, 'import "../2.js";');
       expectIncludes(text, 'import "./3.js";');
@@ -164,7 +159,7 @@ class Bar {
 
   it('does not change imports when ts transform is not enabled', async () => {
     const { server, host } = await createTestServer({
-      rootDir: path.join(__dirname, 'fixture'),
+      rootDir: path.join(import.meta.dirname, 'fixture'),
       plugins: [
         {
           name: 'test',
@@ -177,7 +172,7 @@ class Bar {
       const response = await fetch(`${host}/a/b/foo.ts`);
       const text = await response.text();
 
-      expect(response.status).to.equal(200);
+      assert.equal(response.status, 200);
       expectIncludes(text, "import '../../x.js';");
       expectIncludes(text, "import '../y.js';");
       expectIncludes(text, "import './z.js';");
@@ -188,7 +183,7 @@ class Bar {
 
   it('does not change imports in non-TS files', async () => {
     const { server, host } = await createTestServer({
-      rootDir: path.join(__dirname, 'fixture'),
+      rootDir: path.join(import.meta.dirname, 'fixture'),
       plugins: [
         {
           name: 'test',
@@ -201,7 +196,7 @@ class Bar {
       const response = await fetch(`${host}/a/b/bar.js`);
       const text = await response.text();
 
-      expect(response.status).to.equal(200);
+      assert.equal(response.status, 200);
       expectIncludes(text, "import '../../x.js';");
       expectIncludes(text, "import '../y.js';");
       expectIncludes(text, "import './z.js';");
@@ -214,7 +209,7 @@ class Bar {
     const plugin: RollupPlugin = {
       name: 'my-plugin',
       load(id) {
-        if (id === path.join(__dirname, 'app.js')) {
+        if (id === path.join(import.meta.dirname, 'app.js')) {
           return 'import "\0foo.js";';
         }
       },
@@ -225,7 +220,7 @@ class Bar {
       },
     };
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         fromRollup(() => plugin)(),
         esbuildPlugin({
@@ -248,12 +243,15 @@ class Bar {
 
   it('reads tsconfig.json file', async () => {
     const { server, host } = await createTestServer({
-      rootDir: path.join(__dirname, 'fixture'),
+      rootDir: path.join(import.meta.dirname, 'fixture'),
       plugins: [
         {
           name: 'test',
         },
-        esbuildPlugin({ ts: true, tsconfig: path.join(__dirname, 'fixture', 'tsconfig.json') }),
+        esbuildPlugin({
+          ts: true,
+          tsconfig: path.join(import.meta.dirname, 'fixture', 'tsconfig.json'),
+        }),
       ],
     });
 
@@ -261,10 +259,8 @@ class Bar {
       const response = await fetch(`${host}/a/b/foo.ts`);
       const text = await response.text();
 
-      expect(response.status).to.equal(200);
-      expect(response.headers.get('content-type')).to.equal(
-        'application/javascript; charset=utf-8',
-      );
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
 
       expectIncludes(text, '__publicField(this, "prop");');
     } finally {

--- a/packages/dev-server-esbuild/test/ts.test.ts
+++ b/packages/dev-server-esbuild/test/ts.test.ts
@@ -38,8 +38,11 @@ describe('esbuildPlugin TS', { timeout: 5000 }, () => {
     try {
       const response = await fetch(`${host}/foo.ts`);
       const text = await response.text();
-      assert.equal(response.status, 200);
-      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(
+        response.headers.get('content-type'),
+        'application/javascript; charset=utf-8',
+      );
       expectIncludes(text, 'export function foo(a, b) {');
       expectIncludes(text, 'return a + b;');
       expectIncludes(text, '}');
@@ -82,8 +85,11 @@ class Bar {
       const response = await fetch(`${host}/foo.ts`);
       const text = await response.text();
 
-      assert.equal(response.status, 200);
-      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(
+        response.headers.get('content-type'),
+        'application/javascript; charset=utf-8',
+      );
       expectIncludes(text, '__decorate');
       expectIncludes(text, '__publicField(this, "x", "y");');
       expectIncludes(
@@ -118,8 +124,11 @@ class Bar {
       const response = await fetch(`${host}/a/b/foo.ts`);
       const text = await response.text();
 
-      assert.equal(response.status, 200);
-      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(
+        response.headers.get('content-type'),
+        'application/javascript; charset=utf-8',
+      );
       expectIncludes(text, 'import "../../x.ts";');
       expectIncludes(text, 'import "../y.ts";');
       expectIncludes(text, 'import "./z.ts";');
@@ -143,8 +152,11 @@ class Bar {
       const response = await fetch(`${host}/a/b/foo.ts`);
       const text = await response.text();
 
-      assert.equal(response.status, 200);
-      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(
+        response.headers.get('content-type'),
+        'application/javascript; charset=utf-8',
+      );
       expectIncludes(text, 'import "../../1.js";');
       expectIncludes(text, 'import "../2.js";');
       expectIncludes(text, 'import "./3.js";');
@@ -172,7 +184,7 @@ class Bar {
       const response = await fetch(`${host}/a/b/foo.ts`);
       const text = await response.text();
 
-      assert.equal(response.status, 200);
+      assert.strictEqual(response.status, 200);
       expectIncludes(text, "import '../../x.js';");
       expectIncludes(text, "import '../y.js';");
       expectIncludes(text, "import './z.js';");
@@ -196,7 +208,7 @@ class Bar {
       const response = await fetch(`${host}/a/b/bar.js`);
       const text = await response.text();
 
-      assert.equal(response.status, 200);
+      assert.strictEqual(response.status, 200);
       expectIncludes(text, "import '../../x.js';");
       expectIncludes(text, "import '../y.js';");
       expectIncludes(text, "import './z.js';");
@@ -259,8 +271,11 @@ class Bar {
       const response = await fetch(`${host}/a/b/foo.ts`);
       const text = await response.text();
 
-      assert.equal(response.status, 200);
-      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(
+        response.headers.get('content-type'),
+        'application/javascript; charset=utf-8',
+      );
 
       expectIncludes(text, '__publicField(this, "prop");');
     } finally {

--- a/packages/dev-server-esbuild/test/tsx.test.ts
+++ b/packages/dev-server-esbuild/test/tsx.test.ts
@@ -1,15 +1,14 @@
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 import { createTestServer } from '@web/dev-server-core/test-helpers';
 import { expectIncludes, expectNotIncludes } from '@web/dev-server-core/test-helpers';
 
-import { esbuildPlugin } from '../src/index.js';
+import { esbuildPlugin } from '../dist/index.js';
 
-describe('esbuildPlugin TSX', function () {
-  this.timeout(5000);
-
+describe('esbuildPlugin TSX', { timeout: 5000 }, () => {
   it('transforms .tsx files', async () => {
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -37,10 +36,8 @@ export function foo (a: number, b: number): Foo {
       const response = await fetch(`${host}/foo.tsx`);
       const text = await response.text();
 
-      expect(response.status).to.equal(200);
-      expect(response.headers.get('content-type')).to.equal(
-        'application/javascript; charset=utf-8',
-      );
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
       expectIncludes(text, 'React.createElement("div", {');
       expectIncludes(text, 'id: "myDiv"');
       expectIncludes(text, 'React.createElement(MyElement, {');
@@ -55,7 +52,7 @@ export function foo (a: number, b: number): Foo {
 
   it('can set the JSX factory', async () => {
     const { server, host } = await createTestServer({
-      rootDir: __dirname,
+      rootDir: import.meta.dirname,
       plugins: [
         {
           name: 'test',
@@ -83,10 +80,8 @@ export function foo (a: number, b: number): Foo {
       const response = await fetch(`${host}/foo.tsx`);
       const text = await response.text();
 
-      expect(response.status).to.equal(200);
-      expect(response.headers.get('content-type')).to.equal(
-        'application/javascript; charset=utf-8',
-      );
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
       expectIncludes(text, 'h("div", {');
       expectIncludes(text, 'id: "myDiv"');
       expectIncludes(text, 'h(MyElement, {');

--- a/packages/dev-server-esbuild/test/tsx.test.ts
+++ b/packages/dev-server-esbuild/test/tsx.test.ts
@@ -36,8 +36,11 @@ export function foo (a: number, b: number): Foo {
       const response = await fetch(`${host}/foo.tsx`);
       const text = await response.text();
 
-      assert.equal(response.status, 200);
-      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(
+        response.headers.get('content-type'),
+        'application/javascript; charset=utf-8',
+      );
       expectIncludes(text, 'React.createElement("div", {');
       expectIncludes(text, 'id: "myDiv"');
       expectIncludes(text, 'React.createElement(MyElement, {');
@@ -80,8 +83,11 @@ export function foo (a: number, b: number): Foo {
       const response = await fetch(`${host}/foo.tsx`);
       const text = await response.text();
 
-      assert.equal(response.status, 200);
-      assert.equal(response.headers.get('content-type'), 'application/javascript; charset=utf-8');
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(
+        response.headers.get('content-type'),
+        'application/javascript; charset=utf-8',
+      );
       expectIncludes(text, 'h("div", {');
       expectIncludes(text, 'id: "myDiv"');
       expectIncludes(text, 'h(MyElement, {');


### PR DESCRIPTION
## Summary

- Migrate `@web/dev-server-esbuild` tests from mocha/chai to `node:test` + `node:assert/strict`
- 7 TS test files, imports from `dist/`, `__dirname` -> `import.meta.dirname`
- `import type { Plugin as RollupPlugin } from 'rollup'` (type-only import)
- `import bcd from '@mdn/browser-compat-data'` (CJS default import)
- `--experimental-strip-types` added for CI compat

## Test plan

- [x] 37/37 tests pass on Node 22.22.3 with `NODE_OPTIONS='--no-experimental-strip-types'`
- [x] ESLint clean
- [x] Prettier clean
- [x] Code review clean