### PR TITLE
fix(dev-server-rollup): add basic support for transform objects

### DIFF
--- a/.changeset/forty-rice-sleep.md
+++ b/.changeset/forty-rice-sleep.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server-rollup': patch
+---
+
+added support for `transform` objects in Rollup plugins

--- a/packages/dev-server-rollup/src/rollupAdapter.ts
+++ b/packages/dev-server-rollup/src/rollupAdapter.ts
@@ -412,8 +412,14 @@ export function rollupAdapter(
           );
 
           let result;
-          if (typeof rollupPlugin.transform === 'function') {
-            result = await rollupPlugin.transform?.call(
+
+          const transformHandler = typeof rollupPlugin.transform === 'function'
+            ? rollupPlugin.transform
+            : typeof rollupPlugin.transform?.handler === 'function'
+              ? rollupPlugin.transform.handler
+              : null;
+          if (transformHandler) {
+            result = await transformHandler.call(
               rollupPluginContext as TransformPluginContext,
               context.body as string,
               filePath,


### PR DESCRIPTION
The `transform` hook in a Rollup plugin can be either a function or an object with a handler function: https://rollupjs.org/plugin-development/#build-hooks

If `transform` is not a function, this adds support for a `transform` object with a `handler`  function, instead of silently failing.

Fixes #3120
