### PR TITLE
refactor(rollup-plugin-polyfills-loader): migrate tests to node:test

### DIFF
--- a/packages/rollup-plugin-polyfills-loader/package.json
+++ b/packages/rollup-plugin-polyfills-loader/package.json
@@ -25,9 +25,8 @@
     "node": ">=22.0.0"
   },
   "scripts": {
-    "test:node": "mocha test/**/*.test.ts --require ts-node/register --reporter dot",
-    "test:update-snapshots": "mocha test/**/*.test.ts --require ts-node/register --update-snapshots",
-    "test:watch": "mocha test/**/*.test.ts --require ts-node/register --watch --watch-files src,test"
+    "test:node": "node --experimental-strip-types --test --test-force-exit test/**/*.test.ts",
+    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch test/**/*.test.ts"
   },
   "files": [
     "*.d.ts",

--- a/packages/rollup-plugin-polyfills-loader/test/src/createPolyfillsLoaderConfig.test.ts
+++ b/packages/rollup-plugin-polyfills-loader/test/src/createPolyfillsLoaderConfig.test.ts
@@ -1,5 +1,6 @@
-import { expect } from 'chai';
-import { createPolyfillsLoaderConfig } from '../../src/createPolyfillsLoaderConfig.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createPolyfillsLoaderConfig } from '../../dist/createPolyfillsLoaderConfig.js';
 
 describe('createPolyfillsLoaderConfig()', () => {
   it('creates a config for a single module build', () => {
@@ -12,7 +13,7 @@ describe('createPolyfillsLoaderConfig()', () => {
     // @ts-ignore
     const config = createPolyfillsLoaderConfig(pluginConfig, bundle);
 
-    expect(config).to.eql({
+    assert.deepEqual(config, {
       legacy: undefined,
       modern: { files: [{ path: 'app.js', type: 'module', attributes: [] }] },
       polyfills: undefined,
@@ -33,7 +34,7 @@ describe('createPolyfillsLoaderConfig()', () => {
     // @ts-ignore
     const config = createPolyfillsLoaderConfig(pluginConfig, bundle);
 
-    expect(config).to.eql({
+    assert.deepEqual(config, {
       legacy: undefined,
       modern: {
         files: [
@@ -59,7 +60,7 @@ describe('createPolyfillsLoaderConfig()', () => {
     // @ts-ignore
     const config = createPolyfillsLoaderConfig(pluginConfig, bundle);
 
-    expect(config).to.eql({
+    assert.deepEqual(config, {
       legacy: undefined,
       modern: { files: [{ path: 'app.js', type: 'systemjs', attributes: [] }] },
       polyfills: undefined,
@@ -86,7 +87,7 @@ describe('createPolyfillsLoaderConfig()', () => {
     // @ts-ignore
     const config = createPolyfillsLoaderConfig(pluginConfig, undefined, bundles);
 
-    expect(config).to.eql({
+    assert.deepEqual(config, {
       modern: { files: [{ path: 'app.js', type: 'module', attributes: [] }] },
       legacy: [
         {
@@ -125,7 +126,7 @@ describe('createPolyfillsLoaderConfig()', () => {
     // @ts-ignore
     const config = createPolyfillsLoaderConfig(pluginConfig, undefined, bundles);
 
-    expect(config).to.eql({
+    assert.deepEqual(config, {
       modern: { files: [{ path: 'app.js', type: 'module', attributes: [] }] },
       legacy: [
         {
@@ -165,7 +166,7 @@ describe('createPolyfillsLoaderConfig()', () => {
     // @ts-ignore
     const config = createPolyfillsLoaderConfig(pluginConfig, undefined, bundles);
 
-    expect(config).to.eql({
+    assert.deepEqual(config, {
       modern: { files: [{ path: 'app.js', type: 'script', attributes: [] }] },
       legacy: [
         {
@@ -190,7 +191,7 @@ describe('createPolyfillsLoaderConfig()', () => {
     // @ts-ignore
     const config = createPolyfillsLoaderConfig(pluginConfig, bundle);
 
-    expect(config).to.eql({
+    assert.deepEqual(config, {
       legacy: undefined,
       modern: { files: [{ path: 'app.js', type: 'module', attributes: [] }] },
       polyfills: { fetch: true, webcomponents: true },
@@ -210,7 +211,7 @@ describe('createPolyfillsLoaderConfig()', () => {
 
     // @ts-ignore
     const action = () => createPolyfillsLoaderConfig(pluginConfig, bundle);
-    expect(action).to.throw();
+    assert.throws(action);
   });
 
   it('throws when a multiple builds are output while no builds are configured', () => {
@@ -228,7 +229,7 @@ describe('createPolyfillsLoaderConfig()', () => {
 
     // @ts-ignore
     const action = () => createPolyfillsLoaderConfig(pluginConfig, undefined, bundles);
-    expect(action).to.throw();
+    assert.throws(action);
   });
 
   it('throws when the modern build could not be found', () => {
@@ -249,6 +250,6 @@ describe('createPolyfillsLoaderConfig()', () => {
 
     // @ts-ignore
     const action = () => createPolyfillsLoaderConfig(pluginConfig, undefined, bundles);
-    expect(action).to.throw();
+    assert.throws(action);
   });
 });

--- a/packages/rollup-plugin-polyfills-loader/test/src/rollupPluginPolyfillsLoader.test.ts
+++ b/packages/rollup-plugin-polyfills-loader/test/src/rollupPluginPolyfillsLoader.test.ts
@@ -1,14 +1,16 @@
 /* eslint-disable no-await-in-loop */
-import { OutputChunk, rollup, OutputAsset, RollupOptions, OutputOptions } from 'rollup';
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { rollup } from 'rollup';
+import type { OutputChunk, OutputAsset, RollupOptions, OutputOptions } from 'rollup';
 import fs from 'fs';
 import path from 'path';
 import { rollupPluginHTML as html } from '@web/rollup-plugin-html';
-import polyfillsLoader from '../../src/index.js';
+import { polyfillsLoader } from '../../dist/index.js';
 
 type Output = (OutputChunk | OutputAsset)[];
 
-const relativeUrl = `./${path.relative(process.cwd(), path.join(__dirname, '..'))}`;
+const relativeUrl = `./${path.relative(process.cwd(), path.join(import.meta.dirname, '..'))}`;
 
 const updateSnapshots = process.argv.includes('--update-snapshots');
 
@@ -26,7 +28,7 @@ interface SnapshotArgs {
 }
 
 async function testSnapshot({ name, fileName, inputOptions, outputOptions }: SnapshotArgs) {
-  const snapshotPath = path.join(__dirname, '..', 'snapshots', `${name}.html`);
+  const snapshotPath = path.join(import.meta.dirname, '..', 'snapshots', `${name}.html`);
   const bundle = await rollup(inputOptions);
   let output;
   for (const outputConfig of outputOptions) {
@@ -42,8 +44,7 @@ async function testSnapshot({ name, fileName, inputOptions, outputOptions }: Sna
     fs.writeFileSync(snapshotPath, file.source, 'utf-8');
   } else {
     const snapshot = fs.readFileSync(snapshotPath, 'utf-8');
-    expect(file.source.trim()).to.equal(snapshot.trim());
-    // expect(file.source.replace(/\s/g, '')).to.equal(snapshot.replace(/\s/g, ''));
+    assert.equal(file.source.trim(), snapshot.trim());
   }
   return output;
 }
@@ -55,10 +56,7 @@ const defaultOutputOptions: OutputOptions[] = [
   },
 ];
 
-describe('rollup-plugin-polyfills-loader', function describe() {
-  // bootup of the first test can take a long time in CI to load all the polyfills
-  this.timeout(5000);
-
+describe('rollup-plugin-polyfills-loader', { timeout: 5000 }, () => {
   it('can inject a polyfills loader with a single output', async () => {
     const inputOptions: RollupOptions = {
       plugins: [
@@ -225,8 +223,8 @@ describe('rollup-plugin-polyfills-loader', function describe() {
       outputOptions: defaultOutputOptions,
     });
 
-    expect(output.find(o => o.fileName.startsWith('polyfills/webcomponents'))).to.exist;
-    expect(output.find(o => o.fileName.startsWith('polyfills/fetch'))).to.exist;
+    assert.ok(output.find(o => o.fileName.startsWith('polyfills/webcomponents')));
+    assert.ok(output.find(o => o.fileName.startsWith('polyfills/fetch')));
   });
 
   it('can inject with multiple build outputs', async () => {

--- a/packages/rollup-plugin-polyfills-loader/test/src/utils.test.ts
+++ b/packages/rollup-plugin-polyfills-loader/test/src/utils.test.ts
@@ -1,53 +1,59 @@
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 import { fileTypes } from '@web/polyfills-loader';
-import { shouldInjectLoader } from '../../src/utils.js';
+import { shouldInjectLoader } from '../../dist/utils.js';
 
 describe('shouldInjectLoader', () => {
   it('returns true when modern contains non-module or script', () => {
-    expect(
+    assert.equal(
       shouldInjectLoader({
         modern: { files: [{ type: fileTypes.SYSTEMJS, path: '' }] },
       }),
-    ).to.equal(true);
+      true,
+    );
   });
 
   it('returns true when there are legacy files', () => {
-    expect(
+    assert.equal(
       shouldInjectLoader({
         modern: { files: [{ type: fileTypes.MODULE, path: '' }] },
         legacy: [{ test: '', files: [{ type: fileTypes.SYSTEMJS, path: '' }] }],
       }),
-    ).to.equal(true);
+      true,
+    );
   });
 
   it('returns true when there are polyfills', () => {
-    expect(
+    assert.equal(
       shouldInjectLoader({
         modern: { files: [{ type: fileTypes.MODULE, path: '' }] },
         polyfills: {
           fetch: true,
         },
       }),
-    ).to.equal(true);
+      true,
+    );
 
-    expect(
+    assert.equal(
       shouldInjectLoader({
         modern: { files: [{ type: fileTypes.MODULE, path: '' }] },
         polyfills: {
           regeneratorRuntime: 'always',
         },
       }),
-    ).to.equal(true);
+      true,
+    );
   });
 
   it('returns true when there are custom polyfills', () => {
-    expect(
+    assert.equal(
       shouldInjectLoader({
         modern: { files: [{ type: fileTypes.MODULE, path: '' }] },
         polyfills: {
           custom: [{ test: '', path: '', name: '' }],
         },
       }),
-    ).to.equal(true);
+      true,
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Migrate `@web/rollup-plugin-polyfills-loader` tests from mocha/chai to `node:test` + `node:assert/strict`
- 3 TS test files, `import type` for rollup types, named import for `polyfillsLoader`
- `__dirname` -> `import.meta.dirname`, `../../src/` -> `../../dist/`
- `--experimental-strip-types` for CI compat

## Test plan

- [x] 27/27 tests pass on Node 22.22.3 with `NODE_OPTIONS='--no-experimental-strip-types'`
- [x] ESLint clean
- [x] Prettier clean
- [x] Code review clean