### PR TITLE
fix: add missing bugs metadata field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,5 +146,8 @@
   "workspaces": [
     "packages/*",
     "integration/*"
-  ]
+  ],
+  "bugs": {
+    "url": "https://github.com/modernweb-dev/web/issues"
+  }
 }


### PR DESCRIPTION
Adds missing package metadata fields to `package.json`.

This allows npm tooling and consumers to correctly resolve package metadata.