### PR TITLE
refactor(polyfills-loader): migrate tests to node:test

### DIFF
--- a/packages/polyfills-loader/package.json
+++ b/packages/polyfills-loader/package.json
@@ -26,9 +26,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "test:node": "mocha \"test/**/*.test.{ts,js,mjs,cjs}\" --require ts-node/register --reporter dot",
-    "test:update-snapshots": "mocha \"test/**/*.test.{ts,js,mjs,cjs}\" --require ts-node/register --update-snapshots",
-    "test:watch": "mocha \"test/**/*.test.{ts,js,mjs,cjs}\" --require ts-node/register --watch --watch-files src,test"
+    "test:node": "node --experimental-strip-types --test --test-force-exit test/**/*.test.ts",
+    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch test/**/*.test.ts"
   },
   "files": [
     "*.d.ts",

--- a/packages/polyfills-loader/test/createPolyfillsData.test.ts
+++ b/packages/polyfills-loader/test/createPolyfillsData.test.ts
@@ -1,9 +1,10 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 import path from 'path';
-import { expect } from 'chai';
 
-import { PolyfillsLoaderConfig, PolyfillFile } from '../src/types.js';
-import { createPolyfillsData } from '../src/createPolyfillsData.js';
-import { noModuleSupportTest, fileTypes } from '../src/utils.js';
+import type { PolyfillsLoaderConfig, PolyfillFile } from '../dist/types.js';
+import { createPolyfillsData } from '../dist/createPolyfillsData.js';
+import { noModuleSupportTest, fileTypes } from '../dist/utils.js';
 
 function cleanupPolyfill(polyfill: PolyfillFile) {
   if (!polyfill) {
@@ -40,11 +41,11 @@ describe('polyfills', () => {
 
     const polyfillFiles = await createPolyfillsData(config);
     for (const p of polyfillFiles) {
-      expect(p.content).to.be.a('string', `Polyfill ${p.name} has no content`);
+      assert.equal(typeof p.content, 'string', `Polyfill ${p.name} has no content`);
       cleanupPolyfill(p);
     }
 
-    expect(polyfillFiles).to.eql([
+    assert.deepEqual(polyfillFiles, [
       {
         name: 'core-js',
         type: fileTypes.SCRIPT,
@@ -138,11 +139,11 @@ describe('polyfills', () => {
     };
     const polyfillFiles = await createPolyfillsData(config);
     for (const p of polyfillFiles) {
-      expect(p.content).to.be.a('string', `Polyfill ${p.name} has no content`);
+      assert.equal(typeof p.content, 'string', `Polyfill ${p.name} has no content`);
       cleanupPolyfill(p);
     }
 
-    expect(polyfillFiles).to.eql([
+    assert.deepEqual(polyfillFiles, [
       {
         name: 'fetch',
         path: 'polyfills/fetch.js',
@@ -165,11 +166,11 @@ describe('polyfills', () => {
 
     const polyfillFiles = await createPolyfillsData(config);
     for (const p of polyfillFiles) {
-      expect(p.content).to.be.a('string', `Polyfill ${p.name} has no content`);
+      assert.equal(typeof p.content, 'string', `Polyfill ${p.name} has no content`);
       cleanupPolyfill(p);
     }
 
-    expect(polyfillFiles).to.eql([
+    assert.deepEqual(polyfillFiles, [
       {
         name: 'webcomponents-shady-css-custom-style',
         type: fileTypes.SCRIPT,
@@ -197,11 +198,11 @@ describe('polyfills', () => {
 
     const polyfillFiles = await createPolyfillsData(config);
     for (const p of polyfillFiles) {
-      expect(p.content).to.be.a('string', `Polyfill ${p.name} has no content`);
+      assert.equal(typeof p.content, 'string', `Polyfill ${p.name} has no content`);
       cleanupPolyfill(p);
     }
 
-    expect(polyfillFiles).to.eql([
+    assert.deepEqual(polyfillFiles, [
       {
         name: 'systemjs',
         type: fileTypes.SCRIPT,
@@ -232,11 +233,11 @@ describe('polyfills', () => {
 
     const polyfillFiles = await createPolyfillsData(config);
     for (const p of polyfillFiles) {
-      expect(p.content).to.be.a('string', `Polyfill ${p.name} has no content`);
+      assert.equal(typeof p.content, 'string', `Polyfill ${p.name} has no content`);
       cleanupPolyfill(p);
     }
 
-    expect(polyfillFiles).to.eql([
+    assert.deepEqual(polyfillFiles, [
       {
         name: 'systemjs',
         type: fileTypes.SCRIPT,
@@ -257,11 +258,11 @@ describe('polyfills', () => {
 
     const polyfillFiles = await createPolyfillsData(config);
     for (const p of polyfillFiles) {
-      expect(p.content).to.be.a('string', `Polyfill ${p.name} has no content`);
+      assert.equal(typeof p.content, 'string', `Polyfill ${p.name} has no content`);
       cleanupPolyfill(p);
     }
 
-    expect(polyfillFiles).to.eql([
+    assert.deepEqual(polyfillFiles, [
       {
         name: 'systemjs',
         type: fileTypes.SCRIPT,
@@ -277,12 +278,12 @@ describe('polyfills', () => {
         name: 'polyfill-a',
         test: "'foo' in window",
         content: '',
-        path: path.resolve(__dirname, 'custom-polyfills/polyfill-a.js'),
+        path: path.resolve(import.meta.dirname, 'custom-polyfills/polyfill-a.js'),
       },
       {
         name: 'polyfill-b',
         content: '',
-        path: path.resolve(__dirname, 'custom-polyfills/polyfill-b.js'),
+        path: path.resolve(import.meta.dirname, 'custom-polyfills/polyfill-b.js'),
       },
     ];
 
@@ -300,11 +301,11 @@ describe('polyfills', () => {
 
     const polyfillFiles = await createPolyfillsData(config);
     for (const p of polyfillFiles) {
-      expect(p.content).to.be.a('string', `Polyfill ${p.name} has no content`);
+      assert.equal(typeof p.content, 'string', `Polyfill ${p.name} has no content`);
       cleanupPolyfill(p);
     }
 
-    expect(polyfillFiles).to.eql([
+    assert.deepEqual(polyfillFiles, [
       {
         name: 'core-js',
         type: fileTypes.SCRIPT,
@@ -338,11 +339,11 @@ describe('polyfills', () => {
 
     const polyfillFiles = await createPolyfillsData(config);
     for (const p of polyfillFiles) {
-      expect(p.content).to.be.a('string', `Polyfill ${p.name} has no content`);
+      assert.equal(typeof p.content, 'string', `Polyfill ${p.name} has no content`);
       cleanupPolyfill(p);
     }
 
-    expect(polyfillFiles).to.eql([
+    assert.deepEqual(polyfillFiles, [
       {
         name: 'systemjs',
         type: fileTypes.SCRIPT,

--- a/packages/polyfills-loader/test/createPolyfillsLoader.test.ts
+++ b/packages/polyfills-loader/test/createPolyfillsLoader.test.ts
@@ -1,9 +1,10 @@
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 import fs from 'fs';
 import path from 'path';
-import { PolyfillsLoaderConfig } from '../src/types.js';
-import { createPolyfillsLoader } from '../src/createPolyfillsLoader.js';
-import { noModuleSupportTest, fileTypes } from '../src/utils.js';
+import type { PolyfillsLoaderConfig } from '../dist/types.js';
+import { createPolyfillsLoader } from '../dist/createPolyfillsLoader.js';
+import { noModuleSupportTest, fileTypes } from '../dist/utils.js';
 
 const updateSnapshots = process.argv.includes('--update-snapshots');
 
@@ -14,26 +15,31 @@ interface TestSnapshotArgs {
 }
 
 async function testSnapshot({ name, config, expectedFiles = [] }: TestSnapshotArgs) {
-  const snapshotPath = path.join(__dirname, 'snapshots', 'createPolyfillsLoader', `${name}.js`);
+  const snapshotPath = path.join(
+    import.meta.dirname,
+    'snapshots',
+    'createPolyfillsLoader',
+    `${name}.js`,
+  );
   const loader = await createPolyfillsLoader(config);
   if (!loader) {
     throw new Error('No loader was generated');
   }
 
-  expect(loader.polyfillFiles.map(f => f.path)).to.eql(expectedFiles);
+  assert.deepEqual(
+    loader.polyfillFiles.map(f => f.path),
+    expectedFiles,
+  );
 
   if (updateSnapshots) {
     fs.writeFileSync(snapshotPath, loader.code, 'utf-8');
   } else {
     const snapshot = fs.readFileSync(snapshotPath, 'utf-8');
-    expect(loader.code.trim()).to.equal(snapshot.trim());
+    assert.equal(loader.code.trim(), snapshot.trim());
   }
 }
 
-describe('createPolyfillsLoader', function describe() {
-  // bootup of the first test can take a long time in CI to load all the polyfills
-  this.timeout(5000);
-
+describe('createPolyfillsLoader', { timeout: 5000 }, () => {
   it('generates a loader script with one module resource', async () => {
     await testSnapshot({
       name: 'module-resource',

--- a/packages/polyfills-loader/test/injectPolyfillsLoader.test.ts
+++ b/packages/polyfills-loader/test/injectPolyfillsLoader.test.ts
@@ -1,9 +1,10 @@
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 import path from 'path';
 import fs from 'fs';
-import { injectPolyfillsLoader } from '../src/injectPolyfillsLoader.js';
-import { noModuleSupportTest, fileTypes } from '../src/utils.js';
-import { PolyfillsLoaderConfig } from '../src/types.js';
+import { injectPolyfillsLoader } from '../dist/injectPolyfillsLoader.js';
+import { noModuleSupportTest, fileTypes } from '../dist/utils.js';
+import type { PolyfillsLoaderConfig } from '../dist/types.js';
 
 const updateSnapshots = process.argv.includes('--update-snapshots');
 
@@ -15,14 +16,19 @@ const defaultConfig = {
 };
 
 async function testSnapshot(name: string, htmlString: string, config: PolyfillsLoaderConfig) {
-  const snapshotPath = path.join(__dirname, 'snapshots', 'injectPolyfillsLoader', `${name}.html`);
+  const snapshotPath = path.join(
+    import.meta.dirname,
+    'snapshots',
+    'injectPolyfillsLoader',
+    `${name}.html`,
+  );
   const result = await injectPolyfillsLoader(htmlString, config);
 
   if (updateSnapshots) {
     fs.writeFileSync(snapshotPath, result.htmlString, 'utf-8');
   } else {
     const snapshot = fs.readFileSync(snapshotPath, 'utf-8');
-    expect(result.htmlString.trim()).to.equal(snapshot.trim());
+    assert.equal(result.htmlString.trim(), snapshot.trim());
   }
 }
 


### PR DESCRIPTION
## Summary

- Migrate `@web/polyfills-loader` tests from mocha/chai to `node:test` + `node:assert/strict`
- 3 TS test files, imports from `dist/`, type-only imports for interfaces
- `__dirname` -> `import.meta.dirname`
- `expect(x).to.be.a('string')` -> `assert.equal(typeof x, 'string')`
- `--experimental-strip-types` for CI compat

## Test plan

- [x] 34/34 tests pass on Node 22.22.3 with `NODE_OPTIONS='--no-experimental-strip-types'`
- [x] ESLint clean
- [x] Prettier clean
- [x] Code review clean