### PR TITLE
Fix missing portfinder dependency in dev-server-core test helpers

### DIFF
--- a/.changeset/slimy-moles-clap.md
+++ b/.changeset/slimy-moles-clap.md
@@ -1,0 +1,5 @@
+---
+'@web/dev-server-core': patch
+---
+
+Fix missing portfinder dependency when using test helpers

--- a/package-lock.json
+++ b/package-lock.json
@@ -35136,6 +35136,7 @@
         "mime-types": "^2.1.27",
         "parse5": "^6.0.1",
         "picomatch": "^2.3.2",
+        "portfinder": "^1.0.32",
         "ws": "^7.5.10"
       },
       "devDependencies": {
@@ -35145,8 +35146,7 @@
         "@types/parse5": "^6.0.1",
         "abort-controller": "^3.0.0",
         "express": "^4.22.2",
-        "nanoid": "^3.1.25",
-        "portfinder": "^1.0.32"
+        "nanoid": "^3.1.25"
       },
       "engines": {
         "node": ">=22.0.0"

--- a/packages/dev-server-core/package.json
+++ b/packages/dev-server-core/package.json
@@ -75,6 +75,7 @@
     "mime-types": "^2.1.27",
     "parse5": "^6.0.1",
     "picomatch": "^2.3.2",
+    "portfinder": "^1.0.32",
     "ws": "^7.5.10"
   },
   "devDependencies": {
@@ -84,7 +85,6 @@
     "@types/parse5": "^6.0.1",
     "abort-controller": "^3.0.0",
     "express": "^4.22.2",
-    "nanoid": "^3.1.25",
-    "portfinder": "^1.0.32"
+    "nanoid": "^3.1.25"
   }
 }


### PR DESCRIPTION
## What I did

1. Moved `portfinder` from `devDependencies` to `dependencies` so it is installed when using `@web/dev-server-core/test-helpers`.
2. Updated the package lockfile.
3. Added a patch changeset.

Fixes #2938
