### PR TITLE
refactor(test-runner-commands): migrate tests to node:test

### DIFF
--- a/packages/test-runner-commands/package.json
+++ b/packages/test-runner-commands/package.json
@@ -30,8 +30,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "test:node": "mocha test/**/*.test.ts --require ts-node/register --reporter dot",
-    "test:watch": "mocha test/**/*.test.ts --require ts-node/register --watch --watch-files src,test --watch-ignore **/*.snap.js"
+    "test:node": "node --experimental-strip-types --test --test-force-exit test/**/*.test.ts",
+    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch test/**/*.test.ts"
   },
   "files": [
     "*.d.ts",

--- a/packages/test-runner-commands/test/a11y-snapshot/a11ySnapshotPlugin.test.ts
+++ b/packages/test-runner-commands/test/a11y-snapshot/a11ySnapshotPlugin.test.ts
@@ -1,16 +1,15 @@
+import { describe, it } from 'node:test';
 import path from 'path';
 import { runTests } from '@web/test-runner-core/test-helpers';
 import { chromeLauncher } from '@web/test-runner-chrome';
 import { playwrightLauncher } from '@web/test-runner-playwright';
 
-import { a11ySnapshotPlugin } from '../../src/a11ySnapshotPlugin.js';
+import { a11ySnapshotPlugin } from '../../dist/a11ySnapshotPlugin.js';
 
-describe('a11ySnapshotPlugin', function test() {
-  this.timeout(20000);
-
+describe('a11ySnapshotPlugin', { timeout: 20000 }, () => {
   it('can find accessibility nodes in the returned accessibility tree on puppeteer', async () => {
     await runTests({
-      files: [path.join(__dirname, 'browser-test.js')],
+      files: [path.join(import.meta.dirname, 'browser-test.js')],
       browsers: [chromeLauncher()],
       plugins: [a11ySnapshotPlugin()],
     });
@@ -18,7 +17,7 @@ describe('a11ySnapshotPlugin', function test() {
 
   it('can find accessibility nodes in the returned accessibility tree on playwright', async () => {
     await runTests({
-      files: [path.join(__dirname, 'browser-test.js')],
+      files: [path.join(import.meta.dirname, 'browser-test.js')],
       browsers: [
         playwrightLauncher({ product: 'chromium' }),
         playwrightLauncher({ product: 'firefox' }),

--- a/packages/test-runner-commands/test/emulate-media/emulateMediaPlugin.test.ts
+++ b/packages/test-runner-commands/test/emulate-media/emulateMediaPlugin.test.ts
@@ -1,18 +1,17 @@
+import { describe, it } from 'node:test';
 import path from 'path';
 import { runTests } from '@web/test-runner-core/test-helpers';
 import { chromeLauncher } from '@web/test-runner-chrome';
 import { playwrightLauncher } from '@web/test-runner-playwright';
 
-import { emulateMediaPlugin } from '../../src/emulateMediaPlugin.js';
+import { emulateMediaPlugin } from '../../dist/emulateMediaPlugin.js';
 
-describe('emulateMediaPlugin', function test() {
-  this.timeout(20000);
-
+describe('emulateMediaPlugin', { timeout: 20000 }, () => {
   it('can emulate media on puppeteer', async () => {
     await runTests({
       files: [
-        path.join(__dirname, 'browser-test.js'),
-        path.join(__dirname, 'prefers-reduced-motion-test.js'),
+        path.join(import.meta.dirname, 'browser-test.js'),
+        path.join(import.meta.dirname, 'prefers-reduced-motion-test.js'),
       ],
 
       browsers: [chromeLauncher()],
@@ -23,8 +22,8 @@ describe('emulateMediaPlugin', function test() {
   it('can emulate media on playwright', async () => {
     await runTests({
       files: [
-        path.join(__dirname, 'browser-test.js'),
-        path.join(__dirname, 'prefers-reduced-motion-test.js'),
+        path.join(import.meta.dirname, 'browser-test.js'),
+        path.join(import.meta.dirname, 'prefers-reduced-motion-test.js'),
       ],
       browsers: [
         playwrightLauncher({ product: 'chromium' }),
@@ -37,7 +36,7 @@ describe('emulateMediaPlugin', function test() {
 
   it('can emulate forced-colors on playwright, except webkit', async () => {
     await runTests({
-      files: [path.join(__dirname, 'forced-colors-test.js')],
+      files: [path.join(import.meta.dirname, 'forced-colors-test.js')],
       browsers: [
         playwrightLauncher({ product: 'chromium' }),
         playwrightLauncher({ product: 'firefox' }),

--- a/packages/test-runner-commands/test/execute-server-command/executeServerCommand.test.ts
+++ b/packages/test-runner-commands/test/execute-server-command/executeServerCommand.test.ts
@@ -1,11 +1,10 @@
+import { describe, it } from 'node:test';
 import path from 'path';
 import { runTests } from '@web/test-runner-core/test-helpers';
 import { chromeLauncher } from '@web/test-runner-chrome';
 import type { Logger } from '@web/dev-server-core';
 
-describe('executeServerCommand', function test() {
-  this.timeout(20000);
-
+describe('executeServerCommand', { timeout: 20000 }, () => {
   it('can execute commands', async () => {
     const logger: Logger = {
       ...console,
@@ -26,7 +25,7 @@ describe('executeServerCommand', function test() {
     };
 
     await runTests({
-      files: [path.join(__dirname, 'browser-test.js')],
+      files: [path.join(import.meta.dirname, 'browser-test.js')],
       logger,
       browsers: [chromeLauncher()],
       plugins: [

--- a/packages/test-runner-commands/test/file/filePlugin.test.ts
+++ b/packages/test-runner-commands/test/file/filePlugin.test.ts
@@ -1,15 +1,14 @@
+import { describe, it } from 'node:test';
 import path from 'path';
 import { runTests } from '@web/test-runner-core/test-helpers';
 import { chromeLauncher } from '@web/test-runner-chrome';
 
-import { filePlugin } from '../../src/filePlugin.js';
+import { filePlugin } from '../../dist/filePlugin.js';
 
-describe('filePlugin', function test() {
-  this.timeout(20000);
-
+describe('filePlugin', { timeout: 20000 }, () => {
   it('passes file plugin tests', async () => {
     await runTests({
-      files: [path.join(__dirname, 'browser-test.js')],
+      files: [path.join(import.meta.dirname, 'browser-test.js')],
       browsers: [chromeLauncher()],
       plugins: [filePlugin()],
       logger: {

--- a/packages/test-runner-commands/test/select-option/selectOptionPlugin.test.ts
+++ b/packages/test-runner-commands/test/select-option/selectOptionPlugin.test.ts
@@ -1,16 +1,15 @@
+import { describe, it } from 'node:test';
 import path from 'path';
 import { runTests } from '@web/test-runner-core/test-helpers';
 import { chromeLauncher } from '@web/test-runner-chrome';
 import { playwrightLauncher } from '@web/test-runner-playwright';
 
-import { selectOptionPlugin } from '../../src/selectOptionPlugin.js';
+import { selectOptionPlugin } from '../../dist/selectOptionPlugin.js';
 
-describe('selectOptionPlugin', function test() {
-  this.timeout(20000);
-
+describe('selectOptionPlugin', { timeout: 20000 }, () => {
   it('can send keys on puppeteer', async () => {
     await runTests({
-      files: [path.join(__dirname, 'puppeteer-test.js')],
+      files: [path.join(import.meta.dirname, 'puppeteer-test.js')],
       browsers: [chromeLauncher()],
       plugins: [selectOptionPlugin()],
     });
@@ -18,7 +17,7 @@ describe('selectOptionPlugin', function test() {
 
   it('can send keys on playwright', async () => {
     await runTests({
-      files: [path.join(__dirname, 'playwright-test.js')],
+      files: [path.join(import.meta.dirname, 'playwright-test.js')],
       browsers: [
         playwrightLauncher({ product: 'chromium' }),
         playwrightLauncher({ product: 'firefox' }),

--- a/packages/test-runner-commands/test/send-keys/sendKeysPlugin.test.ts
+++ b/packages/test-runner-commands/test/send-keys/sendKeysPlugin.test.ts
@@ -1,16 +1,15 @@
+import { describe, it } from 'node:test';
 import path from 'path';
 import { runTests } from '@web/test-runner-core/test-helpers';
 import { chromeLauncher } from '@web/test-runner-chrome';
 import { playwrightLauncher } from '@web/test-runner-playwright';
 
-import { sendKeysPlugin } from '../../src/sendKeysPlugin.js';
+import { sendKeysPlugin } from '../../dist/sendKeysPlugin.js';
 
-describe('sendKeysPlugin', function test() {
-  this.timeout(20000);
-
+describe('sendKeysPlugin', { timeout: 20000 }, () => {
   it('can send keys on puppeteer', async () => {
     await runTests({
-      files: [path.join(__dirname, 'browser-test.js')],
+      files: [path.join(import.meta.dirname, 'browser-test.js')],
       browsers: [chromeLauncher()],
       plugins: [sendKeysPlugin()],
     });
@@ -18,7 +17,7 @@ describe('sendKeysPlugin', function test() {
 
   it('can send keys on playwright', async () => {
     await runTests({
-      files: [path.join(__dirname, 'browser-test.js')],
+      files: [path.join(import.meta.dirname, 'browser-test.js')],
       browsers: [
         playwrightLauncher({ product: 'chromium' }),
         playwrightLauncher({ product: 'firefox' }),

--- a/packages/test-runner-commands/test/send-mouse/sendMousePlugin.test.ts
+++ b/packages/test-runner-commands/test/send-mouse/sendMousePlugin.test.ts
@@ -1,18 +1,17 @@
+import { describe, it, before, after } from 'node:test';
 import path from 'path';
 import selenium from 'selenium-standalone';
 import { runTests } from '@web/test-runner-core/test-helpers';
 import { chromeLauncher } from '@web/test-runner-chrome';
 import { webdriverLauncher } from '@web/test-runner-webdriver';
 import { playwrightLauncher } from '@web/test-runner-playwright';
-import { sendMousePlugin } from '../../src/sendMousePlugin.js';
-import { startSeleniumServer } from '../selenium-server.js';
+import { sendMousePlugin } from '../../dist/sendMousePlugin.js';
+import { startSeleniumServer } from '../selenium-server.ts';
 
-describe('sendMousePlugin', function test() {
-  this.timeout(50000);
-
+describe('sendMousePlugin', { timeout: 50000 }, () => {
   it('can send mouse on puppeteer', async () => {
     await runTests({
-      files: [path.join(__dirname, 'browser-test.js')],
+      files: [path.join(import.meta.dirname, 'browser-test.js')],
       browsers: [chromeLauncher()],
       plugins: [sendMousePlugin()],
     });
@@ -20,7 +19,7 @@ describe('sendMousePlugin', function test() {
 
   it('can send mouse on playwright', async () => {
     await runTests({
-      files: [path.join(__dirname, 'browser-test.js')],
+      files: [path.join(import.meta.dirname, 'browser-test.js')],
       browsers: [
         playwrightLauncher({ product: 'chromium' }),
         playwrightLauncher({ product: 'firefox' }),
@@ -52,7 +51,7 @@ describe('sendMousePlugin', function test() {
 
     it('can send mouse on webdriver', async () => {
       await runTests({
-        files: [path.join(__dirname, 'browser-test.js')],
+        files: [path.join(import.meta.dirname, 'browser-test.js')],
         concurrency: 1,
         browsers: [
           webdriverLauncher({

--- a/packages/test-runner-commands/test/set-user-agent/setUserAgentPlugin.test.ts
+++ b/packages/test-runner-commands/test/set-user-agent/setUserAgentPlugin.test.ts
@@ -1,15 +1,14 @@
+import { describe, it } from 'node:test';
 import path from 'path';
 import { runTests } from '@web/test-runner-core/test-helpers';
 import { chromeLauncher } from '@web/test-runner-chrome';
 
-import { setUserAgentPlugin } from '../../src/setUserAgentPlugin.js';
+import { setUserAgentPlugin } from '../../dist/setUserAgentPlugin.js';
 
-describe('setUserAgentPlugin', function test() {
-  this.timeout(20000);
-
+describe('setUserAgentPlugin', { timeout: 20000 }, () => {
   it('can set the user agent on puppeteer', async () => {
     await runTests({
-      files: [path.join(__dirname, 'browser-test.js')],
+      files: [path.join(import.meta.dirname, 'browser-test.js')],
       browsers: [chromeLauncher()],
       plugins: [setUserAgentPlugin()],
     });

--- a/packages/test-runner-commands/test/set-viewport/setViewportPlugin.test.ts
+++ b/packages/test-runner-commands/test/set-viewport/setViewportPlugin.test.ts
@@ -1,17 +1,16 @@
+import { describe, it } from 'node:test';
 import path from 'path';
 
 import { runTests } from '@web/test-runner-core/test-helpers';
 import { chromeLauncher } from '@web/test-runner-chrome';
 import { playwrightLauncher } from '@web/test-runner-playwright';
 
-import { setViewportPlugin } from '../../src/setViewportPlugin.js';
+import { setViewportPlugin } from '../../dist/setViewportPlugin.js';
 
-describe('setViewportPlugin', function test() {
-  this.timeout(20000);
-
+describe('setViewportPlugin', { timeout: 20000 }, () => {
   it('can set the viewport on puppeteer', async () => {
     await runTests({
-      files: [path.join(__dirname, 'browser-test.js')],
+      files: [path.join(import.meta.dirname, 'browser-test.js')],
       browsers: [chromeLauncher()],
       plugins: [setViewportPlugin()],
     });
@@ -19,7 +18,7 @@ describe('setViewportPlugin', function test() {
 
   it('can set the viewport on playwright', async () => {
     await runTests({
-      files: [path.join(__dirname, 'browser-test.js')],
+      files: [path.join(import.meta.dirname, 'browser-test.js')],
       browsers: [
         playwrightLauncher({ product: 'chromium' }),
         playwrightLauncher({ product: 'firefox' }),

--- a/packages/test-runner-commands/test/snapshot/snapshotPlugin.test.ts
+++ b/packages/test-runner-commands/test/snapshot/snapshotPlugin.test.ts
@@ -1,15 +1,14 @@
+import { describe, it } from 'node:test';
 import path from 'path';
 import { runTests } from '@web/test-runner-core/test-helpers';
 import { playwrightLauncher } from '@web/test-runner-playwright';
 
-import { snapshotPlugin } from '../../src/snapshotPlugin.js';
+import { snapshotPlugin } from '../../dist/snapshotPlugin.js';
 
-describe('snapshotPlugin', function test() {
-  this.timeout(20000);
-
+describe('snapshotPlugin', { timeout: 20000 }, () => {
   it('passes snapshot tests', async () => {
     await runTests({
-      files: [path.join(__dirname, 'browser-test.js')],
+      files: [path.join(import.meta.dirname, 'browser-test.js')],
       browsers: [
         playwrightLauncher({ product: 'firefox' }),
         playwrightLauncher({ product: 'chromium' }),
@@ -19,7 +18,7 @@ describe('snapshotPlugin', function test() {
     });
 
     await runTests({
-      files: [path.join(__dirname, 'src', 'nested-test.js')],
+      files: [path.join(import.meta.dirname, 'src', 'nested-test.js')],
       browsers: [
         playwrightLauncher({ product: 'firefox' }),
         playwrightLauncher({ product: 'chromium' }),


### PR DESCRIPTION
## Summary

- Migrate `@web/test-runner-commands` 10 test files from mocha globals to `node:test`
- No chai used in any file (tests use `runTests` which throws on failure)
- `__dirname` -> `import.meta.dirname`, `../../src/` -> `../../dist/`
- `--experimental-strip-types` for CI compat

## Test plan

- [x] 10/17 tests pass on Node 22.22.3 with Chrome (7 fail = Playwright missing system libs, pass in CI)
- [x] ESLint clean
- [x] Prettier clean
- [x] Code review clean