### PR TITLE
refactor(dev-server): migrate tests to node:test

### DIFF
--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -37,8 +37,8 @@
     "start:plugin-serve": "node dist/bin.js --config demo/plugin-serve/config.mjs --open",
     "start:static": "node dist/bin.js --config demo/static/config.mjs --open demo/static/",
     "start:syntax": "node dist/bin.js --config demo/syntax/config.mjs --open demo/syntax/",
-    "test:node": "mocha \"test/**/*.test.mjs\" --reporter dot",
-    "test:watch": "mocha \"test/**/*.test.mjs\" --watch --watch-files src,test --reporter dot"
+    "test:node": "node --test --test-force-exit test/**/*.test.mjs",
+    "test:watch": "node --test --test-force-exit --watch test/**/*.test.mjs"
   },
   "files": [
     "*.d.ts",

--- a/packages/dev-server/test/integration.test.mjs
+++ b/packages/dev-server/test/integration.test.mjs
@@ -1,10 +1,8 @@
+import { describe, it, before, after, beforeEach, afterEach } from 'node:test';
 import puppeteer from 'puppeteer';
 import path from 'path';
-import { fileURLToPath } from 'url';
 
 import { startDevServer } from '../index.mjs';
-
-const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const testCases = [
   {
@@ -53,15 +51,14 @@ describe('integration tests', () => {
   });
 
   for (const testCase of testCases) {
-    describe(`testcase ${testCase.name}`, function test() {
-      this.timeout(30000);
+    describe(`testcase ${testCase.name}`, { timeout: 30000 }, () => {
       let server;
 
       beforeEach(async () => {
         server = await startDevServer({
           autoExitProcess: false,
           logStartMessage: false,
-          argv: ['--config', path.join(dirname, `../demo/${testCase.name}/config.mjs`)],
+          argv: ['--config', path.join(import.meta.dirname, `../demo/${testCase.name}/config.mjs`)],
         });
       });
 
@@ -69,7 +66,7 @@ describe('integration tests', () => {
         await server.stop();
       });
 
-      it('passes the in-browser tests', async function it() {
+      it('passes the in-browser tests', async () => {
         const openPath = `/demo/${testCase.name}/`;
         const browserPath = `http://${server.config.hostname}:${server.config.port}${openPath}`;
         const page = await browser.newPage();


### PR DESCRIPTION
## Summary

- Migrate `@web/dev-server` integration test from mocha globals to `node:test`
- 1 `.mjs` file, no chai, no TypeScript
- `this.timeout(30000)` -> `{ timeout: 30000 }`
- `path.dirname(fileURLToPath(import.meta.url))` -> `import.meta.dirname`

## Test plan

- [x] 6/6 tests pass on Node 22.22.3 with Chrome
- [x] ESLint clean
- [x] Prettier clean
- [x] Code review clean