### PR TITLE
chore: keep certain packages at 0.x.x

### DIFF
--- a/.changeset/drop-eol-node.md
+++ b/.changeset/drop-eol-node.md
@@ -3,8 +3,6 @@
 '@web/config-loader': major
 '@web/dev-server-core': major
 '@web/dev-server-esbuild': major
-'@web/dev-server-hmr': major
-'@web/dev-server-import-maps': major
 '@web/dev-server-legacy': major
 '@web/dev-server': major
 '@web/dev-server-polyfill': major
@@ -29,7 +27,6 @@
 '@web/test-runner-coverage-v8': major
 '@web/test-runner-junit-reporter': major
 '@web/test-runner-mocha': major
-'@web/test-runner-module-mocking': major
 '@web/test-runner': major
 '@web/test-runner-playwright': major
 '@web/test-runner-puppeteer': major

--- a/.changeset/long-areas-worry.md
+++ b/.changeset/long-areas-worry.md
@@ -1,0 +1,7 @@
+---
+'@web/dev-server-hmr': minor
+'@web/dev-server-import-maps': minor
+'@web/test-runner-module-mocking': minor
+---
+
+Drop support for Node.js 18 and 20, which have reached end-of-life. The minimum supported Node.js version is now 22.0.0.


### PR DESCRIPTION
## What I did

See https://github.com/modernweb-dev/web/pull/3076#issuecomment-4650340054

so I propose to keep these packages at 0.x.x
which is OK from the perspective of a major update, since `^0.x.x` will a minor version update as "major" in practice

- '@web/dev-server-hmr': minor
- '@web/dev-server-import-maps': minor
- '@web/test-runner-module-mocking': minor