### PR TITLE
fix: correct rollup-plugin-copy types export

### DIFF
--- a/.changeset/correct-copy-types.md
+++ b/.changeset/correct-copy-types.md
@@ -1,0 +1,5 @@
+---
+'@web/rollup-plugin-copy': patch
+---
+
+Fix the root export's types condition to point to the published declaration file.

--- a/packages/rollup-plugin-copy/package.json
+++ b/packages/rollup-plugin-copy/package.json
@@ -20,7 +20,7 @@
   "module": "index.mjs",
   "exports": {
     ".": {
-      "types": "./index.d.ts",
+      "types": "./dist/copy.d.ts",
       "import": "./index.mjs",
       "require": "./src/copy.js"
     }


### PR DESCRIPTION
## Summary

- Point `@web/rollup-plugin-copy`'s root export `types` condition to `./dist/copy.d.ts`.
- Keep the existing `import` and `require` runtime entries unchanged.

## Why

The published `@web/rollup-plugin-copy@0.5.1` package exports root types from `./index.d.ts`, but that file is not included in the npm tarball. The package-level `types` field already points to `dist/copy.d.ts`, which is included, so this aligns the conditional export with the existing published declaration file.

## Validation

- `node -e "const p=require('./packages/rollup-plugin-copy/package.json'); if(p.exports['.'].types!=='./dist/copy.d.ts') process.exit(1); console.log('manifest export types ok')"`
- `git diff --check`
- Verified npm tarball evidence for `@web/rollup-plugin-copy@0.5.1`:
  - current `exports["."].types: ./index.d.ts` exists: false
  - package-level `types: dist/copy.d.ts` exists: true
  - proposed `exports["."].types: ./dist/copy.d.ts` exists: true