### PR TITLE
test(dev-server-rollup): migrate tests from mocha/chai to node:test

### DIFF
--- a/packages/dev-server-rollup/package.json
+++ b/packages/dev-server-rollup/package.json
@@ -25,8 +25,7 @@
     "node": ">=22.0.0"
   },
   "scripts": {
-    "test:node": "mocha \"test/node/**/*.test.ts\" --require ts-node/register --exit --reporter dot",
-    "test:watch": "mocha \"test/node/**/*.test.ts\" --require ts-node/register --watch --watch-files src,test"
+    "test:node": "node --experimental-strip-types --test --test-force-exit 'test/node/**/*.test.ts'"
   },
   "files": [
     "*.d.ts",
@@ -65,8 +64,6 @@
     "@types/whatwg-url": "^11.0.0",
     "@web/test-runner-chrome": "^0.18.0",
     "@web/test-runner-core": "^0.13.0",
-    "chai": "^4.2.0",
-    "mocha": "^10.8.2",
     "postcss": "^8.5.14",
     "rollup-plugin-postcss": "^4.0.2"
   }

--- a/packages/dev-server-rollup/package.json
+++ b/packages/dev-server-rollup/package.json
@@ -25,7 +25,8 @@
     "node": ">=22.0.0"
   },
   "scripts": {
-    "test:node": "node --experimental-strip-types --test --test-force-exit 'test/node/**/*.test.ts'"
+    "test:node": "node --experimental-strip-types --test --test-force-exit 'test/node/**/*.test.ts'",
+    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch 'test/node/**/*.test.ts'"
   },
   "files": [
     "*.d.ts",

--- a/packages/dev-server-rollup/test/node/plugins/alias.test.ts
+++ b/packages/dev-server-rollup/test/node/plugins/alias.test.ts
@@ -1,7 +1,8 @@
+import { describe, it } from 'node:test';
 import rollupAlias from '@rollup/plugin-alias';
 
-import { createTestServer, fetchText, expectIncludes } from '../test-helpers.js';
-import { fromRollup } from '../../../src/fromRollup.js';
+import { createTestServer, fetchText, expectIncludes } from '../test-helpers.ts';
+import { fromRollup } from '../../../dist/fromRollup.js';
 
 const alias = fromRollup(rollupAlias);
 

--- a/packages/dev-server-rollup/test/node/plugins/babel.test.ts
+++ b/packages/dev-server-rollup/test/node/plugins/babel.test.ts
@@ -1,8 +1,12 @@
 /// <reference types="../../../types/rollup__plugin-babel" />
+import { describe, it } from 'node:test';
+import { createRequire } from 'node:module';
 import rollupBabel from '@rollup/plugin-babel';
 
-import { createTestServer, fetchText, expectIncludes } from '../test-helpers.js';
-import { fromRollup } from '../../../src/index.js';
+import { createTestServer, fetchText, expectIncludes } from '../test-helpers.ts';
+import { fromRollup } from '../../../dist/index.js';
+
+const require = createRequire(import.meta.url);
 
 const babel = fromRollup(rollupBabel);
 

--- a/packages/dev-server-rollup/test/node/plugins/commonjs.test.ts
+++ b/packages/dev-server-rollup/test/node/plugins/commonjs.test.ts
@@ -1,11 +1,12 @@
+import { describe, it } from 'node:test';
 import rollupCommonjs from '@rollup/plugin-commonjs';
 import { runTests } from '@web/test-runner-core/test-helpers';
 import { resolve } from 'path';
 import { chromeLauncher } from '@web/test-runner-chrome';
 
 import * as path from 'path';
-import { createTestServer, fetchText, expectIncludes } from '../test-helpers.js';
-import { fromRollup } from '../../../src/index.js';
+import { createTestServer, fetchText, expectIncludes } from '../test-helpers.ts';
+import { fromRollup } from '../../../dist/index.js';
 import { nodeResolvePlugin } from '@web/dev-server';
 
 const commonjs = fromRollup(rollupCommonjs);
@@ -140,7 +141,7 @@ exports.default = _default;`;
   });
 
   it('can transform modules which require node-resolved modules', async () => {
-    const rootDir = path.resolve(__dirname, '..', 'fixtures', 'basic');
+    const rootDir = path.resolve(import.meta.dirname, '..', 'fixtures', 'basic');
     const { server, host } = await createTestServer({
       plugins: [
         {
@@ -199,11 +200,11 @@ exports.default = _default;`;
     }
   });
 
-  it('passes the in-browser tests', async function () {
-    this.timeout(40000);
-
+  it('passes the in-browser tests', { timeout: 40000 }, async () => {
     await runTests({
-      files: [resolve(__dirname, '..', 'fixtures', 'commonjs', 'commonjs-browser-test.js')],
+      files: [
+        resolve(import.meta.dirname, '..', 'fixtures', 'commonjs', 'commonjs-browser-test.js'),
+      ],
       browsers: [chromeLauncher({ launchOptions: { devtools: false } })],
       plugins: [
         fromRollup(rollupCommonjs)({

--- a/packages/dev-server-rollup/test/node/plugins/node-resolve.test.ts
+++ b/packages/dev-server-rollup/test/node/plugins/node-resolve.test.ts
@@ -1,10 +1,11 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 import path from 'path';
 import rollupNodeResolve from '@rollup/plugin-node-resolve';
 import rollupCommonjs from '@rollup/plugin-commonjs';
 
-import { createTestServer, fetchText, expectIncludes } from '../test-helpers.js';
-import { fromRollup } from '../../../src/index.js';
-import { expect } from 'chai';
+import { createTestServer, fetchText, expectIncludes } from '../test-helpers.ts';
+import { fromRollup } from '../../../dist/index.js';
 
 const nodeResolve = fromRollup(rollupNodeResolve, {}, { throwOnUnresolvedImport: true });
 const commonjs = fromRollup(rollupCommonjs);
@@ -61,7 +62,7 @@ describe('@rollup/plugin-node-resolve', () => {
 
   it('can resolve private imports in inline scripts', async () => {
     const { server, host } = await createTestServer({
-      rootDir: path.resolve(__dirname, '..', 'fixtures', 'private-imports'),
+      rootDir: path.resolve(import.meta.dirname, '..', 'fixtures', 'private-imports'),
       plugins: [nodeResolve()],
     });
 
@@ -76,13 +77,13 @@ describe('@rollup/plugin-node-resolve', () => {
 
   it('throws when trying to access files from the package directly if they are not exposed in the export map', async () => {
     const { server, host } = await createTestServer({
-      rootDir: path.resolve(__dirname, '..', 'fixtures', 'private-imports'),
+      rootDir: path.resolve(import.meta.dirname, '..', 'fixtures', 'private-imports'),
       plugins: [nodeResolve()],
     });
 
     try {
       const response = await fetch(`${host}/import-private-directly.html`);
-      expect(response.status).to.equal(500);
+      assert.equal(response.status, 500);
     } finally {
       server.stop();
     }
@@ -105,7 +106,7 @@ describe('@rollup/plugin-node-resolve', () => {
 
     try {
       const response = await fetch(`${host}/test-app.js`);
-      expect(response.status).to.equal(500);
+      assert.equal(response.status, 500);
     } finally {
       server.stop();
     }
@@ -128,7 +129,7 @@ describe('@rollup/plugin-node-resolve', () => {
 
     try {
       const text = await fetchText(`${host}/test-app.js`);
-      expect(text).to.equal('import "/non-existing.js"; import "./src/non-existing.js";');
+      assert.equal(text, 'import "/non-existing.js"; import "./src/non-existing.js";');
     } finally {
       server.stop();
     }
@@ -136,7 +137,7 @@ describe('@rollup/plugin-node-resolve', () => {
 
   it('node modules resolved outside root directory with matching basename via symlink are rewritten', async () => {
     const { server, host } = await createTestServer({
-      rootDir: path.resolve(__dirname, '..', 'fixtures', 'resolve-outside-dir'),
+      rootDir: path.resolve(import.meta.dirname, '..', 'fixtures', 'resolve-outside-dir'),
       plugins: [nodeResolve()],
     });
 
@@ -153,7 +154,7 @@ describe('@rollup/plugin-node-resolve', () => {
 
   it('node modules resolved outside root directory are rewritten', async () => {
     const { server, host } = await createTestServer({
-      rootDir: path.resolve(__dirname, '..', 'fixtures', 'resolve-outside-dir', 'src'),
+      rootDir: path.resolve(import.meta.dirname, '..', 'fixtures', 'resolve-outside-dir', 'src'),
       plugins: [nodeResolve()],
     });
 
@@ -170,7 +171,7 @@ describe('@rollup/plugin-node-resolve', () => {
 
   it('node modules resolved outside root directory are rewritten with commonjs', async () => {
     const { server, host } = await createTestServer({
-      rootDir: path.resolve(__dirname, '..', 'fixtures', 'resolve-outside-dir', 'src'),
+      rootDir: path.resolve(import.meta.dirname, '..', 'fixtures', 'resolve-outside-dir', 'src'),
       plugins: [commonjs(), nodeResolve()],
     });
 

--- a/packages/dev-server-rollup/test/node/plugins/postcss.test.ts
+++ b/packages/dev-server-rollup/test/node/plugins/postcss.test.ts
@@ -1,18 +1,19 @@
 /// <reference types="../../../types/rollup-plugin-postcss" />
+import { describe, it } from 'node:test';
 import rollupPostcss from 'rollup-plugin-postcss';
 import { chromeLauncher } from '@web/test-runner-chrome';
 import { runTests } from '@web/test-runner-core/test-helpers';
 import { resolve } from 'path';
 
-import { createTestServer, fetchText, expectIncludes } from '../test-helpers.js';
-import { fromRollup } from '../../../src/index.js';
+import { createTestServer, fetchText, expectIncludes } from '../test-helpers.ts';
+import { fromRollup } from '../../../dist/index.js';
 
 const postcss = fromRollup(rollupPostcss);
 
 describe('@rollup/plugin-postcss', () => {
   it('can run postcss on imported css files', async () => {
     const { server, host } = await createTestServer({
-      rootDir: resolve(__dirname, '..', '..', '..', '..', '..'),
+      rootDir: resolve(import.meta.dirname, '..', '..', '..', '..', '..'),
       mimeTypes: {
         '**/*.css': 'js',
       },
@@ -57,10 +58,9 @@ html {
     }
   });
 
-  it('passes the in-browser tests', async function () {
-    this.timeout(40000);
+  it('passes the in-browser tests', { timeout: 40000 }, async () => {
     await runTests({
-      files: [resolve(__dirname, '..', 'fixtures', 'postcss', 'postcss-browser-test.js')],
+      files: [resolve(import.meta.dirname, '..', 'fixtures', 'postcss', 'postcss-browser-test.js')],
       browsers: [chromeLauncher()],
       mimeTypes: {
         '**/*.css': 'js',

--- a/packages/dev-server-rollup/test/node/plugins/replace.test.ts
+++ b/packages/dev-server-rollup/test/node/plugins/replace.test.ts
@@ -1,7 +1,8 @@
+import { describe, it } from 'node:test';
 import rollupReplace from '@rollup/plugin-replace';
 
-import { createTestServer, fetchText, expectIncludes } from '../test-helpers.js';
-import { fromRollup } from '../../../src/index.js';
+import { createTestServer, fetchText, expectIncludes } from '../test-helpers.ts';
+import { fromRollup } from '../../../dist/index.js';
 
 const replace = fromRollup(rollupReplace as any);
 

--- a/packages/dev-server-rollup/test/node/rollupBundlePlugin.test.ts
+++ b/packages/dev-server-rollup/test/node/rollupBundlePlugin.test.ts
@@ -1,15 +1,16 @@
-import { rollupBundlePlugin } from '../../src/rollupBundlePlugin.js';
+import { describe, it } from 'node:test';
+import { rollupBundlePlugin } from '../../dist/rollupBundlePlugin.js';
 import path from 'path';
-import { createTestServer, fetchText, expectIncludes } from './test-helpers.js';
+import { createTestServer, fetchText, expectIncludes } from './test-helpers.ts';
 
 describe('rollupBundlePlugin', () => {
   it('can bundle a single entrypoint', async () => {
     const { server, host } = await createTestServer({
-      rootDir: path.join(__dirname, 'fixtures', 'bundle-basic'),
+      rootDir: path.join(import.meta.dirname, 'fixtures', 'bundle-basic'),
       plugins: [
         rollupBundlePlugin({
           rollupConfig: {
-            input: path.join(__dirname, 'fixtures', 'bundle-basic', 'a.js'),
+            input: path.join(import.meta.dirname, 'fixtures', 'bundle-basic', 'a.js'),
           },
         }),
       ],
@@ -28,14 +29,14 @@ describe('rollupBundlePlugin', () => {
 
   it('can bundle multiple entrypoint', async () => {
     const { server, host } = await createTestServer({
-      rootDir: path.join(__dirname, 'fixtures', 'bundle-multi'),
+      rootDir: path.join(import.meta.dirname, 'fixtures', 'bundle-multi'),
       plugins: [
         rollupBundlePlugin({
           rollupConfig: {
             input: [
-              path.join(__dirname, 'fixtures', 'bundle-multi', 'a1.js'),
-              path.join(__dirname, 'fixtures', 'bundle-multi', 'a2.js'),
-              path.join(__dirname, 'fixtures', 'bundle-multi', 'a3.js'),
+              path.join(import.meta.dirname, 'fixtures', 'bundle-multi', 'a1.js'),
+              path.join(import.meta.dirname, 'fixtures', 'bundle-multi', 'a2.js'),
+              path.join(import.meta.dirname, 'fixtures', 'bundle-multi', 'a3.js'),
             ],
             output: {
               chunkFileNames: '[name].js',
@@ -73,11 +74,11 @@ describe('rollupBundlePlugin', () => {
 
   it('can serve regular files not bundled by rollup', async () => {
     const { server, host } = await createTestServer({
-      rootDir: path.join(__dirname, 'fixtures', 'bundle-basic'),
+      rootDir: path.join(import.meta.dirname, 'fixtures', 'bundle-basic'),
       plugins: [
         rollupBundlePlugin({
           rollupConfig: {
-            input: path.join(__dirname, 'fixtures', 'bundle-basic', 'a.js'),
+            input: path.join(import.meta.dirname, 'fixtures', 'bundle-basic', 'a.js'),
           },
         }),
       ],
@@ -94,11 +95,11 @@ describe('rollupBundlePlugin', () => {
 
   it('can serve files emitted by a rollup plugin', async () => {
     const { server, host } = await createTestServer({
-      rootDir: path.join(__dirname, 'fixtures', 'bundle-basic'),
+      rootDir: path.join(import.meta.dirname, 'fixtures', 'bundle-basic'),
       plugins: [
         rollupBundlePlugin({
           rollupConfig: {
-            input: path.join(__dirname, 'fixtures', 'bundle-basic', 'a.js'),
+            input: path.join(import.meta.dirname, 'fixtures', 'bundle-basic', 'a.js'),
             plugins: [
               {
                 name: 'file-plugin',

--- a/packages/dev-server-rollup/test/node/test-helpers.ts
+++ b/packages/dev-server-rollup/test/node/test-helpers.ts
@@ -5,12 +5,12 @@ import {
   fetchText,
   expectIncludes,
 } from '@web/dev-server-core/test-helpers';
-import { DevServerCoreConfig, Logger } from '@web/dev-server-core';
+import type { DevServerCoreConfig, Logger } from '@web/dev-server-core';
 
 export function createTestServer(config: Partial<DevServerCoreConfig> = {}, mockLogger?: Logger) {
   return originalCreateTestServer(
     {
-      rootDir: path.resolve(__dirname, 'fixtures', 'basic'),
+      rootDir: path.resolve(import.meta.dirname, 'fixtures', 'basic'),
       ...config,
     },
     mockLogger,

--- a/packages/dev-server-rollup/test/node/unit.test.ts
+++ b/packages/dev-server-rollup/test/node/unit.test.ts
@@ -1,9 +1,10 @@
-import { Plugin as RollupPlugin, AstNode } from 'rollup';
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Plugin as RollupPlugin, AstNode } from 'rollup';
 import path from 'path';
 
-import { createTestServer, fetchText, expectIncludes } from './test-helpers.js';
-import { fromRollup } from '../../src/index.js';
+import { createTestServer, fetchText, expectIncludes } from './test-helpers.ts';
+import { fromRollup } from '../../dist/index.js';
 
 describe('@web/dev-server-rollup', () => {
   describe('resolveId', () => {
@@ -68,7 +69,7 @@ describe('@web/dev-server-rollup', () => {
       const plugin: RollupPlugin = {
         name: 'my-plugin',
         resolveId() {
-          return path.join(__dirname, 'fixtures', 'basic', 'src', 'foo.js');
+          return path.join(import.meta.dirname, 'fixtures', 'basic', 'src', 'foo.js');
         },
       };
       const { server, host } = await createTestServer({
@@ -84,7 +85,7 @@ describe('@web/dev-server-rollup', () => {
     });
 
     it('files resolved outside root directory are rewritten', async () => {
-      const resolvedId = path.resolve(__dirname, '..', '..', '..', '..', '..', 'foo.js');
+      const resolvedId = path.resolve(import.meta.dirname, '..', '..', '..', '..', '..', 'foo.js');
       const plugin: RollupPlugin = {
         name: 'my-plugin',
         resolveId() {
@@ -106,7 +107,7 @@ describe('@web/dev-server-rollup', () => {
 
   it('files inside root directory imported by files inside or outside are resolved to be deduped in the browser', async () => {
     const rootDir = path.resolve(
-      __dirname,
+      import.meta.dirname,
       'fixtures',
       'monorepo-import-inside-from-outside',
       'src',
@@ -149,7 +150,7 @@ describe('@web/dev-server-rollup', () => {
       const plugin: RollupPlugin = {
         name: 'my-plugin',
         load(id) {
-          if (id === path.join(__dirname, 'fixtures', 'basic', 'src', 'foo.js')) {
+          if (id === path.join(import.meta.dirname, 'fixtures', 'basic', 'src', 'foo.js')) {
             return 'console.log("hello world")';
           }
         },
@@ -170,7 +171,7 @@ describe('@web/dev-server-rollup', () => {
       const plugin: RollupPlugin = {
         name: 'my-plugin',
         load(id) {
-          if (id === path.join(__dirname, 'fixtures', 'basic', 'src', 'foo.js')) {
+          if (id === path.join(import.meta.dirname, 'fixtures', 'basic', 'src', 'foo.js')) {
             return { code: 'console.log("hello world")' };
           }
         },
@@ -193,7 +194,7 @@ describe('@web/dev-server-rollup', () => {
       const plugin: RollupPlugin = {
         name: 'my-plugin',
         transform(code, id) {
-          if (id === path.join(__dirname, 'fixtures', 'basic', 'app.js')) {
+          if (id === path.join(import.meta.dirname, 'fixtures', 'basic', 'app.js')) {
             return `${code}\nconsole.log("transformed");`;
           }
         },
@@ -214,7 +215,7 @@ describe('@web/dev-server-rollup', () => {
       const plugin: RollupPlugin = {
         name: 'my-plugin',
         transform(code, id) {
-          if (id === path.join(__dirname, 'fixtures', 'basic', 'app.js')) {
+          if (id === path.join(import.meta.dirname, 'fixtures', 'basic', 'app.js')) {
             return { code: `${code}\nconsole.log("transformed");` };
           }
         },
@@ -237,7 +238,7 @@ describe('@web/dev-server-rollup', () => {
     const plugin: RollupPlugin = {
       name: 'my-plugin',
       transform(code, id) {
-        if (id === path.join(__dirname, 'fixtures', 'basic', 'app.js')) {
+        if (id === path.join(import.meta.dirname, 'fixtures', 'basic', 'app.js')) {
           parsed = this.parse(code, {});
           return undefined;
         }
@@ -249,7 +250,7 @@ describe('@web/dev-server-rollup', () => {
 
     try {
       await fetchText(`${host}/app.js`);
-      expect(parsed).to.exist;
+      assert.ok(parsed);
     } finally {
       server.stop();
     }
@@ -259,9 +260,9 @@ describe('@web/dev-server-rollup', () => {
     const plugin: RollupPlugin = {
       name: 'my-plugin',
       transform(code, id) {
-        if (id === path.join(__dirname, 'fixtures', 'basic', 'app.js')) {
+        if (id === path.join(import.meta.dirname, 'fixtures', 'basic', 'app.js')) {
           return `import "${path
-            .join(__dirname, 'fixtures', 'basic', 'foo.js')
+            .join(import.meta.dirname, 'fixtures', 'basic', 'foo.js')
             .split('\\')
             .join('/')}";\n${code}`;
         }
@@ -283,7 +284,7 @@ describe('@web/dev-server-rollup', () => {
     const plugin: RollupPlugin = {
       name: 'my-plugin',
       load(id) {
-        if (id === path.join(__dirname, 'fixtures', 'basic', 'app.js')) {
+        if (id === path.join(import.meta.dirname, 'fixtures', 'basic', 'app.js')) {
           return 'import "\0foo.js";';
         }
       },
@@ -335,7 +336,7 @@ describe('@web/dev-server-rollup', () => {
     const plugin: RollupPlugin = {
       name: 'my-plugin',
       transform(code, id) {
-        if (id === path.join(__dirname, 'fixtures', 'basic', 'foo.html')) {
+        if (id === path.join(import.meta.dirname, 'fixtures', 'basic', 'foo.html')) {
           return { code: code.replace('foo', 'transformed') };
         }
       },
@@ -347,7 +348,8 @@ describe('@web/dev-server-rollup', () => {
 
     try {
       const text = await fetchText(`${host}/foo.html`);
-      expect(text).to.equal(
+      assert.equal(
+        text,
         `<html><head></head><body>\n    <script type="module">\n      console.log("transformed");\n    </script>\n  \n\n</body></html>`,
       );
     } finally {
@@ -359,7 +361,7 @@ describe('@web/dev-server-rollup', () => {
     const plugin: RollupPlugin = {
       name: 'my-plugin',
       transform(code, id) {
-        if (id === path.join(__dirname, 'fixtures', 'basic', 'multiple-inline.html')) {
+        if (id === path.join(import.meta.dirname, 'fixtures', 'basic', 'multiple-inline.html')) {
           return { code: code.replace('bar', 'transformed') };
         }
       },
@@ -371,7 +373,8 @@ describe('@web/dev-server-rollup', () => {
 
     try {
       const text = await fetchText(`${host}/multiple-inline.html`);
-      expect(text).to.equal(
+      assert.equal(
+        text,
         `<html><head></head><body>\n    <script type="module">\n      console.log("asd");\n    </script>\n    <script type="module">\n      console.log("transformed");\n    </script>\n  \n\n</body></html>`,
       );
     } finally {


### PR DESCRIPTION
## Summary

- Migrate all 8 test files and shared test-helpers from mocha/chai to node:test/node:assert/strict
- Replace `__dirname` with `import.meta.dirname` throughout
- Change source imports (`../../src/`) to dist imports (`../../dist/`) for native type stripping compatibility
- Change local `.js` imports to `.ts` (strip-types cannot resolve `.js` to `.ts`)
- Convert `this.timeout(N)` to `{ timeout: N }` test option
- Add `createRequire(import.meta.url)` for `require.resolve()` in babel tests
- Add `import type` for type-only imports (`DevServerCoreConfig`, `Logger`, `RollupPlugin`, `AstNode`)
- Use quoted glob in test script so Node's built-in glob expansion handles nested directories
- Remove mocha and chai devDependencies

## Pre-existing issues noticed (not fixed here)

- `babel.test.ts` describe block says `@rollup/plugin-alias` instead of `@rollup/plugin-babel` (copy-paste error)
- `node-resolve.test.ts:71` has a leftover `console.log(text)` debugging statement

## Test plan

- [x] All 43 tests pass locally on Node 22.22.3 (8 files, 11 suites)
- [x] Browser-based tests pass with `CHROME_PATH` set
- [x] Lint passes
- [x] Verified quoted glob is necessary for npm scripts (sh does not expand `**` recursively)