### PR TITLE
chore: disable selenium tests

### DIFF
--- a/packages/test-runner-selenium/package.json
+++ b/packages/test-runner-selenium/package.json
@@ -25,9 +25,7 @@
     "node": ">=22.0.0"
   },
   "scripts": {
-    "build": "tsc",
-    "test:node": "node --experimental-strip-types --test --test-force-exit \"test/**/*.test.ts\"",
-    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch \"test/**/*.test.ts\""
+    "build": "tsc"
   },
   "files": [
     "*.d.ts",

--- a/packages/test-runner-webdriver/package.json
+++ b/packages/test-runner-webdriver/package.json
@@ -25,9 +25,7 @@
     "node": ">=22.0.0"
   },
   "scripts": {
-    "build": "tsc",
-    "test:node": "node --experimental-strip-types --test --test-force-exit \"test/**/*.test.ts\"",
-    "test:watch": "node --experimental-strip-types --test --test-force-exit --watch \"test/**/*.test.ts\""
+    "build": "tsc"
   },
   "files": [
     "*.d.ts",


### PR DESCRIPTION
## What I did

I reenabled these tests in one of previous PRs and it worked, both in CI and on my machine.

But now it stopped, in both.

I investigated and turns out it's a mismatch of Chrome version between local (or CI) installation and the chrome driver that is installed by selenium-standalone. I tried a few solutions and I keep on running into bugs. There is no easy fix for this if you want to test on latest Chrome stable, you need to write custom code to keep them in sync and it requires quite some work to make a proper fix for our build setup. Not saying it's a lot of work, but...

Given we discussed today with @thepassle that we want to deprecate these 2 packages, I don't want to invest more time into this and prefer to disable the tests for now.