### PR TITLE
fix: use node glob to find all test files consistently

### DIFF
--- a/packages/browser-logs/package.json
+++ b/packages/browser-logs/package.json
@@ -26,8 +26,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "test:node": "node --experimental-strip-types --test --test-force-exit test/**/*.test.ts",
-    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch test/**/*.test.ts"
+    "test:node": "node --experimental-strip-types --test --test-force-exit \"test/**/*.test.ts\"",
+    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch \"test/**/*.test.ts\""
   },
   "files": [
     "*.d.ts",

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -27,8 +27,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "test:node": "node --test --test-force-exit test/**/*.test.js",
-    "test:watch": "node --test --test-force-exit --watch test/**/*.test.js"
+    "test:node": "node --test --test-force-exit \"test/**/*.test.js\"",
+    "test:watch": "node --test --test-force-exit --watch \"test/**/*.test.js\""
   },
   "files": [
     "*.d.ts",

--- a/packages/dev-server-esbuild/package.json
+++ b/packages/dev-server-esbuild/package.json
@@ -28,8 +28,8 @@
     "build": "tsc",
     "start:demo:jsx": "es-dev-server --config demo/jsx/server.config.js",
     "start:demo:ts": "es-dev-server --config demo/ts/server.config.js",
-    "test:node": "node --experimental-strip-types --test --test-force-exit test/**/*.test.ts",
-    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch test/**/*.test.ts"
+    "test:node": "node --experimental-strip-types --test --test-force-exit \"test/**/*.test.ts\"",
+    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch \"test/**/*.test.ts\""
   },
   "files": [
     "*.d.ts",

--- a/packages/dev-server-hmr/package.json
+++ b/packages/dev-server-hmr/package.json
@@ -28,8 +28,8 @@
     "build": "tsc",
     "start:lit-html": "wds --config demo/lit-html/server.config.mjs",
     "start:vanilla": "wds --config demo/vanilla/server.config.mjs",
-    "test:node": "node --experimental-strip-types --test --test-force-exit test/**/*.test.ts",
-    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch test/**/*.test.ts"
+    "test:node": "node --experimental-strip-types --test --test-force-exit \"test/**/*.test.ts\"",
+    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch \"test/**/*.test.ts\""
   },
   "files": [
     "*.d.ts",

--- a/packages/dev-server-import-maps/package.json
+++ b/packages/dev-server-import-maps/package.json
@@ -27,8 +27,8 @@
   "scripts": {
     "build": "tsc",
     "test:browser": "node ../test-runner/dist/bin.js test-browser/test/**/*.test.{js,html} --config test-browser/web-test-runner.config.mjs",
-    "test:node": "node --experimental-strip-types --test --test-force-exit test/**/*.test.ts",
-    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch test/**/*.test.ts"
+    "test:node": "node --experimental-strip-types --test --test-force-exit \"test/**/*.test.ts\"",
+    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch \"test/**/*.test.ts\""
   },
   "files": [
     "*.d.ts",

--- a/packages/dev-server-rollup/package.json
+++ b/packages/dev-server-rollup/package.json
@@ -25,8 +25,8 @@
     "node": ">=22.0.0"
   },
   "scripts": {
-    "test:node": "node --experimental-strip-types --test --test-force-exit 'test/node/**/*.test.ts'",
-    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch 'test/node/**/*.test.ts'"
+    "test:node": "node --experimental-strip-types --test --test-force-exit \"test/node/**/*.test.ts\"",
+    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch \"test/node/**/*.test.ts\""
   },
   "files": [
     "*.d.ts",

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -37,8 +37,8 @@
     "start:plugin-serve": "node dist/bin.js --config demo/plugin-serve/config.mjs --open",
     "start:static": "node dist/bin.js --config demo/static/config.mjs --open demo/static/",
     "start:syntax": "node dist/bin.js --config demo/syntax/config.mjs --open demo/syntax/",
-    "test:node": "node --test --test-force-exit test/**/*.test.mjs",
-    "test:watch": "node --test --test-force-exit --watch test/**/*.test.mjs"
+    "test:node": "node --test --test-force-exit \"test/**/*.test.mjs\"",
+    "test:watch": "node --test --test-force-exit --watch \"test/**/*.test.mjs\""
   },
   "files": [
     "*.d.ts",

--- a/packages/parse5-utils/package.json
+++ b/packages/parse5-utils/package.json
@@ -26,8 +26,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "test:node": "node --test --test-force-exit test/**/*.test.js",
-    "test:watch": "node --test --test-force-exit --watch test/**/*.test.js"
+    "test:node": "node --test --test-force-exit \"test/**/*.test.js\"",
+    "test:watch": "node --test --test-force-exit --watch \"test/**/*.test.js\""
   },
   "files": [
     "*.d.ts",

--- a/packages/polyfills-loader/package.json
+++ b/packages/polyfills-loader/package.json
@@ -26,8 +26,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "test:node": "node --experimental-strip-types --test --test-force-exit test/**/*.test.ts",
-    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch test/**/*.test.ts"
+    "test:node": "node --experimental-strip-types --test --test-force-exit \"test/**/*.test.ts\"",
+    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch \"test/**/*.test.ts\""
   },
   "files": [
     "*.d.ts",

--- a/packages/rollup-plugin-copy/package.json
+++ b/packages/rollup-plugin-copy/package.json
@@ -29,8 +29,8 @@
     "node": ">=22.0.0"
   },
   "scripts": {
-    "test:node": "node --test --test-force-exit test/**/*.test.js",
-    "test:watch": "node --test --test-force-exit --watch test/**/*.test.js"
+    "test:node": "node --test --test-force-exit \"test/**/*.test.js\"",
+    "test:watch": "node --test --test-force-exit --watch \"test/**/*.test.js\""
   },
   "files": [
     "*.d.ts",

--- a/packages/rollup-plugin-html/package.json
+++ b/packages/rollup-plugin-html/package.json
@@ -28,8 +28,8 @@
     "demo:mpa": "rm -rf demo/dist && rollup -c demo/mpa/rollup.config.js --watch & npm run serve-demo",
     "demo:spa": "rm -rf demo/dist && rollup -c demo/spa/rollup.config.js --watch & npm run serve-demo",
     "serve-demo": "node ../dev-server/dist/bin.js --watch --root-dir demo/dist --app-index index.html --compatibility none --open",
-    "test:node": "node --experimental-strip-types --test --test-force-exit 'test/**/*.test.ts'",
-    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch 'test/**/*.test.ts'"
+    "test:node": "node --experimental-strip-types --test --test-force-exit \"test/**/*.test.ts\"",
+    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch \"test/**/*.test.ts\""
   },
   "files": [
     "*.js",

--- a/packages/rollup-plugin-import-meta-assets/package.json
+++ b/packages/rollup-plugin-import-meta-assets/package.json
@@ -25,8 +25,8 @@
   },
   "scripts": {
     "test": "npm run test:node",
-    "test:node": "node --test --test-force-exit test/**/*.test.js",
-    "test:watch": "node --test --test-force-exit --watch test/**/*.test.js"
+    "test:node": "node --test --test-force-exit \"test/**/*.test.js\"",
+    "test:watch": "node --test --test-force-exit --watch \"test/**/*.test.js\""
   },
   "files": [
     "*.js",

--- a/packages/rollup-plugin-polyfills-loader/package.json
+++ b/packages/rollup-plugin-polyfills-loader/package.json
@@ -25,8 +25,8 @@
     "node": ">=22.0.0"
   },
   "scripts": {
-    "test:node": "node --experimental-strip-types --test --test-force-exit test/**/*.test.ts",
-    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch test/**/*.test.ts"
+    "test:node": "node --experimental-strip-types --test --test-force-exit \"test/**/*.test.ts\"",
+    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch \"test/**/*.test.ts\""
   },
   "files": [
     "*.d.ts",

--- a/packages/test-runner-commands/package.json
+++ b/packages/test-runner-commands/package.json
@@ -30,8 +30,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "test:node": "node --experimental-strip-types --test --test-force-exit test/**/*.test.ts",
-    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch test/**/*.test.ts"
+    "test:node": "node --experimental-strip-types --test --test-force-exit \"test/**/*.test.ts\"",
+    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch \"test/**/*.test.ts\""
   },
   "files": [
     "*.d.ts",

--- a/packages/test-runner-core/package.json
+++ b/packages/test-runner-core/package.json
@@ -33,8 +33,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "test:node": "node --experimental-strip-types --test --test-force-exit test/**/*.test.ts",
-    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch test/**/*.test.ts"
+    "test:node": "node --experimental-strip-types --test --test-force-exit \"test/**/*.test.ts\"",
+    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch \"test/**/*.test.ts\""
   },
   "files": [
     "*.d.ts",

--- a/packages/test-runner-mocha/package.json
+++ b/packages/test-runner-mocha/package.json
@@ -20,8 +20,8 @@
   "scripts": {
     "build": "tsc",
     "build:production": "rimraf dist && rollup -c ./rollup.config.mjs",
-    "test:node": "node --test --test-force-exit test/**/*.test.js",
-    "test:watch": "node --test --test-force-exit --watch test/**/*.test.js"
+    "test:node": "node --test --test-force-exit \"test/**/*.test.js\"",
+    "test:watch": "node --test --test-force-exit --watch \"test/**/*.test.js\""
   },
   "files": [
     "dist"

--- a/packages/test-runner-module-mocking/package.json
+++ b/packages/test-runner-module-mocking/package.json
@@ -24,8 +24,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "test:node": "node --experimental-strip-types --test --test-force-exit test/**/*.test.ts",
-    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch test/**/*.test.ts"
+    "test:node": "node --experimental-strip-types --test --test-force-exit \"test/**/*.test.ts\"",
+    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch \"test/**/*.test.ts\""
   },
   "files": [
     "*.d.ts",

--- a/packages/test-runner-visual-regression/package.json
+++ b/packages/test-runner-visual-regression/package.json
@@ -30,8 +30,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "test:node": "node --experimental-strip-types --test --test-force-exit test/**/*.test.ts",
-    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch test/**/*.test.ts"
+    "test:node": "node --experimental-strip-types --test --test-force-exit \"test/**/*.test.ts\"",
+    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch \"test/**/*.test.ts\""
   },
   "files": [
     "*.d.ts",


### PR DESCRIPTION
## What I did

1. added `"` around glob so that instead of shell glob we used node glob, for consistency across all systems where tests are executed
