### PR TITLE
refactor(test-runner-module-mocking): migrate tests to node:test

### DIFF
--- a/packages/test-runner-module-mocking/package.json
+++ b/packages/test-runner-module-mocking/package.json
@@ -24,8 +24,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "test:node": "mocha test/**/*.test.ts --loader=ts-node/esm --reporter dot",
-    "test:watch": "mocha test/**/*.test.ts --loader ts-node/esm --watch --watch-files src,test"
+    "test:node": "node --experimental-strip-types --test --test-force-exit test/**/*.test.ts",
+    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch test/**/*.test.ts"
   },
   "files": [
     "*.d.ts",

--- a/packages/test-runner-module-mocking/test/moduleMockingPlugin.test.ts
+++ b/packages/test-runner-module-mocking/test/moduleMockingPlugin.test.ts
@@ -1,32 +1,28 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 import path from 'path';
-import { fileURLToPath } from 'url';
 import { runTests } from '@web/test-runner-core/test-helpers';
 import { chromeLauncher } from '@web/test-runner-chrome';
 import { nodeResolvePlugin } from '@web/dev-server';
 
-import { moduleMockingPlugin } from '../src/moduleMockingPlugin.js';
-import { expect } from 'chai';
+import { moduleMockingPlugin } from '../dist/moduleMockingPlugin.js';
 
-const dirname = fileURLToPath(new URL('.', import.meta.url));
-
-describe('moduleMockingPlugin', function test() {
-  this.timeout(20000);
-
+describe('moduleMockingPlugin', { timeout: 20000 }, () => {
   it('can intercept server relative modules', async () => {
     await runTests({
-      files: [path.join(dirname, 'fixtures', 'server-relative', 'browser-test.js')],
+      files: [path.join(import.meta.dirname, 'fixtures', 'server-relative', 'browser-test.js')],
       browsers: [chromeLauncher()],
       plugins: [moduleMockingPlugin(), nodeResolvePlugin('', false, {})],
     });
   });
 
   it('can intercept bare modules', async () => {
-    const rootDir = path.resolve(dirname, 'fixtures', 'bare', 'fixture');
+    const rootDir = path.resolve(import.meta.dirname, 'fixtures', 'bare', 'fixture');
     // Define the bare module as duped to force nodeResolve to use the passed rootDir instead of the cwd
     const dedupe = (importee: string) => importee === 'time-library/hour';
 
     await runTests({
-      files: [path.join(dirname, 'fixtures', 'bare', 'browser-test.js')],
+      files: [path.join(import.meta.dirname, 'fixtures', 'bare', 'browser-test.js')],
       browsers: [chromeLauncher()],
       plugins: [moduleMockingPlugin(), nodeResolvePlugin(rootDir, false, { dedupe })],
     });
@@ -35,7 +31,7 @@ describe('moduleMockingPlugin', function test() {
   it('throws when trying to intercept without the plugin', async () => {
     const { sessions } = await runTests(
       {
-        files: [path.join(dirname, 'fixtures', 'server-relative', 'browser-test.js')],
+        files: [path.join(import.meta.dirname, 'fixtures', 'server-relative', 'browser-test.js')],
         browsers: [chromeLauncher()],
         plugins: [nodeResolvePlugin('', false, {})],
       },
@@ -43,17 +39,17 @@ describe('moduleMockingPlugin', function test() {
       { allowFailure: true, reportErrors: false },
     );
 
-    expect(sessions.length).to.equal(1);
-    expect(sessions[0].passed).to.equal(false);
-    expect(sessions[0].errors.length).to.equal(1);
-    expect(sessions[0].logs[0][0]).to.match(/Error: Module interception is not active./);
-    expect(sessions[0].errors[0].message).to.match(/Could not import your test module./);
+    assert.equal(sessions.length, 1);
+    assert.equal(sessions[0].passed, false);
+    assert.equal(sessions[0].errors.length, 1);
+    assert.match(sessions[0].logs[0][0], /Error: Module interception is not active./);
+    assert.match(sessions[0].errors[0].message, /Could not import your test module./);
   });
 
   it('throws when trying to intercept an inexistent module', async () => {
     const { sessions } = await runTests(
       {
-        files: [path.join(dirname, 'fixtures', 'inexistent', 'browser-test.js')],
+        files: [path.join(import.meta.dirname, 'fixtures', 'inexistent', 'browser-test.js')],
         browsers: [chromeLauncher()],
         plugins: [moduleMockingPlugin(), nodeResolvePlugin('', false, {})],
       },
@@ -61,17 +57,17 @@ describe('moduleMockingPlugin', function test() {
       { allowFailure: true, reportErrors: false },
     );
 
-    expect(sessions.length).to.equal(1);
-    expect(sessions[0].passed).to.equal(false);
-    expect(sessions[0].errors.length).to.equal(1);
-    expect(sessions[0].logs[0][0]).to.match(/Error: Could not resolve "\/inexistent-module.js"./);
-    expect(sessions[0].errors[0].message).to.match(/Could not import your test module./);
+    assert.equal(sessions.length, 1);
+    assert.equal(sessions[0].passed, false);
+    assert.equal(sessions[0].errors.length, 1);
+    assert.match(sessions[0].logs[0][0], /Error: Could not resolve "\/inexistent-module.js"./);
+    assert.match(sessions[0].errors[0].message, /Could not import your test module./);
   });
 
   it('throws when trying to intercept a relative module', async () => {
     const { sessions } = await runTests(
       {
-        files: [path.join(dirname, 'fixtures', 'relative', 'browser-test.js')],
+        files: [path.join(import.meta.dirname, 'fixtures', 'relative', 'browser-test.js')],
         browsers: [chromeLauncher()],
         plugins: [moduleMockingPlugin(), nodeResolvePlugin('', false, {})],
       },
@@ -79,12 +75,13 @@ describe('moduleMockingPlugin', function test() {
       { allowFailure: true, reportErrors: false },
     );
 
-    expect(sessions.length).to.equal(1);
-    expect(sessions[0].passed).to.equal(false);
-    expect(sessions[0].errors.length).to.equal(1);
-    expect(sessions[0].logs[0][0]).to.match(
+    assert.equal(sessions.length, 1);
+    assert.equal(sessions[0].passed, false);
+    assert.equal(sessions[0].errors.length, 1);
+    assert.match(
+      sessions[0].logs[0][0],
       /Error: Parameter `moduleName` \('.\/file\.js'\) contains a relative reference./,
     );
-    expect(sessions[0].errors[0].message).to.match(/Could not import your test module./);
+    assert.match(sessions[0].errors[0].message, /Could not import your test module./);
   });
 });


### PR DESCRIPTION
## Summary

- Migrate `@web/test-runner-module-mocking` tests from mocha/chai to `node:test` + `node:assert/strict`
- 1 TS file, imports from `dist/`, needs Chrome
- `fileURLToPath(new URL('.', import.meta.url))` simplified to `import.meta.dirname`
- `--experimental-strip-types` for CI compat

## Test plan

- [x] 5/5 tests pass on Node 22.22.3 with Chrome + `NODE_OPTIONS='--no-experimental-strip-types'`
- [x] ESLint clean
- [x] Prettier clean
- [x] Code review clean