### PR TITLE
Fix rollup-plugin-copy types export

### DIFF
--- a/.changeset/rollup-copy-types-export.md
+++ b/.changeset/rollup-copy-types-export.md
@@ -1,0 +1,5 @@
+---
+'@web/rollup-plugin-copy': patch
+---
+
+Fix the package export declaration to point TypeScript at the shipped `dist/copy.d.ts` declarations.

--- a/packages/rollup-plugin-copy/package.json
+++ b/packages/rollup-plugin-copy/package.json
@@ -20,7 +20,7 @@
   "module": "index.mjs",
   "exports": {
     ".": {
-      "types": "./index.d.ts",
+      "types": "./dist/copy.d.ts",
       "import": "./index.mjs",
       "require": "./src/copy.js"
     }


### PR DESCRIPTION
## Summary
- point @web/rollup-plugin-copy's export types entry at the shipped dist/copy.d.ts declarations
- add a patch changeset

## Verification
- npm-installed @web/rollup-plugin-copy@0.5.1 in a clean temp project
- confirmed TypeScript fails to find declarations before the metadata fix
- patched exports.types to ./dist/copy.d.ts in the temp install and confirmed tsc resolves the module